### PR TITLE
fix(recipes/postgres-fixture): end-to-end verified, drop alpha status

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -32,7 +32,7 @@ sudo -E forkd fork --tag <name> -n 100 --per-child-netns
 | [`nodejs/`](./nodejs/) | `node:22-slim` | ~250 MB | JavaScript / TypeScript workloads (Jest, Playwright fan-out) |
 | [`playwright-browser/`](./playwright-browser/) | `mcr.microsoft.com/playwright` (Node + Chromium pre-warmed) | ~2.5 GB | Browser-driving agents (computer-use, web research, UI test gen). Fork warmed headless Chromium at ~10 ms instead of ~2 s. **Alpha** |
 | [`agent-workbench/`](./agent-workbench/) | `agent-infra/sandbox` (browser + VSCode + Jupyter + MCP + shell) | ~5 GB | Kitchen-sink agent workbench when you want every tool already mounted; trades a bigger memory.bin for batteries-included |
-| [`postgres-fixture/`](./postgres-fixture/) | `postgres:16-alpine` (initdb done, postmaster pre-launched) | ~300 MB | Fork-per-test isolated databases; each child gets a ready-to-query postgres in ~10 ms instead of ~2 s for fresh initdb. **Alpha** |
+| [`postgres-fixture/`](./postgres-fixture/) | `postgres:16` (initdb done, postmaster pre-launched) | ~500 MB | Fork-per-test isolated databases; each child gets a ready-to-query postgres in ~10 ms instead of ~2 s for fresh initdb |
 
 ## Choosing a recipe
 

--- a/recipes/postgres-fixture/README.md
+++ b/recipes/postgres-fixture/README.md
@@ -1,15 +1,16 @@
 # `postgres-fixture`
 
-A forkd parent built from `postgres:16-alpine` with `initdb` already
-run and the postmaster pre-launched. **Each child fork gets its own
+A forkd parent built from `postgres:16` with `initdb` already run and
+the postmaster pre-launched. **Each child fork gets its own
 isolated postgres ready to query in ~10 ms**, sharing the parent's
 resident memory via CoW.
 
-> **Status: alpha.** End-to-end snapshot + fork verified on a
-> bare-metal x86_64 / Linux 6.14 / KVM host. The interesting failure
-> mode to know about: postgres uses POSIX shared memory for its
-> shared buffers; CoW handles this correctly because each child runs
-> in its own kernel, so `/dev/shm` is independent per child VM.
+> **Status: working.** End-to-end verified on a bare-metal i7-12700
+> dev box (Linux 6.14, KVM, 30 GiB): snapshot → fork 5 children with
+> per-child netns → `psql -h 10.42.0.2 -U forkd -d forkd_test` from
+> each child's netns returns its own row count. Children mutate
+> their own postgres without affecting siblings (`/dev/shm` is per
+> child VM, postmaster state diverges per page via mmap CoW).
 
 ## Why this recipe
 
@@ -42,14 +43,18 @@ because per-test cost was prohibitive can now go fully isolated.
 
 ## What you get
 
-- `postgres:16-alpine` base (lean, ~250 MB image)
+- `postgres:16` Debian base (the postgres-image PATH expects bash
+  process-substitution; Alpine is not supported)
+- `python3` installed (required by forkd-init)
+- `/dev/fd` symlinked to `/proc/self/fd` so docker-entrypoint's
+  `initdb --pwfile=<(printf ...)` works
 - Database **already initialised** at `/var/lib/postgresql/data`
 - **Postmaster already running** in the parent at snapshot time
 - Default user/db (override via env): user=`forkd`, password=`forkd`,
   database=`forkd_test`, trust auth on `0.0.0.0/0` (safe — postgres
   is only reachable inside the child netns)
 
-Total rootfs: **~300 MB**.
+Total rootfs: **~500 MB**.
 
 ## Use it
 

--- a/recipes/postgres-fixture/build.sh
+++ b/recipes/postgres-fixture/build.sh
@@ -14,9 +14,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-IMAGE="${IMAGE:-postgres:16-alpine}"
-SIZE_MIB="${SIZE_MIB:-1024}"
+IMAGE="${IMAGE:-postgres:16}"
+SIZE_MIB="${SIZE_MIB:-1536}"
 OUT="$SCRIPT_DIR/parent.ext4"
+
+# python3 is required by forkd-init.sh to launch forkd-agent.py inside
+# the guest. The Debian-based postgres:16 image doesn't ship it; we
+# add it via build-rootfs.sh's extra-apt-packages mechanism. (Alpine
+# variants are unsupported because build-rootfs.sh uses apt.)
+EXTRA_PKGS="${EXTRA_PKGS:-python3}"
 
 # Database credentials for the parent. Children inherit these; tests
 # typically connect with these values and don't care about the password
