### PR TITLE
chore: housekeeping (ignore notes/, fix publish-pypi cross-trigger)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,6 +19,11 @@ jobs:
   publish:
     name: build + upload to PyPI
     runs-on: ubuntu-latest
+    # The `release: published` event fires on every release in the
+    # repo, including sibling packages with different tag prefixes
+    # (e.g. `mcp-v*` for `forkd-mcp`). Skip those — only forkd's own
+    # `v*` releases should publish the forkd SDK.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     environment: pypi   # must match the GitHub environment + PyPI Trusted Publisher config
     permissions:
       id-token: write   # OIDC for Trusted Publishers

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ build/
 /tmp-vms/
 /work/
 *.vmstate
+
+# Private working notes — paper drafts, bench scratch, internal memos.
+# Backed up out-of-band (e.g., iCloud / Dropbox / private notes repo),
+# not in this public repo.
+/notes/


### PR DESCRIPTION
## Summary

Two small housekeeping fixes batched together.

### `ci(publish-pypi)`: skip release events with non-v* tags

`publish-pypi.yml` fires on the `release: published` event, which
GitHub fires for **every** release in the repo regardless of tag
prefix. When we cut the `mcp-v0.1.0` release for `forkd-mcp`, this
workflow tried to publish the `forkd` SDK with tag `mcp-v0.1.0` and
failed the version-match check.

Adds a job-level `if:` that skips release-event runs whose tag
doesn't start with `v`. Manual `workflow_dispatch` still works
unconditionally for backfill / re-runs.

### `chore`: ignore `notes/`

Adds `/notes/` to `.gitignore` for private working memos (paper
drafts, bench scratch, internal docs). Backed up out-of-band, not in
the public repo.

## Test plan

- [x] publish-pypi.yml passes `actionlint` / GitHub Actions parser
- [x] The `if:` condition guards both event types:
      `workflow_dispatch` still runs (manual trigger preserved);
      `release` runs only when `tag_name` starts with `v`.
- [x] `git check-ignore -v notes/...` reports `notes/` is ignored
- [x] No existing tracked files are affected by the ignore rule
