### PR TITLE
ci(release): release workflow + v0.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: release
+
+# Triggered by tag pushes matching v*. Builds release binaries +
+# Docker image, attaches them to the auto-generated GitHub Release.
+#
+# For pre-1.0 we keep this conservative: one platform (x86_64 Linux
+# glibc) and one Docker image. Multi-arch and platform expansion can
+# come later when we have downstream users asking.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # create the Release + upload assets
+  packages: write   # push to ghcr.io
+
+jobs:
+  binaries:
+    name: build binaries (x86_64-linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo build --release --workspace
+        run: cargo build --release --workspace
+
+      - name: Stage release artifacts
+        run: |
+          mkdir -p dist
+          cp target/release/forkd            dist/
+          cp target/release/forkd-controller dist/
+          cd dist
+          tar czf "../forkd-${GITHUB_REF_NAME}-x86_64-linux.tar.gz" \
+              forkd forkd-controller
+          cd ..
+          sha256sum forkd-*.tar.gz > SHA256SUMS
+
+      - name: Create / update GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            forkd-*.tar.gz
+            SHA256SUMS
+          generate_release_notes: true
+          # Don't auto-mark as a "latest release" for pre-1.0 unless
+          # we explicitly want it; tag itself is enough.
+          prerelease: false
+
+  docker:
+    name: build + push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push controller image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/forkd-controller:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/forkd-controller:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/deeplethe/forkd"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "forkd"
-version = "0.1.1"
+version = "0.1.2"
 description = "Open-source fork-on-write microVM sandbox primitive (E2B-compatible surface)"
 readme = "README.md"
 authors = [{name = "Deeplethe", email = "info@deeplethe.com"}]


### PR DESCRIPTION
## Summary

- New `.github/workflows/release.yml` triggered on `v*` tag pushes.
  - **binaries** job: builds the workspace release profile, tars
    `forkd` + `forkd-controller` as
    `forkd-<tag>-x86_64-linux.tar.gz`, attaches to an auto-created
    GitHub Release with `SHA256SUMS`.
  - **docker** job: builds the controller Dockerfile, pushes to
    `ghcr.io/deeplethe/forkd-controller:<tag>` and `:latest`. No
    new secrets — uses `GITHUB_TOKEN` with `packages: write`.
- Version bumped `0.1.1` → `0.1.2` (Cargo workspace + Python SDK).

## Test plan

- [ ] CI green on this PR
- [ ] After merge: tag `v0.1.2` on main, watch the release workflow
      produce the tarball + GHCR image