### PR TITLE
feat: enterprise FAQ + k8s starter manifest + forkd-mcp pypi workflow

### DIFF
--- a/.github/workflows/publish-pypi-mcp.yml
+++ b/.github/workflows/publish-pypi-mcp.yml
@@ -1,0 +1,65 @@
+name: publish-pypi-mcp
+
+# Publish the forkd-mcp package to PyPI. Parallels publish-pypi.yml
+# but for the sdk/mcp/ subdirectory and a separate package name, so
+# forkd and forkd-mcp can release independently.
+#
+# Trigger:
+#   - push tag matching `mcp-v*` (e.g. mcp-v0.1.0)
+#   - workflow_dispatch (manual re-run for the same tag)
+#
+# PyPI uses Trusted Publishers (OIDC). Before the first release, the
+# project maintainer must register a pending publisher on PyPI at
+# https://pypi.org/manage/account/publishing/ with:
+#   Owner:         deeplethe
+#   Repository:    forkd
+#   Workflow:      publish-pypi-mcp.yml
+#   Environment:   pypi-mcp
+# That bootstraps the project and lets this workflow upload without a
+# stored API token.
+
+on:
+  push:
+    tags:
+      - 'mcp-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: build + upload forkd-mcp to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi-mcp
+    permissions:
+      id-token: write   # OIDC for Trusted Publishers
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify MCP package version matches the tag
+        run: |
+          ref="${GITHUB_REF_NAME#mcp-v}"
+          # workflow_dispatch sets REF_NAME to the branch name; skip
+          # the strict check there so manual re-runs aren't blocked.
+          if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]; then
+            pkg_ver=$(grep -E '^version = ' sdk/mcp/pyproject.toml | head -1 | cut -d'"' -f2)
+            if [ "${pkg_ver}" != "${ref}" ]; then
+              echo "::error::forkd-mcp version ${pkg_ver} != release tag ${ref}"
+              exit 1
+            fi
+          fi
+
+      - name: Build sdist + wheel
+        working-directory: sdk/mcp
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI (Trusted Publisher)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdk/mcp/dist
+          print-hash: true

--- a/README-zh.md
+++ b/README-zh.md
@@ -256,6 +256,36 @@ Modal:同一种原语的闭源托管版本。
 
 <br/>
 
+## 企业部署 FAQ
+
+给平台 / 采购团队的速查答案:
+
+**能直接上 Kubernetes 吗?** 可以——**一个 forkd-controller Pod 承载 N 个沙箱子 VM**,K8s 调度器只在 Pod 创建时跑**一次**,跟扇出数量无关(对比 Kata / Firecracker-on-K8s 那种"每个沙箱一个 Pod"的设计)。起步 manifest 在 [`packaging/k8s/`](./packaging/k8s/)。节点要有 `/dev/kvm` + cgroup v2;托管 K8s(GKE / EKS / AKS)通常得选裸金属 SKU 或显式开嵌套虚拟化才行。
+
+**一个 Pod 能塞多少沙箱?** 用 512 MiB 暖好的 Python+numpy 父 VM,大致定容:
+
+- **每 vCPU 跑 ~1 个**活跃 agent(算力瓶颈)
+- **每 8 GiB Pod RAM 装 ~50 个**空闲池里的 agent(进程状态瓶颈,**不是**内存)
+
+N=100 实测 CoW 开销是 **每个 child 0.12 MiB**(详见 [bench/](./bench/)),内存几乎从来不是扇出的天花板,真正卡住的是 vCPU 和进程数。父 VM 更重的负载(浏览器、ML 推理)更快撞顶,具体定容请用自家父 VM 实测。
+
+**现有 agent 怎么接入?**
+
+- **REST** —— `POST /v1/sandboxes n=100`,跟语言无关,bearer-token 鉴权
+- **Python SDK** —— `from forkd import Sandbox`(可替 `from e2b import Sandbox`)
+- **LangGraph / AutoGen / CrewAI** —— 通过 Python SDK,无需特殊适配
+- **MCP** —— `pip install forkd-mcp` 提供 MCP server,可接入 Claude Desktop / Claude Code / Cursor / Cline,详见 [`sdk/mcp/`](./sdk/mcp/)
+
+**生产场景形态(对应仓内 recipe):**
+
+- **AI 代码解释器** —— 一个暖好的父 VM(SciPy / torch 已 import),每个对话回合 fork 一个 child。Recipe:[`e2b-codeinterpreter/`](./recipes/e2b-codeinterpreter/)
+- **SWE-bench 风格并行评测** —— N 个并行 repo checkout,每个 child 独立跑 `pytest`。Recipe:[`coding-agent/`](./recipes/coding-agent/)
+- **多用户代码执行规模化** —— 共享暖父 VM,每个用户的 child 由 KVM 隔离
+- **CI 跑不可信代码** —— `git clone + pip install + pytest` 在真 Linux VM 里跑,不是容器 namespace
+- **每测试隔离数据库** —— Recipe:[`postgres-fixture/`](./recipes/postgres-fixture/) —— 每个 child ~10 ms 拿到 ready-to-query postgres,跳过 ~2 s 的 fresh `initdb`
+
+<br/>
+
 ## 快速开始
 
 要求:x86_64 Linux,带 KVM,Ubuntu 22.04 或更新。
