### PR TITLE
feat(recipes): jupyter-kernel + surface Jupyter in positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,11 @@ not designed for.
 
 **Where forkd fits.**
 
-- **Code interpreters and tool-use sandboxes.** Each conversation
-  turn or tool call spawns a fresh isolated child; the warmed parent
-  carries the runtime, so per-request `import numpy` / `import torch`
-  collapses to zero.
+- **Code interpreters and Jupyter-kernel sandboxes.** Each conversation
+  turn or tool call spawns a fresh kernel; the warmed parent carries
+  the SciPy / ML runtime, so per-request `import numpy` / `import torch`
+  collapses to zero. This is the design point — the workload shape
+  Anthropic / OpenAI / Modal code-interpreter products are all on.
 - **Evaluation harnesses.** Hundreds of repository checkouts or test
   rollouts in parallel — SWE-bench-style — without paying Docker
   cold-start per task.
@@ -292,6 +293,7 @@ and run its `build.sh`:
 |---|---|
 | [`python-numpy/`](./recipes/python-numpy/) | Reproduce the benchmark; lightest Python + numpy |
 | [`e2b-codeinterpreter/`](./recipes/e2b-codeinterpreter/) | AI code-interpreter agents (E2B SDK-compatible) |
+| [`jupyter-kernel/`](./recipes/jupyter-kernel/) | Notebook / SciPy stack pre-imported; ~1 ms per kernel |
 | [`coding-agent/`](./recipes/coding-agent/) | SWE-bench / coding agents with `git` + dev tools |
 | [`nodejs/`](./recipes/nodejs/) | JS / TS workloads, Playwright fan-out |
 | [`agent-workbench/`](./recipes/agent-workbench/) | Kitchen sink — browser + VSCode + Jupyter + MCP |

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -27,6 +27,7 @@ sudo -E forkd fork --tag <name> -n 100 --per-child-netns
 |---|---|---|---|
 | [`python-numpy/`](./python-numpy/) | `python:3.12-slim` + `python3-numpy` | ~1.5 GB | The canonical fan-out demo; what the chart on the front README measures |
 | [`e2b-codeinterpreter/`](./e2b-codeinterpreter/) | `e2bdev/code-interpreter` | ~600 MB | AI code-execution agents (Anthropic / OpenAI tutorials use this image). Lightest "agent ready" option |
+| [`jupyter-kernel/`](./jupyter-kernel/) | `quay.io/jupyter/scipy-notebook` | ~3 GB | Code-interpreter / notebook-style agents — full SciPy stack pre-imported, ~1 ms per fresh kernel instead of ~2 s |
 | [`coding-agent/`](./coding-agent/) | `python:3.12` + git + ruff + black + pytest | ~1.8 GB | SWE-style coding agents that need a real dev toolchain inside the sandbox |
 | [`nodejs/`](./nodejs/) | `node:22-slim` | ~250 MB | JavaScript / TypeScript workloads (Jest, Playwright fan-out) |
 | [`agent-workbench/`](./agent-workbench/) | `agent-infra/sandbox` (browser + VSCode + Jupyter + MCP + shell) | ~5 GB | Kitchen-sink agent workbench when you want every tool already mounted; trades a bigger memory.bin for batteries-included |
@@ -35,6 +36,7 @@ sudo -E forkd fork --tag <name> -n 100 --per-child-netns
 
 - **You're benchmarking** → `python-numpy/`
 - **You're running an AI code interpreter** → `e2b-codeinterpreter/`
+- **You need the full SciPy / notebook stack** → `jupyter-kernel/`
 - **You're running a coding agent (SWE-bench style)** → `coding-agent/`
 - **JS / TS only** → `nodejs/`
 - **You want browser + IDE + everything in one box** → `agent-workbench/`

