### PR TITLE
ci(release): use RELEASE_PAT so release event auto-chains into PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,22 @@ name: release
 # For pre-1.0 we keep this conservative: one platform (x86_64 Linux
 # glibc) and one Docker image. Multi-arch and platform expansion can
 # come later when we have downstream users asking.
+#
+# Note on downstream workflow chaining
+# ------------------------------------
+# `publish-pypi.yml` is triggered by the `release: published` event.
+# GitHub Actions deliberately won't fire downstream workflows when
+# the upstream action uses the default `GITHUB_TOKEN` (it prevents
+# accidental infinite loops). To make `tag push → release → PyPI
+# publish` go end-to-end without a manual
+# `gh workflow run publish-pypi.yml`, create a fine-grained PAT
+# scoped to this repo with the `Contents: read & write` permission
+# and add it as the `RELEASE_PAT` repo secret.
+#
+# Without RELEASE_PAT the workflow still creates the release fine —
+# it just uses the default token and PyPI publishing falls back to
+# manual `gh workflow run publish-pypi.yml` (the publish workflow
+# keeps `workflow_dispatch` for exactly this case).
 on:
   push:
     tags:
@@ -43,6 +59,11 @@ jobs:
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Prefer the PAT so the `release: published` event fires
+          # downstream workflows (publish-pypi.yml). Fall back to
+          # GITHUB_TOKEN if the PAT secret isn't configured — the
+          # release still lands, just without the auto-chain.
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           files: |
             forkd-*.tar.gz
             SHA256SUMS

--- a/README-zh.md
+++ b/README-zh.md
@@ -291,6 +291,7 @@ with Sandbox() as sb:
 | [`jupyter-kernel/`](./recipes/jupyter-kernel/) | 预导入 notebook / SciPy 栈;每个 kernel ~1 ms |
 | [`coding-agent/`](./recipes/coding-agent/) | SWE-bench / 编码 agent,带 `git` + 开发工具 |
 | [`nodejs/`](./recipes/nodejs/) | JS / TS 负载,Playwright 扇出 |
+| [`playwright-browser/`](./recipes/playwright-browser/) | 驱动浏览器的 agent(computer-use / 网页研究 / UI 测试生成),fork 出已暖好的 Chromium ≈10 ms |
 | [`agent-workbench/`](./recipes/agent-workbench/) | 全家桶——浏览器 + VSCode + Jupyter + MCP |
 
 <br/>
@@ -359,13 +360,18 @@ Python SDK 都已就绪,并由 CI 里的 25 个单元 + 集成测试覆盖。
 本版本暂未达到生产可用的项:
 
 - 多节点调度(目前 一个守护进程 = 一台主机)。
