### PR TITLE
docs(bench): recontextualise CubeSandbox row + small-N replay numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,14 @@ numpy.zeros(5).tolist()`.
 | gVisor (runsc) | 288.6 s | — | userspace kernel container |
 | Docker (runc) | 335.3 s | 4 MiB | standard container runtime |
 
-¹ CubeSandbox: 77 of 100 sandboxes spawned cleanly; the rest hit
-reflink-copy storage errors under concurrent load on this host. See
-[`bench/CUBESANDBOX.md`](./bench/CUBESANDBOX.md).
+¹ CubeSandbox: this is a **slow-path** measurement on a host outside
+CubeSandbox's documented testing matrix. The template used a 2 GiB
+writable layer which doesn't match the default 1 GiB pool, so each
+sandbox went through a live `mkfs.ext4 + reflink-copy` instead of
+the pool fast path; 77/100 spawned cleanly, the rest hit a reflink
+race. CubeSandbox advertises **<60 ms** single-instance under the
+fast-path configuration on a 96 vCPU host; we didn't re-test that
+shape here. See [`bench/CUBESANDBOX.md`](./bench/CUBESANDBOX.md).
 
 ² BoxLite is optimised for one long-lived stateful Box per workload,
 not 100 concurrent fresh microVMs. The cold fan-out is included for
@@ -190,7 +195,7 @@ not designed for.
 | Docker (runc) | OCI container | 335 s | ✗ | cgroups | n/a | Apache 2.0 |
 | gVisor (runsc) | userspace kernel | 289 s | ✗ | cgroups | n/a | Apache 2.0 |
 
-¹ Wall-clock at N=100 concurrent on this **bare-metal** host (`systemd-detect-virt: none`, i7-12700, no nested virt); 77/100 succeeded, the rest hit a cubelet reflink-copy race (`bad magic number in superblock`). CubeSandbox advertises **<60 ms** single-instance cold-start (P95 90 ms at 50-concurrent) — that figure isn't disputed. Note also that this row compares **fork-from-warm (forkd)** with **cold-start (every other project)**; they're different operating points by design, not equivalent primitives. See [bench/CUBESANDBOX.md](./bench/CUBESANDBOX.md).
+¹ Wall-clock at N=100 concurrent on this **bare-metal** host (`systemd-detect-virt: none`, i7-12700, no nested virt). The template used a 2 GiB writable layer which doesn't match the default 1 GiB pool, so each sandbox went through the live `mkfs.ext4 + reflink-copy` path instead of the pool fast path. 77/100 spawned cleanly; the rest hit a cubelet reflink-copy race that only triggers on the slow path. CubeSandbox advertises **<60 ms** single-instance cold-start (P95 90 ms at 50-concurrent) under the fast-path configuration on a 96 vCPU host — that figure isn't disputed and we did not re-test it here. Note also that this row compares **fork-from-warm (forkd)** with **cold-start (every other project)**; they're different operating points by design, not equivalent primitives. See [bench/CUBESANDBOX.md](./bench/CUBESANDBOX.md) for the host config, the upstream issue discussion, and the small-N replay numbers.
 ² Daytona's advertised number; we did not measure it (workspace runtime, not a fan-out-comparable shape).
 
 [cs]: https://github.com/TencentCloud/CubeSandbox

--- a/bench/CUBESANDBOX.md
+++ b/bench/CUBESANDBOX.md
@@ -80,3 +80,66 @@ On the specific Ubuntu 24.04 / Linux 6.14 / 20-vCPU host we tested,
 the storage path was the bottleneck, not VM boot. A cleaner host (no
 1Panel co-tenancy, dedicated XFS partition for `/data/cubelet`) is
 likely to give CubeSandbox a substantially better number.
+
+## Upstream response (2026-05-14)
+
+We filed the methodology + the reflink-copy race upstream:
+[TencentCloud/CubeSandbox#235](https://github.com/TencentCloud/CubeSandbox/issues/235).
+The maintainer's response confirmed two things that recontextualise
+the numbers above:
+
+1. **The race is on a slow code path the original template
+   inadvertently selected.** CubeSandbox pre-formats a pool of
+   writable-layer ext4 images at sizes listed in
+   `pool_default_format_size_list` (default `["1Gi"]`). A sandbox
+   whose `writable_layer_size` matches one of those sizes reuses a
+   pool entry — fast path, no `mkfs.ext4` or reflink-copy per
+   sandbox. We passed `--writable-layer-size 2Gi`, which doesn't
+   match the default pool, so every sandbox went through the live
+   `mkfs.ext4 + reflink-copy` slow path. That's where the bad-magic
+   race lives.
+2. **Cube's published N=50/N=100 numbers are measured on a 96 vCPU
+   server.** A 20 vCPU host (this dev box) is outside their tested
+   matrix. Per the maintainer: P99 under 200 ms at N=100 on a
+   96-vCPU node.
+
+Cube also accepted the first two improvements from our issue (a
+configurable `cmdTimeout`, and richer diagnostic info on
+`newExt4RawByReflinkCopy` failures) and is reviewing the third
+(drop per-clone `e2fsck`).
+
+## Small-N replay on the same (slow-path) configuration
+
+After the upstream exchange we re-ran with the same 2 GiB template
+at smaller N — staying on the slow path so the comparison is
+apples-to-apples with the N=100 row, but small enough to fit the
+30 GiB host RAM budget (template spec = 2 GiB per sandbox →
+max ~14 concurrent).
+
+Script: [`bench/cube-replay.sh`](./cube-replay.sh).
+
+| N | Succeeded | Wall-clock | Per-sandbox |
+|---:|:---:|---:|---:|
+| 1 | 1/1 | 924 ms | 924 ms |
+| 5 | 5/5 | 2,207 ms | 441 ms |
+| 10 | 10/10 | 2,567 ms | 257 ms |
+
+Observations:
+
+- **100 % success rate at every size we measured.** The reflink-copy
+  race only fired at N=100 with the 2 GiB writable layer; smaller N
+  hit no failures.
+- Single-instance cold start ≈ **924 ms** here, vs Cube's published
+  fast-path **<60 ms**. The ~15× gap is the combined cost of the
+  slow path (live `mkfs.ext4` plus reflink-copy of a 2 GiB image)
+  and the host being well outside their 96 vCPU testing matrix.
+- Per-sandbox cost shrinks substantially with concurrency
+  (924 → 441 → 257 ms / sandbox) — pipelined work the original
+  20.3 s / 100 = 203 ms-per-sandbox number is consistent with.
+
+What we did **not** measure here: the fast path
+(`writable_layer_size` matching `pool_default_format_size_list`).
+Doing so would require either a new template with a 1 GiB writable
+layer or reconfiguring the pool for 2 GiB; we left it for whenever
+either Cube or a downstream user wants a head-to-head fast-path
+number on this host.

--- a/bench/cube-replay.sh
+++ b/bench/cube-replay.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Re-bench CubeSandbox with the same 2 Gi writable-layer template the
+# original run used, but at smaller N (N=1, N=5, N=10) so we stay
+# under the 30 GiB host RAM budget (template spec = 2 GiB per sandbox).
+#
+# Uses cube-api's E2B-compatible REST endpoints directly so we don't
+# need to chase the right req.json shape for cubemastercli multirun.
+set -euo pipefail
+
+API=http://127.0.0.1:6000
+KEY="X-API-Key: local"
+
+create_one() {
+    local out
+    out=$(curl -sS -X POST "$API/sandboxes" -H "Content-Type: application/json" -H "$KEY" \
+                -d '{"templateID":"forkd-bench-pynp"}' 2>&1)
+    # sandboxID extraction without jq
+    echo "$out" | sed -n 's/.*"sandboxID":"\([^"]*\)".*/\1/p'
+}
+
+kill_one() {
+    local id="$1"
+    curl -sS -X DELETE "$API/sandboxes/$id" -H "$KEY" > /dev/null 2>&1 || true
+}
+
+run_n() {
+    local N="$1"
+    echo "==> N=$N concurrent create"
+    declare -a pids ids
+    local tmpd
+    tmpd=$(mktemp -d)
+    local t0=$(date +%s%N)
+    for i in $(seq 1 "$N"); do
+        ( create_one > "$tmpd/$i" ) &
+        pids[$i]=$!
+    done
+    for p in "${pids[@]}"; do wait "$p" 2>/dev/null || true; done
+    local t1=$(date +%s%N)
+    local elapsed_ms=$(( (t1 - t0) / 1000000 ))
+
+    local succ=0
+    for i in $(seq 1 "$N"); do
+        id=$(cat "$tmpd/$i" 2>/dev/null)
+        if [ -n "$id" ]; then
+            ids+=("$id")
+            succ=$((succ + 1))
+        fi
+    done
+    echo "    succeeded: $succ / $N"
+    echo "    wall-clock: ${elapsed_ms} ms"
+
+    echo "    killing ..."
+    for id in "${ids[@]:-}"; do
+        [ -n "$id" ] && kill_one "$id" &
+    done
+    wait
+    rm -rf "$tmpd"
+    sleep 3
+}
+
+# warm up: cubelet pool may need a moment after restart
+echo "==> warming cubelet (single sandbox, discarded)"
+warm_id=$(create_one || true)
+[ -n "$warm_id" ] && kill_one "$warm_id"
+sleep 3
+
+run_n 1
+run_n 5
+run_n 10


### PR DESCRIPTION
Follow-up to [TencentCloud/CubeSandbox#235](https://github.com/TencentCloud/CubeSandbox/issues/235). The Cube maintainer responded with two clarifications that change how the 20.3 s / 77-of-100 N=100 number should be interpreted (without changing the measurement itself).

## What the Cube team said

1. **The reflink-copy race is on a slow code path the original template inadvertently selected.** CubeSandbox pre-formats a pool of writable-layer ext4 images at sizes listed in \`pool_default_format_size_list\` (default \`[\"1Gi\"]\`). A sandbox whose \`writable_layer_size\` matches one of those sizes reuses a pool entry — fast path, no \`mkfs.ext4\` or reflink-copy per sandbox. We passed \`--writable-layer-size 2Gi\`, which doesn't match, so every sandbox went through the live \`mkfs.ext4 + reflink-copy\` path. That's where the bad-magic race lives.
2. **Cube's published <60 ms single-instance / P95 90 ms @ N=50 / <200 ms @ N=100 numbers are measured on a 96 vCPU server.** Our 20 vCPU host (the dev box) is outside their tested matrix.

Cube also accepted the first two improvements from our issue (configurable \`cmdTimeout\`, richer diagnostic info on \`newExt4RawByReflinkCopy\` failures) and is reviewing the third (drop per-clone \`e2fsck\`).

## Doc changes

- **README.md** — both footnotes ¹ rewritten to lead with \"slow-path measurement on a host outside CubeSandbox's documented testing matrix\". The 20.3 s figure itself stays in the table. The footnote now explicitly says we did not re-test the fast-path configuration.
- **bench/CUBESANDBOX.md** — two new sections:
  - *Upstream response (2026-05-14)* with the clarifications from Cube and the status of our improvement proposals.
  - *Small-N replay on the same (slow-path) configuration* with N=1/5/10 numbers — done so the row's narrative isn't just \"we hit a race once.\"
- **bench/cube-replay.sh** — the script that produced the small-N numbers.

## Small-N replay results

Same 2 GiB template (slow path), this dev box (20 vCPU / 30 GiB):

| N | Succeeded | Wall-clock | Per-sandbox |
|---:|:---:|---:|---:|
| 1 | 1/1 | 924 ms | 924 ms |
| 5 | 5/5 | 2,207 ms | 441 ms |
| 10 | 10/10 | 2,567 ms | 257 ms |

100 % success at every size measured — the race is specifically a slow-path-at-high-N phenomenon. The 20.3 s / 100 = 203 ms-per-sandbox figure at N=100 is consistent with the per-sandbox cost shrinking with concurrency.

## Test plan
- [x] README footnotes render OK on GitHub
- [x] bench/CUBESANDBOX.md anchor link from README footnote works
- [x] bench/cube-replay.sh is executable + matches the numbers reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)