### PR TITLE
docs(readme): refresh for 0.1.3 — recipe list, CHANGELOG link, security pin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -291,6 +291,7 @@ with Sandbox() as sb:
 | [`jupyter-kernel/`](./recipes/jupyter-kernel/) | 预导入 notebook / SciPy 栈;每个 kernel ~1 ms |
 | [`coding-agent/`](./recipes/coding-agent/) | SWE-bench / 编码 agent,带 `git` + 开发工具 |
 | [`nodejs/`](./recipes/nodejs/) | JS / TS 负载,Playwright 扇出 |
+| [`playwright-browser/`](./recipes/playwright-browser/) | 驱动浏览器的 agent(computer-use / 网页研究 / UI 测试生成),fork 出已暖好的 Chromium ≈10 ms |
 | [`agent-workbench/`](./recipes/agent-workbench/) | 全家桶——浏览器 + VSCode + Jupyter + MCP |
 
 <br/>
@@ -359,13 +360,18 @@ Python SDK 都已就绪,并由 CI 里的 25 个单元 + 集成测试覆盖。
 本版本暂未达到生产可用的项:
 
 - 多节点调度(目前 一个守护进程 = 一台主机)。
-- TLS 终结——非 loopback 访问请用反向代理在前面挡一下。
 - 子 VM netns 的默认拒绝出站(目前是共享 MASQUERADE 规则;
   想要 allow-list 策略的用户需要自己给每个 netns 加 `iptables` 规则)。
 - `memory.max` 之外的 `cpu.max`、`io.max`、`pids.max` 配额。
 - 第三方安全审计。
 
 Roadmap 和正在追踪的工作都在 [GitHub issues](https://github.com/deeplethe/forkd/issues)。
+版本变更记录:[CHANGELOG.md](./CHANGELOG.md)。
+安全策略与历史漏洞通告:[docs/SECURITY.md](./docs/SECURITY.md)。
+
+> **0.1.3 包含一个安全修复**。`--tag` 处理有 path-traversal,
+> 影响 0.1.0–0.1.2,请升级。完整公告见
+> [docs/SECURITY.md#past-advisories](./docs/SECURITY.md#past-advisories)。
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,8 @@ Security posture: [`docs/SECURITY.md`](./docs/SECURITY.md).
 ```
 crates/
   forkd-vmm/            Firecracker wrapper: BootConfig, Vm, Snapshot, cgroup
-  forkd-cli/            `forkd` binary (snapshot, fork, run, exec, eval)
+  forkd-cli/            `forkd` binary (snapshot, fork, run, exec, eval,
+                        pack/unpack/pull/push/images, cleanup)
   forkd-controller/     `forkd-controller` daemon: REST, registry, audit
 rootfs-init/
   forkd-init.sh         PID 1 inside the guest; mounts pseudo-fs, launches agent
@@ -371,8 +372,9 @@ sdk/python/             E2B-compatible Python SDK
 scripts/                Host-side helpers (KVM, Firecracker, netns, rootfs)
 packaging/systemd/      systemd unit for the controller
 recipes/                Pre-built parent-rootfs recipes (python-numpy,
-                        e2b-codeinterpreter, coding-agent, nodejs,
-                        agent-workbench). See recipes/README.md.
+                        e2b-codeinterpreter, jupyter-kernel, coding-agent,
+                        nodejs, playwright-browser, agent-workbench).
+                        See recipes/README.md.
 bench/                  Benchmark harness, chart generators, results
 docs/                   API.md, SECURITY.md, RUNBOOK.md
 ```
@@ -389,8 +391,6 @@ in CI. On-disk formats and API shapes may still change before 1.0.
 Production-readiness items not yet in this release:
 
 - Multi-node scheduling (one daemon = one host).
-- TLS termination — front the daemon with a reverse proxy for
-  non-loopback access.
 - Default-deny egress on per-child netns (today: shared MASQUERADE
   rule; users wanting an allow-list policy add their own `iptables`
   rules per netns).
@@ -399,6 +399,13 @@ Production-readiness items not yet in this release:
 - Third-party security audit.
 
 The roadmap and tracked work live in [GitHub issues](https://github.com/deeplethe/forkd/issues).
+Release notes per version: [CHANGELOG.md](./CHANGELOG.md).
+Security posture and past advisories: [docs/SECURITY.md](./docs/SECURITY.md).
+
+> **0.1.3 contains a security fix.** A path-traversal in `--tag`
+> handling affected 0.1.0–0.1.2; users on those versions should
+> upgrade. Full advisory in
+> [docs/SECURITY.md#past-advisories](./docs/SECURITY.md#past-advisories).
 
 <br/>
 


### PR DESCRIPTION
README + README-zh refresh to land alongside the 0.1.3 release.

- Repository layout: \`forkd-cli\` now lists the new subcommands (pack/unpack/pull/push/images, cleanup); \`recipes/\` mentions \`jupyter-kernel\` and \`playwright-browser\` alongside the original six.
- Status: drop the \"TLS termination — front the daemon with a reverse proxy\" item. rustls-backed TLS is wired into \`forkd-controller\`; \`docs/SECURITY.md\` has the operator details.
- Add \"Release notes\" + \"Security posture\" link block above Contributing.
- Pin a one-paragraph 0.1.3 security advisory callout — anyone landing on the README from a stale version sees it before they copy/paste the quickstart.
- \`README-zh\` mirrors all of the above.

No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)