### PR TITLE
docs(readme): add PyPI version badge

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,56 @@
+name: publish-pypi
+
+# Publish the forkd Python SDK to PyPI when a GitHub Release is
+# published. Uses PyPI's Trusted Publishers (OIDC) — no API token,
+# no repository secret. The trust relationship is configured on PyPI:
+# Owner=deeplethe, Repository=forkd, Workflow=publish-pypi.yml,
+# Environment=pypi.
+#
+# Trigger chain:
+#   push tag v* → release.yml builds binaries + creates GitHub Release
+#                 → this workflow fires on the "release published" event
+#                 → sdist + wheel uploaded to https://pypi.org/p/forkd
+on:
+  release:
+    types: [published]
+  workflow_dispatch:   # let maintainers re-run a publish manually
+
+jobs:
+  publish:
+    name: build + upload to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi   # must match the GitHub environment + PyPI Trusted Publisher config
+    permissions:
+      id-token: write   # OIDC for Trusted Publishers
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify SDK version matches the release tag
+        run: |
+          ref="${GITHUB_REF_NAME#v}"
+          # workflow_dispatch sets REF_NAME to the branch name; skip
+          # the check there so manual re-runs aren't blocked.
+          if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]; then
+            sdk_ver=$(grep -E '^version = ' sdk/python/pyproject.toml | head -1 | cut -d'"' -f2)
+            if [ "${sdk_ver}" != "${ref}" ]; then
+              echo "::error::SDK version ${sdk_ver} != release tag ${ref}"
+              exit 1
+            fi
+          fi
+
+      - name: Build sdist + wheel
+        working-directory: sdk/python
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI (Trusted Publisher)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdk/python/dist
+          print-hash: true

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 <p align="center">
   <a href="https://github.com/deeplethe/forkd/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/deeplethe/forkd/ci.yml?branch=main&style=flat-square&label=ci"></a>
   <a href="https://github.com/deeplethe/forkd/releases"><img alt="Release" src="https://img.shields.io/github/v/release/deeplethe/forkd?style=flat-square&color=4c956c"></a>
+  <a href="https://pypi.org/project/forkd/"><img alt="PyPI" src="https://img.shields.io/pypi/v/forkd?style=flat-square&color=3776ab&logo=pypi&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square"></a>
   <a href="https://firecracker-microvm.github.io"><img alt="Firecracker" src="https://img.shields.io/badge/built%20on-Firecracker-blue?style=flat-square"></a>
   <a href="https://github.com/deeplethe/forkd/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/deeplethe/forkd?style=flat-square&color=eab308&logo=github"></a>


### PR DESCRIPTION
## Summary
- Surface `pip install forkd` availability with a PyPI version badge next to the existing GitHub release badge.

forkd 0.1.2 is now live on PyPI via the Trusted Publisher workflow added in #22.

## Test plan
- [x] Visual check of badge rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)