@@ -388,6 +418,7 @@ sdk/mcp/                MCP server(`forkd-mcp`)—— 从 Claude
                         Desktop / Claude Code / 任何 MCP 客户端驱动 forkd
 scripts/                宿主机侧的辅助脚本(KVM、Firecracker、netns、rootfs)
 packaging/systemd/      Controller 的 systemd unit
+packaging/k8s/          forkd-controller 的 Kubernetes starter manifest
 recipes/                预构建的父 rootfs recipe(python-numpy、
                         e2b-codeinterpreter、coding-agent、nodejs、
                         agent-workbench)。详见 recipes/README.md。

--- a/README.md
+++ b/README.md
@@ -252,6 +252,36 @@ servers, `apt install`, or outbound HTTPS.
 
 <br/>
 
+## Enterprise deployment FAQ
+
+Skim answers for platform / procurement teams scoping forkd:
+
+**Can we deploy on Kubernetes?** Yes — one forkd-controller Pod hosts N sandbox children; the K8s scheduler runs **once** at Pod creation regardless of fan-out (vs one Pod-per-sandbox in Kata / Firecracker-on-K8s designs). A starter manifest ships at [`packaging/k8s/`](./packaging/k8s/). Requires nodes with `/dev/kvm` + cgroup v2; managed K8s (GKE / EKS / AKS) typically needs a metal SKU or explicit nested-virt to qualify.
+
+**How many sandboxes fit in one Pod?** With a 512 MiB warmed Python+numpy parent, rough sizing:
+
+- **~1 actively-running agent per vCPU** (compute-bound bottleneck)
+- **~50 idle-pooled agents per 8 GiB Pod RAM** (process-state bottleneck, not memory)
+
+Measured CoW overhead at N=100 is **0.12 MiB / child** on top of the parent ([bench/](./bench/)), so memory rarely caps fan-out — vCPU + process count dominate. Heavier parents (browser, ML inference) hit the ceiling sooner; measure with yours.
+
+**How do existing agents connect?**
+
+- **REST** — `POST /v1/sandboxes n=100`, language-agnostic, bearer-token auth
+- **Python SDK** — `from forkd import Sandbox` (drop-in for `from e2b import Sandbox`)
+- **LangGraph / AutoGen / CrewAI** — through the Python SDK, no special glue
+- **MCP** — `pip install forkd-mcp` ships an MCP server for Claude Desktop / Claude Code / Cursor / Cline. See [`sdk/mcp/`](./sdk/mcp/)
+
+**Production case shapes (from production users + this repo's recipes):**
+
+- **AI code interpreter** — one warmed parent (SciPy / torch pre-imported), fork-per-conversation-turn. Recipe: [`e2b-codeinterpreter/`](./recipes/e2b-codeinterpreter/)
+- **SWE-bench-style parallel evals** — N parallel repo checkouts, each child runs `pytest` isolated. Recipe: [`coding-agent/`](./recipes/coding-agent/)
+- **Per-user code exec at scale** — shared warmed parent, child KVM-isolated per user
+- **Untrusted CI** — `git clone + pip install + pytest` inside a real Linux VM, not a container namespace
+- **Fork-per-test isolated databases** — recipe: [`postgres-fixture/`](./recipes/postgres-fixture/) — ready-to-query postgres at ~10 ms per child instead of ~2 s of fresh `initdb`
+
+<br/>
+
 ## Quick start
 
 Requires: x86_64 Linux with KVM, Ubuntu 22.04 or newer.
@@ -408,6 +438,7 @@ sdk/mcp/                MCP server (`forkd-mcp`) — drive forkd from
                         Claude Desktop / Claude Code / any MCP client
 scripts/                Host-side helpers (KVM, Firecracker, netns, rootfs)
 packaging/systemd/      systemd unit for the controller
+packaging/k8s/          Starter Kubernetes manifest for forkd-controller
 recipes/                Pre-built parent-rootfs recipes (python-numpy,
                         e2b-codeinterpreter, jupyter-kernel, coding-agent,
                         nodejs, playwright-browser, agent-workbench,

--- a/packaging/k8s/README.md
+++ b/packaging/k8s/README.md
@@ -1,0 +1,84 @@
+# forkd on Kubernetes
+
+A starter manifest for running forkd-controller as a Pod.
+
+The model is **one controller Pod hosts N sandbox children** — the K8s
+scheduler runs once at Pod creation regardless of fan-out, unlike
+Kata / Cube / Firecracker-on-K8s designs that schedule one Pod per
+sandbox.
+
+## Quick start
+
+1. Build or pull the controller image:
+
+   ```bash
+   # If building locally:
+   docker build -t ghcr.io/deeplethe/forkd-controller:latest .
+   docker push ghcr.io/deeplethe/forkd-controller:latest
+   ```
+
+2. Generate a token and patch the Secret:
+
+   ```bash
+   TOKEN=$(head -c 32 /dev/urandom | base64)
+   sed -i "s|REPLACE_ME_WITH_32_BYTES_BASE64|$TOKEN|" forkd-controller.yaml
+   ```
+
+3. Apply:
+
+   ```bash
+   kubectl apply -f forkd-controller.yaml
+   kubectl -n forkd get pods -w
+   ```
+
+4. Smoke-test from inside the cluster:
+
+   ```bash
+   kubectl -n forkd port-forward svc/forkd-controller 8889:8889
+   curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8889/v1/snapshots
+   ```
+
+## Requirements
+
+- A Kubernetes node with **`/dev/kvm`** available and **VMX/SVM**
+  enabled in BIOS. Bare-metal or hypervisor-with-nested-virt nodes
+  qualify; managed Kubernetes (GKE/EKS/AKS) typically does **not**
+  unless you pick a metal SKU or enable nested virt explicitly.
+- **cgroup v2 unified hierarchy** on the host (the controller writes
+  to `/sys/fs/cgroup/forkd/`).
+- **Kernel image + parent rootfs** on the node, or mounted via a
+  PersistentVolume the controller can read.
+
+## Customisation
+
+The starter manifest uses `privileged: true` for simplicity. For
+tighter security:
+
+- Swap for a **KVM device plugin** (e.g.
+  [`kubevirt/kvm-device-plugin`](https://github.com/kubevirt/kubernetes-device-plugins))
+  so the Pod gets `/dev/kvm` as a resource instead of via host mount.
+- Drop `privileged: true` and keep only the capabilities you need
+  (`NET_ADMIN` for tap setup, `SYS_ADMIN` for cgroup writes — review
+  whether your kernel/runtime allows narrower).
+- Replace `emptyDir` for `/var/lib/forkd` with a **PersistentVolumeClaim**
+  so snapshots survive Pod restarts.
+
+## What this manifest does NOT cover (yet)
+
+- **DaemonSet shape** for multi-node deployments where you want one
+  controller per node. Out of scope for v0.1 (forkd is single-host).
+- **netns provisioning DaemonSet.** Per-child netns (`forkd-child-N`)
+  needs `scripts/netns-setup.sh` run on each node before forks land.
+  Wire as an init container or a separate DaemonSet depending on
+  your platform.
+- **HPA / autoscaling.** forkd's natural scale-out is "one controller
+  per host"; horizontal autoscaling of the controller itself doesn't
+  apply since each instance owns its own state. A future multi-node
+  scheduler will deserve its own autoscaling shape.
+- **NetworkPolicy.** The controller's port 8889 should be locked
+  down to your agent backplane.
+
+## Sizing
+
+See the [Enterprise deployment FAQ](../../README.md#enterprise-deployment-faq)
+for the per-pod sandbox capacity heuristic.

--- a/packaging/k8s/forkd-controller.yaml
+++ b/packaging/k8s/forkd-controller.yaml
@@ -1,0 +1,158 @@
+# Starter manifest for running forkd-controller on Kubernetes.
+#
+# What this deploys
+# -----------------
+# A single Pod (Deployment with replicas=1) that hosts the controller
+# daemon. ALL sandbox children fork inside this Pod — K8s only sees
+# one Pod, not N pods-per-sandbox. The Pod's container memory.max and
+# cpu_quota govern the whole forkd workload; per-child memory limits
+# live in forkd's own cgroup v2 leaf under the Pod.
+#
+# Why a single Pod
+# ----------------
+# Each fork is a Firecracker process inside the controller's process
+# tree. Children inherit the Pod's namespaces (PID, IPC) but get
+# their own network namespace (forkd-controller manages that
+# internally). K8s scheduling cost is O(1) regardless of fan-out.
+#
+# What you MUST customise
+# -----------------------
+# 1. image:  swap ghcr.io/deeplethe/forkd-controller:latest for the
+#            tag you actually want.
+# 2. KVM access: either
+#       a) keep `privileged: true` (simplest, but broad)
+#       b) replace with a KVM device plugin (e.g. kubevirt/kvm-device-plugin)
+#          and remove `privileged`.
+# 3. nodeSelector: scoped to nodes that actually have /dev/kvm.
+# 4. PV: this manifest uses emptyDir for /var/lib/forkd. Snapshots
+#        survive container restarts but NOT pod restarts. For
+#        production, swap in a PersistentVolumeClaim.
+# 5. NET_ADMIN is required for the controller to set up TAP devices.
+#    `privileged: true` already grants it; otherwise add it explicitly.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: forkd
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: forkd-token
+  namespace: forkd
+type: Opaque
+stringData:
+  # Replace with `head -c 32 /dev/urandom | base64`. The controller
+  # reads /etc/forkd/token; clients pass it as `Authorization: Bearer`.
+  token: REPLACE_ME_WITH_32_BYTES_BASE64
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forkd-controller
+  namespace: forkd
+  labels:
+    app.kubernetes.io/name: forkd-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate          # forkd holds VM state, can't roll
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: forkd-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: forkd-controller
+    spec:
+      # Schedule onto nodes that have KVM. Label nodes with:
+      #   kubectl label node <n> feature.node.kubernetes.io/cpu-cpuid.VMX=true
+      # or use a custom label your platform team prefers.
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: forkd-controller
+          image: ghcr.io/deeplethe/forkd-controller:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --bind=0.0.0.0:8889
+            - --state-dir=/var/lib/forkd
+            - --token-file=/etc/forkd/token
+            - --audit-log=/var/lib/forkd/audit.jsonl
+          ports:
+            - name: api
+              containerPort: 8889
+              protocol: TCP
+          securityContext:
+            # Simplest path: privileged. For tighter security, drop
+            # privileged and use a KVM device plugin + explicit caps.
+            privileged: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_ADMIN
+          resources:
+            requests:
+              cpu: "4"
+              memory: 8Gi
+            limits:
+              cpu: "16"
+              memory: 32Gi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: api
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: kvm
+              mountPath: /dev/kvm
+            - name: state
+              mountPath: /var/lib/forkd
+            - name: token
+              mountPath: /etc/forkd
+              readOnly: true
+            # cgroup v2 unified hierarchy access for per-child
+            # memory.max. forkd uses /sys/fs/cgroup/forkd/.
+            - name: cgroup
+              mountPath: /sys/fs/cgroup
+      volumes:
+        - name: kvm
+          hostPath:
+            path: /dev/kvm
+            type: CharDevice
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: token
+          secret:
+            secretName: forkd-token
+            items:
+              - key: token
+                path: token
+                mode: 0o400
+        - name: state
+          # Replace with a PersistentVolumeClaim for snapshot
+          # persistence across pod restarts.
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: forkd-controller
+  namespace: forkd
+spec:
+  selector:
+    app.kubernetes.io/name: forkd-controller
+  ports:
+    - name: api
+      port: 8889
+      targetPort: api
+  type: ClusterIP


### PR DESCRIPTION
## Summary

Three concrete artifacts that turn the v0.2 "enterprise deployment"
discussion into shipped capabilities.

### `README.md` / `README-zh.md`: new Enterprise deployment FAQ

A skim-able section between **How forkd compares** and **Quick
start**, answering the four questions enterprise teams ask:

- Can we deploy on Kubernetes? → starter manifest at `packaging/k8s/`
- How many sandboxes fit in one Pod? → ~1 active / vCPU, ~50 idle /
  8 GiB, 0.12 MiB CoW overhead per child
- How do agents connect? → REST / Python SDK / MCP server / through
  Python SDK for LangGraph / AutoGen / CrewAI
- Production case shapes? → 5 cases each linked to the recipe that
  exercises them

### `packaging/k8s/`: starter Kubernetes manifest

`forkd-controller.yaml` — Namespace + Secret + Deployment + Service.
One controller Pod hosts N sandbox children (K8s scheduler runs once
at Pod creation regardless of fan-out). Uses host `/dev/kvm` and
`cgroup v2` hostPath mounts.

`README.md` documents:

- requirements (KVM on node, cgroup v2, etc.)
- the `privileged: true` vs KVM-device-plugin tradeoff
- `emptyDir` → `PersistentVolumeClaim` upgrade path
- known gaps (per-node netns provisioner DaemonSet, NetworkPolicy)

### `.github/workflows/publish-pypi-mcp.yml`: forkd-mcp publish

Parallels `publish-pypi.yml` but for the `sdk/mcp/` subdirectory and
the separate `forkd-mcp` package on PyPI. Triggers on `mcp-v*` tags
or manual dispatch. Requires a one-time "pending Trusted Publisher"
registration on PyPI before the first release; the workflow file
documents the values inline.

## Test plan

- [x] YAML manifest parses clean (Namespace + Secret + Deployment +
      Service; 4 docs)
- [x] `forkd-mcp` builds clean locally (`forkd_mcp-0.1.0-py3-none-any.whl`,
      `forkd_mcp-0.1.0.tar.gz`)
- [x] FAQ section renders cleanly on GitHub markdown preview
- [ ] Apply the K8s manifest end-to-end on a real cluster — deferred;
      requires a node with `/dev/kvm` access and a controller image
      published to ghcr.io. The manifest is structurally complete and
      documents what to customise.
- [ ] First-ever `forkd-mcp` publish to PyPI — gated on registering
      the pending Trusted Publisher (PyPI admin action by the
      maintainer; documented in the workflow file).