@@ -27,8 +33,8 @@ PG_DATABASE="${PG_DATABASE:-forkd_test}"
 
 [ "$(id -u)" -eq 0 ] || { echo "run as root" >&2; exit 1; }
 
-echo "==> building rootfs from $IMAGE"
-bash "$REPO_ROOT/scripts/build-rootfs.sh" "$IMAGE" "$OUT" "$SIZE_MIB"
+echo "==> building rootfs from $IMAGE (+ extra: $EXTRA_PKGS)"
+bash "$REPO_ROOT/scripts/build-rootfs.sh" "$IMAGE" "$OUT" "$SIZE_MIB" $EXTRA_PKGS
 
 # Mount the rootfs and inject:
 # 1. A warmup script that runs initdb (once) + starts the postmaster,
@@ -50,38 +56,7 @@ mkdir -p "$ROOTFS_MNT/var/lib/postgresql/data"
 chmod 700 "$ROOTFS_MNT/var/lib/postgresql/data"
 chown 70:70 "$ROOTFS_MNT/var/lib/postgresql/data"  # alpine postgres uid
 
-cat > "$ROOTFS_MNT/usr/local/bin/forkd-pg-warmup" <<EOF
-#!/bin/sh
-# Spawned by forkd-agent.py via FORKD_WARMUP_CMD before the parent
-# snapshot is taken. initdb the cluster (idempotent), start the
-# postmaster in background, emit the line-JSON ready handshake the
-# agent waits for, then idle so the agent's bookkeeping is happy.
-
-set -e
-export PGDATA=/var/lib/postgresql/data
-export POSTGRES_USER=$PG_USER
-export POSTGRES_PASSWORD=$PG_PASSWORD
-export POSTGRES_DB=$PG_DATABASE
-
-if [ ! -f "\$PGDATA/PG_VERSION" ]; then
-    su postgres -c "initdb -D \$PGDATA --username=$PG_USER --auth=trust" >/dev/null 2>&1
-    echo "host all all 0.0.0.0/0 trust"   >> "\$PGDATA/pg_hba.conf"
-    echo "listen_addresses = '*'"          >> "\$PGDATA/postgresql.conf"
-fi
-
-su postgres -c "pg_ctl -D \$PGDATA -l /tmp/pg.log -w start" >/dev/null 2>&1
-
-# Create the application database if missing.
-su postgres -c "psql -tAc \"SELECT 1 FROM pg_database WHERE datname='$PG_DATABASE'\" | grep -q 1 || createdb -U $PG_USER $PG_DATABASE" >/dev/null 2>&1
-
-# Tell forkd-agent we're ready; it will proceed and the snapshot can
-# be taken with postmaster already accepting connections.
-echo '{"ready": true}'
-
-# Park forever — postgres runs via pg_ctl in background, the agent
-# only cares that this PID stays alive (so it can correlate logs).
-exec sleep infinity
-EOF
+cp "$SCRIPT_DIR/forkd-pg-warmup" "$ROOTFS_MNT/usr/local/bin/forkd-pg-warmup"
 chmod 755 "$ROOTFS_MNT/usr/local/bin/forkd-pg-warmup"
 
 cat > "$ROOTFS_MNT/etc/forkd-recipe.env" <<EOF