--- a/recipes/jupyter-kernel/README.md
+++ b/recipes/jupyter-kernel/README.md
@@ -1,0 +1,86 @@
+# `jupyter-kernel`
+
+A forkd parent built from `quay.io/jupyter/scipy-notebook` — the
+canonical Jupyter image with the full SciPy stack preinstalled
+(`numpy`, `pandas`, `scipy`, `scikit-learn`, `matplotlib`,
+`seaborn`, `sympy`, `ipython`).
+
+## Why this recipe
+
+Jupyter / code-interpreter workloads spend 1–3 seconds per fresh
+kernel just on import time: numpy alone is ~300 ms, add pandas +
+sklearn and you're at 2 s before the first cell runs. With forkd,
+the parent VM does that import work **once** at snapshot time;
+every child fork inherits the post-import memory state via mmap CoW.
+
+Net: a "fresh kernel" goes from ~2 s to ~1 ms per child.
+
+This is the shape Anthropic Claude code-interpreter, OpenAI
+code-interpreter, and Modal-hosted notebook agents all run on —
+many short-lived kernel sessions, each needing the SciPy runtime
+ready immediately.
+
+## What you get
+
+- `quay.io/jupyter/scipy-notebook` base
+- Full SciPy stack: numpy, pandas, scipy, sklearn, matplotlib,
+  seaborn, sympy, ipython
+- forkd-init.sh + forkd-agent.py as PID 1; the agent's `eval`
+  endpoint runs Python expressions against the warmed interpreter
+  (same as Jupyter's kernel does over ZMQ, but simpler JSON over TCP)
+
+Total rootfs: **~3 GB**, memory image after warm-up: **~700 MiB**.
+
+## Use it
+
+```bash
+sudo bash recipes/jupyter-kernel/build.sh
+sudo bash scripts/host-tap.sh
+sudo forkd snapshot --tag jk \
+    --kernel ./vmlinux-6.1.141 \
+    --rootfs recipes/jupyter-kernel/parent.ext4 \
+    --tap forkd-tap0 \
+    --boot-wait-secs 20    # SciPy import takes longer than plain Python
+
+# Fork 50 kernel sessions, all share the warmed SciPy stack
+sudo bash scripts/netns-setup.sh 50
+sudo -E forkd fork --tag jk -n 50 --per-child-netns --memory-limit-mib 512
+
+# Each child can eval pandas / sklearn instantly
+sudo forkd eval --child forkd-child-7 -- \
+    "pandas.DataFrame({'a':[1,2,3]}).describe().to_dict()"
+```
+
+## Python SDK
+
+```python
+from forkd import Sandbox
+
+with Sandbox(tag="jk") as sb:
+    # First cell: model train, no extra imports needed
+    sb.eval("sklearn.datasets.load_iris().data.shape")  # → (150, 4)
+    sb.eval("numpy.linalg.eigvals([[1,2],[3,4]]).tolist()")
+```
+
+## When to pick this
+
+- You're building an **AI code interpreter** and Python is your
+  primary language.
+- You run **notebook-style evaluation harnesses** (papermill,
+  nbconvert, custom rollouts) and want per-task isolation without
+  per-task cold-start.
+- You want **JupyterHub-like multi-user kernels** but with sub-second
+  spawn instead of multi-second container startup.
+
+If you need full Jupyter kernel ZMQ protocol (rather than forkd's
+simpler `eval` channel), the parent kernel can still be started
+in the rootfs build — but you'll need to wire ZMQ port forwarding
+through the netns, which we don't ship a recipe for yet. See the
+JupyterHub spawner tracking issue on GitHub.
+
+## When NOT to pick this
+
+- You only need plain Python without the SciPy stack → use
+  [`python-numpy/`](../python-numpy/) (1/2 the size, faster snapshot).
+- You're running a coding agent that needs `git` + `pytest` + dev
+  tooling → use [`coding-agent/`](../coding-agent/).

--- a/recipes/jupyter-kernel/build.sh
+++ b/recipes/jupyter-kernel/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build a forkd parent rootfs from the canonical Jupyter SciPy image.
+#
+# The base image is ~3 GB (full SciPy stack preinstalled). Plan for
+# a larger memory.bin after warm-up (~700 MiB) — more pages get
+# touched during the snapshot warm-up phase than with python-numpy/.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+IMAGE="${IMAGE:-quay.io/jupyter/scipy-notebook:latest}"
+SIZE_MIB="${SIZE_MIB:-4096}"
+OUT="$SCRIPT_DIR/parent.ext4"
+
+[ "$(id -u)" -eq 0 ] || { echo "run as root" >&2; exit 1; }
+
+echo "==> building rootfs from $IMAGE (this is a ~3 GB image; first pull may take several minutes)"
+bash "$REPO_ROOT/scripts/build-rootfs.sh" "$IMAGE" "$OUT" "$SIZE_MIB"
+
+echo
+echo "parent rootfs ready: $OUT ($(du -h "$OUT" | cut -f1))"
+echo
+echo "next:"
+echo "  sudo forkd snapshot --tag jk --kernel <vmlinux> --rootfs $OUT \\"
+echo "      --tap forkd-tap0 --boot-wait-secs 20"
+echo
+echo "tip: --boot-wait-secs 20 gives ipython + SciPy time to fully import"
+echo "into the parent before snapshot; lower values miss some warm-up."


### PR DESCRIPTION
## Summary

- **README** — first "Where forkd fits" bullet now explicitly names
  Jupyter-kernel sandboxes, with a one-line callout that this is the
  shape Anthropic / OpenAI / Modal code-interpreter products run on.
- **New recipe** `recipes/jupyter-kernel/` — from
  `quay.io/jupyter/scipy-notebook`. Parent pre-imports the full
  SciPy stack (numpy / pandas / scipy / sklearn / matplotlib /
  sympy / ipython). Children get a fresh "kernel" in ~1 ms instead
  of the ~2 s cold-import cost a fresh Python kernel pays.
- **Indexes updated** — `recipes/README.md` (row 3 of the table)
  and the main README's Quick start recipes table.

## Test plan

- [ ] CI green (docs + new recipe, no code changes)

Follow-up tracked in #20: forkd-jupyter-spawner package for JupyterHub.