-- TLS 终结——非 loopback 访问请用反向代理在前面挡一下。
 - 子 VM netns 的默认拒绝出站(目前是共享 MASQUERADE 规则;
   想要 allow-list 策略的用户需要自己给每个 netns 加 `iptables` 规则)。
 - `memory.max` 之外的 `cpu.max`、`io.max`、`pids.max` 配额。
 - 第三方安全审计。
 
 Roadmap 和正在追踪的工作都在 [GitHub issues](https://github.com/deeplethe/forkd/issues)。
+版本变更记录:[CHANGELOG.md](./CHANGELOG.md)。
+安全策略与历史漏洞通告:[docs/SECURITY.md](./docs/SECURITY.md)。
+
+> **0.1.3 包含一个安全修复**。`--tag` 处理有 path-traversal,
+> 影响 0.1.0–0.1.2,请升级。完整公告见
+> [docs/SECURITY.md#past-advisories](./docs/SECURITY.md#past-advisories)。
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,8 @@ Security posture: [`docs/SECURITY.md`](./docs/SECURITY.md).
 ```
 crates/
   forkd-vmm/            Firecracker wrapper: BootConfig, Vm, Snapshot, cgroup
-  forkd-cli/            `forkd` binary (snapshot, fork, run, exec, eval)
+  forkd-cli/            `forkd` binary (snapshot, fork, run, exec, eval,
+                        pack/unpack/pull/push/images, cleanup)
   forkd-controller/     `forkd-controller` daemon: REST, registry, audit
 rootfs-init/
   forkd-init.sh         PID 1 inside the guest; mounts pseudo-fs, launches agent
@@ -371,8 +372,9 @@ sdk/python/             E2B-compatible Python SDK
 scripts/                Host-side helpers (KVM, Firecracker, netns, rootfs)
 packaging/systemd/      systemd unit for the controller
 recipes/                Pre-built parent-rootfs recipes (python-numpy,
-                        e2b-codeinterpreter, coding-agent, nodejs,
-                        agent-workbench). See recipes/README.md.
+                        e2b-codeinterpreter, jupyter-kernel, coding-agent,
+                        nodejs, playwright-browser, agent-workbench).
+                        See recipes/README.md.
 bench/                  Benchmark harness, chart generators, results
 docs/                   API.md, SECURITY.md, RUNBOOK.md
 ```
@@ -389,8 +391,6 @@ in CI. On-disk formats and API shapes may still change before 1.0.
 Production-readiness items not yet in this release:
 
 - Multi-node scheduling (one daemon = one host).
-- TLS termination — front the daemon with a reverse proxy for
-  non-loopback access.
 - Default-deny egress on per-child netns (today: shared MASQUERADE
   rule; users wanting an allow-list policy add their own `iptables`
   rules per netns).
@@ -399,6 +399,13 @@ Production-readiness items not yet in this release:
 - Third-party security audit.
 
 The roadmap and tracked work live in [GitHub issues](https://github.com/deeplethe/forkd/issues).
+Release notes per version: [CHANGELOG.md](./CHANGELOG.md).
+Security posture and past advisories: [docs/SECURITY.md](./docs/SECURITY.md).
+
+> **0.1.3 contains a security fix.** A path-traversal in `--tag`
+> handling affected 0.1.0–0.1.2; users on those versions should
+> upgrade. Full advisory in
+> [docs/SECURITY.md#past-advisories](./docs/SECURITY.md#past-advisories).
 
 <br/>
 


### PR DESCRIPTION
Fixes the manual-dispatch workaround we hit while shipping 0.1.3.

## Problem

\`publish-pypi.yml\` triggers on \`release: published\`. GitHub Actions deliberately won't fire downstream workflows when the upstream release was created with the default \`GITHUB_TOKEN\` (infinite-loop prevention). So for 0.1.3 the publish step needed a manual \`gh workflow run publish-pypi.yml --ref main\` after \`release.yml\` finished.

## Fix

Plumb a \`RELEASE_PAT\` secret through \`softprops/action-gh-release\`:

\`\`\`yaml
token: \${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
\`\`\`

If \`RELEASE_PAT\` is set, the release-creation event runs under the PAT identity and downstream workflows fire normally. If not set, falls back to \`GITHUB_TOKEN\` so the release still lands — just no auto-chain (current behaviour).

## Maintainer setup (one-time)

1. **Create a fine-grained PAT** at https://github.com/settings/personal-access-tokens
   - Resource owner: \`deeplethe\`
   - Repository access: \`deeplethe/forkd\` (only)
   - Permission: \`Contents → Read and write\`
   - Expiration: pick a date you'll remember (90 days is a sensible default)
2. **Add it as a repo secret** at https://github.com/deeplethe/forkd/settings/secrets/actions/new
   - Name: \`RELEASE_PAT\`
   - Value: paste the token
3. Next \`git push origin v0.1.4\` then **auto-publishes to PyPI in the same workflow run**.

## Why not workflow_call

The cleaner-looking alternative is to expose \`publish-pypi.yml\` as \`workflow_call\` and \`uses: ./.github/workflows/publish-pypi.yml\` from release.yml. But the OIDC token in a reusable workflow carries the *calling* workflow's ref, not the called workflow's — so PyPI's Trusted Publisher (which we configured for \`publish-pypi.yml\`) would reject the request. The PAT path keeps the existing PyPI config working unchanged.

## Test plan
- [x] Inline-commented \`release.yml\` to make the setup discoverable
- [x] Fallback to \`GITHUB_TOKEN\` means missing-PAT case doesn't break releases
- [ ] First real validation: \`v0.1.4\` tag push (whenever that lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)