### PR TITLE
fix(packaging/k8s): make starter manifest actually applyable end-to-end

### DIFF
--- a/packaging/k8s/README.md
+++ b/packaging/k8s/README.md
@@ -2,6 +2,14 @@
 
 A starter manifest for running forkd-controller as a Pod.
 
+> **Status: API surface verified end-to-end.** Deployed `forkd-controller`
+> on a single-node **k3s v1.35** cluster on bare-metal Ubuntu 24.04 /
+> Linux 6.14 / KVM; pod reaches `Running`, `/healthz` returns 200,
+> bearer-token auth works against `/version` / `/v1/snapshots` /
+> `/v1/sandboxes` / `/metrics`. Actually forking VMs from inside the
+> pod also requires a kernel image + parent rootfs reachable on the
+> node — see the [Quick start](#quick-start) for that.
+
 The model is **one controller Pod hosts N sandbox children** — the K8s
 scheduler runs once at Pod creation regardless of fan-out, unlike
 Kata / Cube / Firecracker-on-K8s designs that schedule one Pod per

--- a/packaging/k8s/forkd-controller.yaml
+++ b/packaging/k8s/forkd-controller.yaml
@@ -74,19 +74,28 @@ spec:
         - name: forkd-controller
           image: ghcr.io/deeplethe/forkd-controller:latest
           imagePullPolicy: IfNotPresent
+          # Dockerfile ENTRYPOINT already supplies `forkd-controller serve`,
+          # so args here are appended after `serve`.
           args:
             - --bind=0.0.0.0:8889
-            - --state-dir=/var/lib/forkd
+            - --state=/var/lib/forkd/state.json
+            - --snapshot-root=/var/lib/forkd/snapshots
+            - --audit-log=/var/lib/forkd/audit.log
             - --token-file=/etc/forkd/token
-            - --audit-log=/var/lib/forkd/audit.jsonl
           ports:
             - name: api
               containerPort: 8889
               protocol: TCP
           securityContext:
-            # Simplest path: privileged. For tighter security, drop
-            # privileged and use a KVM device plugin + explicit caps.
+            # Simplest path: privileged + root. For tighter security,
+            # drop privileged, use a KVM device plugin, set fsGroup to
+            # the non-root forkd GID baked into the image, and use
+            # explicit caps. The Dockerfile creates a non-root `forkd`
+            # user; running as root here lets us read the mode-0400
+            # bearer-token secret without configuring fsGroup, and is
+            # consistent with the privileged + CAP_NET_ADMIN model.
             privileged: true
+            runAsUser: 0
             capabilities:
               add:
                 - NET_ADMIN


### PR DESCRIPTION
Real k3s deployment surfaced two bugs (wrong CLI flag, secret unreadable as non-root). Both fixed; the API surface now verifies end-to-end (/healthz, /version, /v1/snapshots, /v1/sandboxes, /metrics with bearer-token auth) on k3s v1.35 single-node.

See commit message for full details + verification trail.