--- a/recipes/postgres-fixture/forkd-pg-warmup
+++ b/recipes/postgres-fixture/forkd-pg-warmup
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Spawned by forkd-agent.py via FORKD_WARMUP_CMD before the parent
+# snapshot is taken. Delegates to upstream docker-entrypoint.sh for
+# the heavy lifting (initdb, /docker-entrypoint-initdb.d/, password
+# config), then emits the line-JSON ready handshake and parks.
+#
+# Stdout is the agent's handshake channel: the FIRST line on stdout
+# must be {"ready": true}. Everything else goes to a log file so it
+# does not confuse the agent. Stderr stays intact for visibility.
+#
+# Configuration is read from /etc/forkd-recipe.env at startup
+# (PG_USER, PG_PASSWORD, PG_DATABASE).
+
+set -e
+
+# The Debian postgres image puts binaries under
+# /usr/lib/postgresql/16/bin/ and adds them to PATH via the image's
+# ENV. forkd-agent inherits a minimal PATH so we restore it
+# explicitly here so initdb, pg_ctl, psql resolve.
+export PATH=/usr/lib/postgresql/16/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# docker-entrypoint.sh uses bash process substitution (<(printf ...))
+# to pass the postgres password to initdb. That writes to /dev/fd/63.
+# In a Debian rootfs /dev/fd is normally a symlink to /proc/self/fd,
+# but forkd's devtmpfs setup doesn't create it. Make sure it exists.
+[ -e /dev/fd ] || ln -s /proc/self/fd /dev/fd
+
+# Read recipe env if present; build.sh writes it alongside this script.
+if [ -f /etc/forkd-recipe.env ]; then
+    . /etc/forkd-recipe.env
+fi
+
+export PGDATA=/var/lib/postgresql/data
+export POSTGRES_USER="${PG_USER:-forkd}"
+export POSTGRES_PASSWORD="${PG_PASSWORD:-forkd}"
+export POSTGRES_DB="${PG_DATABASE:-forkd_test}"
+export POSTGRES_HOST_AUTH_METHOD=trust
+
+# Start postgres via upstream docker-entrypoint. The script runs
+# initdb the first time (idempotent on existing PGDATA), then execs
+# the postmaster. We background it and silence its stdout so only
+# our handshake reaches the agent.
+docker-entrypoint.sh postgres -c listen_addresses='*' >/tmp/pg-entry.log 2>&1 &
+ENTRY_PID=$!
+
+# Wait up to 30 s for the postmaster to accept connections on TCP.
+# The wait probes as $POSTGRES_USER (not "postgres") because initdb
+# creates only the configured app role, not a separate postgres role.
+i=0
+while [ $i -lt 60 ]; do
+    if su postgres -c "psql -h 127.0.0.1 -U \"$POSTGRES_USER\" -d postgres -tAc 'SELECT 1' >/dev/null 2>&1"; then
+        break
+    fi
+    sleep 0.5
+    i=$((i + 1))
+done
+
+# Signal ready to forkd-agent. Snapshot will be taken shortly after,
+# capturing the postmaster's resident memory + open sockets.
+echo '{"ready": true}'
+
+# Park alive: agent uses this PID for lifecycle correlation;
+# postgres runs in the background and is what children inherit.
+wait $ENTRY_PID


### PR DESCRIPTION
## Summary

Took the alpha `postgres-fixture` recipe to a real KVM testbed, hit
three concrete failures, fixed them in place; recipe is now
end-to-end verified.

**Demonstrated working flow on i7-12700 / Linux 6.14 / KVM:**

```
sudo bash recipes/postgres-fixture/build.sh
sudo -E forkd snapshot --tag pgfix --kernel <vmlinux> --rootfs ...
sudo bash scripts/netns-setup.sh 5
sudo -E forkd fork --tag pgfix -n 5 --per-child-netns

# from inside each child's netns:
sudo ip netns exec forkd-child-N psql -h 10.42.0.2 -U forkd \
    -d forkd_test -c "INSERT INTO marker VALUES (N); SELECT count(*) FROM marker"
# → each child sees rows=1 (independent DBs, CoW isolation verified)
```

## Fixes

| # | Symptom | Root cause | Fix |
|---|---|---|---|
| 1 | `forkd-init: ERROR: no python interpreter` | postgres:16-alpine ships no python3, forkd-init.sh needs it | Switch base to `postgres:16` (Debian) + add `python3` as an extra apt package |
| 2 | `initdb: command not found` | postgres binaries under `/usr/lib/postgresql/16/bin/`, forkd-agent's minimal inherited PATH doesn't include it | Prepend `/usr/lib/postgresql/16/bin` to PATH in the warmup script |
| 3 | `initdb: could not open file "/dev/fd/63"` | `docker-entrypoint.sh` uses bash process substitution; Debian normally ships `/dev/fd → /proc/self/fd` but forkd's devtmpfs setup doesn't preserve it | `[ -e /dev/fd ] \|\| ln -s /proc/self/fd /dev/fd` at warmup start |

Also one cleanup along the way:

- The warmup script is now a real file in the recipe directory
  (`recipes/postgres-fixture/forkd-pg-warmup`) and `cp`'d into the
  rootfs, instead of being embedded as a heredoc inside `build.sh`.
  Debugging the recipe involved a round of unexplained heredoc
  expansion edges — concrete files are easier to reason about.

## Test plan

- [x] `bash recipes/postgres-fixture/build.sh` — builds parent.ext4
      (~1.5 GiB sparse, ~500 MB used)
- [x] `forkd snapshot --tag pgfix ...` — parent VM logs
      `forkd: warmup ready` before snapshot; `snapshot took 6.7 s`
- [x] `forkd fork --tag pgfix -n 5 --per-child-netns` — 5 children
      come up; postgres `pgrep -af` shows postmaster + workers
      inside each child
- [x] 5 children each `INSERT INTO marker (i); SELECT count(*)` —
      every child returns `count=1` (proves CoW isolation; without
      isolation, child N would see count=N)
- [x] Recipe README + index row updated to drop the alpha status
