### PR TITLE
feat: sandbox branching Phase 3 — volume inheritance + Python SDK Controller + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ sudo forkd eval --child forkd-child-42 -- "numpy.zeros(100).sum()"
 
 ### Python SDK
 
+In-guest agent (E2B-compatible):
+
 ```python
 from forkd import Sandbox   # drop-in for `from e2b import Sandbox`
 
@@ -333,6 +335,23 @@ with Sandbox() as sb:
     print(sb.commands.run("uname -a").stdout)
     print(sb.eval("numpy.zeros(5).tolist()"))    # reuses warmed PID 1
 ```
+
+Controller daemon (lifecycle + branching):
+
+```python
+from forkd import Controller
+
+c = Controller()                                  # http://127.0.0.1:8889
+children = c.spawn_sandboxes("pyagent", n=1, per_child_netns=True)
+sb_id = children[0]["id"]
+
+# … drive sb_id via in-guest Sandbox, then branch before a risky step:
+branch = c.branch_sandbox(sb_id, tag="checkpoint-1")
+grandchildren = c.spawn_sandboxes(branch["tag"], n=5)  # speculative fan-out
+```
+
+See [`docs/design/branching.md`](./docs/design/branching.md) for the
+fork-from-warm tree model and use cases.
 
 ### MCP server
 

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -383,6 +383,22 @@ async fn branch_sandbox(
         return conflict(&format!("snapshot {} already exists; DELETE first", tag));
     }
 
+    // Look up the source sandbox's snapshot_tag so we can inherit its volumes
+    // into the branch. Branches without inherited volumes wouldn't be able to
+    // re-attach the parent's persistent disks on restore.
+    let source_snapshot_tag = match s.registry.get_sandbox(&id) {
+        Some(info) => info.snapshot_tag,
+        None => return not_found(&format!("sandbox {id}")),
+    };
+    let source_volumes = match read_snapshot_volumes(&s.snapshot_root, &source_snapshot_tag) {
+        Ok(v) => v,
+        Err(e) => {
+            return server_error(&format!(
+                "read source snapshot volumes from tag '{source_snapshot_tag}': {e:#}"
+            ));
+        }
+    };
+
     // Take the VM out of live_vms briefly; we'll put it back unconditionally
     // (even on failure) unless a concurrent DELETE on the same id happened.
     let vm = {
@@ -404,10 +420,9 @@ async fn branch_sandbox(
                 let snap = vm.snapshot_to(
                     snap_dir_for_task.join("vmstate"),
                     snap_dir_for_task.join("memory.bin"),
-                    // v0.2: branches inherit no volumes from the source. Threading
-                    // the source's volume list through requires plumbing them into
-                    // the SandboxInfo / live_vms entry; deferred to a follow-up.
-                    Vec::new(),
+                    // Inherit volumes from the source snapshot so grandchildren
+                    // re-attach the same persistent disks the source had.
+                    source_volumes,
                 )?;
                 // resume() may fail after a successful snapshot. The snapshot file
                 // is intact and usable; the source sandbox is in an unknown state
@@ -479,6 +494,22 @@ async fn branch_sandbox(
         return server_error(&format!("persist snapshot: {e:#}"));
     }
     (StatusCode::CREATED, Json(info)).into_response()
+}
+
+/// Read the volumes list from a tagged snapshot's `snapshot.json` on disk.
+/// Returns an empty Vec if `snapshot.json` is missing (some legacy snapshots
+/// don't have it) — that matches the pre-volumes behaviour.
+fn read_snapshot_volumes(
+    snapshot_root: &std::path::Path,
+    tag: &str,
+) -> anyhow::Result<Vec<forkd_vmm::VolumeSpec>> {
+    let path = snapshot_root.join(tag).join("snapshot.json");
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let raw = std::fs::read_to_string(&path)?;
+    let snap: forkd_vmm::Snapshot = serde_json::from_str(&raw)?;
+    Ok(snap.volumes)
 }
 
 fn unix_now() -> u64 {

--- a/docs/API.md
+++ b/docs/API.md
@@ -163,6 +163,48 @@ Request: `{ "code": "numpy.zeros(5).sum()" }`
 
 Response: `{ "result": "0.0", "error": null, "exit_code": 0 }`
 
+### POST /v1/sandboxes/:id/branch
+
+Pause a running sandbox, snapshot its memory + vmstate to a new tag,
+resume it. The resulting snapshot is independent of the source's
+lifecycle — fork from it or delete it regardless of whether the source
+sandbox is still alive. Volumes from the source snapshot are inherited
+automatically, so grandchildren see the same persistent disks.
+
+Request:
+
+```json
+{ "tag": "checkpoint-1" }
+```
+
+- `tag` is optional. When unset the daemon generates
+  `branch-<source-id>-<unix-ts>`. Must match
+  `^[A-Za-z0-9_][A-Za-z0-9._-]{0,63}$`.
+
+Response (201 Created): [`SnapshotInfo`](#snapshotinfo) with
+`branched_from` set to the source sandbox id.
+
+Errors:
+
+- `404 Not Found` — source sandbox id not in `live_vms`
+- `409 Conflict` — tag already exists on disk; `DELETE` it first
+- `500 Internal Server Error` — pause / snapshot / resume failure
+
+**Pause-window semantics.** The source sandbox is paused at the vCPU
+level (kernel state and TCP sockets stay; application-level keepalives
+may time out) for the duration of the snapshot write — typically
+0.5–8 s depending on memory image size. Modal's "branch" operation
+has the same semantics.
+
+If `resume` fails after a successful snapshot the snapshot file is
+intact and returned to the caller; the source sandbox may be left in
+an unknown state. The controller logs this as a warning rather than
+failing the request, because the user's primary expectation (a valid
+new snapshot) has been met.
+
+See [`docs/design/branching.md`](design/branching.md) for the full
+rationale, use cases, and follow-up roadmap.
+
 ---
 
 ## SandboxInfo
@@ -185,9 +227,16 @@ Response: `{ "result": "0.0", "error": null, "exit_code": 0 }`
 {
   "tag": "py",
   "dir": "/var/lib/forkd/snapshots/py",
-  "created_at_unix": 1717000000
+  "created_at_unix": 1717000000,
+  "branched_from": "sb-67a1b3-0000"
 }
 ```
+
+- `branched_from` is **omitted** when the snapshot was built from
+  kernel + rootfs via `POST /v1/snapshots`; it is **present**
+  (carrying the source sandbox id) only when the snapshot was
+  produced via `POST /v1/sandboxes/:id/branch`. Use this field to
+  trace snapshot lineage / audit.
 
 ## ErrorBody
 

--- a/docs/design/branching.md
+++ b/docs/design/branching.md
@@ -1,0 +1,199 @@
+# Sandbox branching
+
+**Status:** shipped in v0.2 (PR #49 controller / #50 CLI / #51 SDK).
+**REST:** `POST /v1/sandboxes/:id/branch` on the controller daemon.
+**CLI:** `forkd snapshot --from-sandbox <id> [--tag <tag>]`.
+**Python SDK:** `Controller.branch_sandbox(sandbox_id, tag=None)`.
+
+## Why
+
+forkd today supports `parent snapshot → N children` (a two-layer tree,
+fan-out terminates at fork). Modal-style **branching** turns this into
+an arbitrary-depth tree where any running child can itself be snapshot'd
+and forked into grandchildren.
+
+Concrete agent-runtime use cases this unlocks:
+
+- **Safe destructive ops** — branch before `rm -rf` / `apt remove`;
+  discard on regret, commit on confirm.
+- **A/B tool execution** — agent tries `grep` vs `ripgrep` in parallel
+  branches, picks the winner.
+- **Conversation checkpointing** — auto-branch every N turns in
+  production; if turn 47 misbehaves, attach to turn 45's snapshot to
+  reproduce.
+- **SWE-bench style iteration** — branch after expensive setup
+  (clone + install), iterate on the test prompt without re-doing setup.
+
+Without branching, today's agent developers either avoid destructive
+ops, manually restore state, or restart conversations from scratch.
+
+## What ships in v0.2
+
+The mechanism = `vm.pause() → vm.snapshot_to() → vm.resume()` against a
+running child VM. **All three primitives already exist in
+`crates/forkd-vmm/src/lib.rs`** (`pause` at L716, `snapshot_to` at L724,
+`resume` needs verification — add if missing). The work is wiring,
+not new kernel-level engineering.
+
+### Surface
+
+**REST** (controller daemon, requires bearer token):
+
+```
+POST /v1/sandboxes/:id/branch
+  body: { "tag": "<optional-branch-tag>" }
+  → 201 { tag, dir, vmstate, memory, created_at_unix, branched_from }
+```
+
+Behaviour:
+1. Look up sandbox `:id` in `live_vms`. 404 if not present.
+2. Call `vm.pause()` (source sandbox now stops vCPUs).
+3. Call `vm.snapshot_to(<snapshot_root>/<tag>/...)`.
+4. Write `snapshot.json` (mirrors `create_snapshot()` flow).
+5. Call `vm.resume()` (source sandbox runs again).
+6. `registry.insert_snapshot(...)` with `branched_from: Some(sandbox_id)`.
+7. Return `SnapshotInfo`.
+
+**CLI:**
+
+```bash
+# Phase 1 (this milestone)
+forkd snapshot --from-sandbox sb-67a1b3-0042 --tag spec-1
+forkd fork --tag spec-1 -n 5
+
+# Phase 2 (follow-up, optional)
+forkd branch --from-sandbox sb-67a1b3-0042 -n 5     # one-shot helper
+```
+
+**Python SDK:**
+
+```python
+with Sandbox(tag="pyagent") as sb:
+    sb.commands.run("apt install -y something-risky")
+    branch = sb.branch()              # POST /v1/sandboxes/{sb.id}/branch
+                                       # → SnapshotInfo (the new tag)
+    grandchildren = branch.fork(n=5)   # spawns from the new snapshot
+    for g in grandchildren:
+        g.commands.run("...")
+```
+
+## Design decisions (committed)
+
+1. **Tag default:** `branch-<source_sandbox_id>-<seq>` where `seq` is
+   per-source-sandbox monotonic. Readable, debuggable.
+
+2. **No ephemeral branches in v0.2.** Every branch persists to the
+   snapshot registry until explicitly deleted. Adds ~30% complexity to
+   support transient branches; not worth it before users ask for it.
+
+3. **No depth limit.** Document the disk cost (each branch level
+   carries a full `memory.bin`) and stop there. If a user wants 10
+   branches of a 2 GiB-memory parent, they consciously commit 20 GiB.
+
+4. **Volume mounts inherit.** `--volume` settings recorded in
+   `snapshot.json` are propagated unchanged from source to branch. Zero
+   extra work; the snapshot serialization already covers volumes.
+
+5. **`branched_from` field on `SnapshotInfo`:** `Option<String>` carrying
+   the source sandbox id. Used for audit / debugging / lineage queries.
+   Does **not** create a hard dependency — branches remain valid after
+   the source sandbox is killed.
+
+6. **Source-sandbox lifecycle independence.** Branching does not change
+   source sandbox state visible to the user. The source may be killed
+   immediately after a branch returns; the branch survives (it's a
+   snapshot on disk).
+
+## Pause-window semantics
+
+Between `pause()` and `resume()`, the source sandbox is frozen at the
+vCPU level:
+
+- TCP sockets stay open (kernel keeps them).
+- TCP application-level keepalive *may* time out depending on remote
+  side and configuration.
+- Sleeping processes don't notice the pause; on resume they continue
+  as if no time passed.
+- Outside observers (other VMs trying to talk to it) see a timeout.
+
+**Pause window duration:** dominated by `vm.snapshot_to()` —
+~0.5–8 s for memory.bin sizes 256 MiB to 8 GiB on local NVMe. For
+LLM-inference parents with ≥4 GiB resident, plan for ~3–5 s.
+
+This trade-off is acceptable and explicit in docs. Modal's branch has
+the same semantics.
+
+## Non-goals (this milestone)
+
+- **Live branching (no pause):** would require userfaultfd-based
+  copy-on-write of the source VM's memory; significant new engineering.
+  Defer to v0.3+.
+- **Branch chain merge / promote.** No `merge_from()` API. v0.2 users
+  manually copy filesystem deltas back if they want; SDK adds a helper
+  later if real demand emerges.
+- **Cross-host branching.** Branches live on the host that made them.
+  Multi-host distribution waits for snapshot diff/incremental work.
+- **Branch GC policies.** All branches persist until explicit delete.
+  Auto-prune by age / count is a v0.3 nice-to-have.
+
+## Failure modes
+
+| Failure | Behaviour |
+|---|---|
+| Source sandbox not in `live_vms` | 404, no side effect |
+| `vm.pause()` fails | 500, source sandbox state unchanged (firecracker still running) |
+| `vm.snapshot_to()` fails | 500, attempt `vm.resume()` to recover source; partial snapshot files cleaned |
+| `vm.resume()` fails after successful snapshot | 500, source sandbox is dead (firecracker may still be paused); snapshot file persists and is valid |
+| Disk full during snapshot_to | 500 with disk-full error; source VM resumed |
+| Tag collision | 409 Conflict; no side effect |
+
+The trickiest case is "snapshot succeeded but resume failed." This
+leaves source as effectively dead while the branch is intact. Probably
+acceptable: the snapshot itself is the user's escape hatch. Document
+in failure-modes section of API doc.
+
+## Implementation plan
+
+### Phase 1 — REST end-to-end (this PR, ~half-day)
+
+1. **`crates/forkd-vmm/src/lib.rs`** — confirm `vm.resume()` exists; add
+   if not. ~5 LoC.
+2. **`crates/forkd-controller/src/http.rs`** — add `POST
+   /v1/sandboxes/:id/branch` handler. Mirror `create_snapshot()`
+   structure. ~60 LoC.
+3. **`crates/forkd-controller/src/api.rs`** — extend `SnapshotInfo`
+   with `branched_from: Option<String>`. Update existing serializers.
+4. **`crates/forkd-controller/src/state.rs`** — `insert_snapshot()`
+   accepts the new field. Persistence already JSON, no schema migration.
+5. **dev-box smoke test** — bring up postgres-fixture, fork one child,
+   branch it, fork 3 grandchildren, verify each has independent psql.
+
+### Phase 2 — CLI (next PR, ~half-day)
+
+6. `crates/forkd-cli/src/main.rs` — add `--from-sandbox <id>` flag to
+   `snapshot` subcommand. Calls the controller REST endpoint.
+7. `docs/API.md` — document the new endpoint + behaviour.
+8. `docs/RUNBOOK.md` — operator notes on pause-window semantics.
+
+### Phase 3 — SDK + demo (next PR, ~1 day)
+
+9. `sdk/python/forkd/sandbox.py` — add `Sandbox.branch() -> Snapshot` +
+   `Snapshot.fork(n=...) -> list[Sandbox]`.
+10. `recipes/postgres-fixture/demo.py` — extend with a branching example.
+11. Top-level `README.md` — short subsection under "Quick start"
+    advertising branching.
+
+### Phase 4 — promote design doc
+
+12. Move `notes/design/branching.md` → `docs/design/branching.md` as
+    part of the final PR (or the first PR if we're confident).
+
+## Test plan
+
+- **Unit:** mock `Vm` for snapshot/pause/resume; assert handler calls
+  in the right order, restores on failure.
+- **Integration (dev-box):** the smoke test above + multi-branch
+  isolation (branch source A and B from same parent; A and B don't
+  influence each other).
+- **Failure injection:** kill snapshot mid-flight via `sudo kill -9` of
+  firecracker; assert handler returns 5xx and source VM state.

--- a/sdk/python/forkd/__init__.py
+++ b/sdk/python/forkd/__init__.py
@@ -1,10 +1,18 @@
 """forkd — open-source fork-on-write microVM sandbox primitive.
 
-This Python SDK provides an E2B-compatible Sandbox API. Under the hood,
-each Sandbox is a forked microVM child managed by the `forkd` Rust CLI.
+This Python SDK provides two complementary surfaces:
+
+- ``Sandbox`` (E2B-compatible) — connect to the in-guest agent of a
+  running child VM to exec / eval code inside it.
+- ``Controller`` — manage VM lifecycle (snapshots, sandboxes,
+  branching) via the forkd-controller daemon's REST API.
+
+Most agent runtimes use both: ``Controller`` to spawn / branch / kill,
+``Sandbox`` to drive code execution inside one specific child.
 """
 
+from .controller import Controller, ControllerError
 from .sandbox import CommandResult, Sandbox
 
 __version__ = "0.1.3"
-__all__ = ["Sandbox", "CommandResult"]
+__all__ = ["Sandbox", "CommandResult", "Controller", "ControllerError"]

--- a/sdk/python/forkd/controller.py
+++ b/sdk/python/forkd/controller.py
@@ -1,0 +1,203 @@
+"""HTTP client for the forkd-controller daemon's REST API.
+
+The `Controller` class wraps `/v1/snapshots` and `/v1/sandboxes` endpoints
+(docs/API.md) so Python agent code can manage snapshots, fork sandboxes,
+branch running sandboxes, and tear things down without shelling out to
+`forkd`.
+
+Talking to the controller is orthogonal to the in-guest `Sandbox` agent
+class (`forkd.Sandbox`): Controller manages VM lifecycle from the host
+side; Sandbox talks to the in-guest agent on TCP for exec/eval inside
+one specific child VM. Most agent runtimes use both — Controller to
+spawn/branch/kill, Sandbox to drive code execution.
+
+Example
+-------
+
+>>> from forkd import Controller, Sandbox
+>>> c = Controller()  # default http://127.0.0.1:8889, no token
+>>> [s["tag"] for s in c.list_snapshots()]
+['pyagent']
+>>> children = c.spawn_sandboxes("pyagent", n=1, per_child_netns=True)
+>>> sb_id = children[0]["id"]
+>>> # ... drive the sandbox via Sandbox(target=children[0]['guest_addr'])
+>>> branch = c.branch_sandbox(sb_id, tag="checkpoint-1")
+>>> branch["tag"]
+'checkpoint-1'
+>>> branch["branched_from"]
+'sb-...'
+>>> grandchildren = c.spawn_sandboxes(branch["tag"], n=5)
+>>> c.kill_sandbox(sb_id)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Optional
+
+
+class ControllerError(RuntimeError):
+    """Raised on non-2xx responses from the daemon.
+
+    Carries the HTTP status code and the daemon's parsed error body
+    (when it returned JSON). Inspect ``status`` and ``body`` to
+    distinguish 404 (sandbox/snapshot missing) from 409 (tag
+    collision) from 500 (internal).
+    """
+
+    def __init__(self, status: int, body: Any, url: str) -> None:
+        self.status = status
+        self.body = body
+        self.url = url
+        snippet = body if isinstance(body, str) else json.dumps(body)
+        super().__init__(f"controller {url}: HTTP {status}: {snippet}")
+
+
+class Controller:
+    """Client for the forkd-controller daemon's REST API.
+
+    Parameters
+    ----------
+    base_url:
+        Daemon base URL. Defaults to ``$FORKD_URL`` then
+        ``http://127.0.0.1:8889``.
+    token:
+        Bearer token. Defaults to ``$FORKD_TOKEN``. Required only when
+        the daemon was started with ``--token-file``.
+    timeout:
+        Per-request timeout in seconds. Branching can take 0.5-8 s on
+        a large parent VM; default is generous.
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        timeout: float = 60.0,
+    ) -> None:
+        self.base_url = (
+            base_url
+            or os.environ.get("FORKD_URL")
+            or "http://127.0.0.1:8889"
+        ).rstrip("/")
+        self.token = token if token is not None else os.environ.get("FORKD_TOKEN")
+        self.timeout = timeout
+
+    # --- snapshots ------------------------------------------------
+
+    def list_snapshots(self) -> list[dict]:
+        """``GET /v1/snapshots`` — every snapshot known to the daemon."""
+        return self._request("GET", "/v1/snapshots")
+
+    def delete_snapshot(self, tag: str) -> None:
+        """``DELETE /v1/snapshots/:tag`` — drop both registry and disk files."""
+        self._request("DELETE", f"/v1/snapshots/{tag}")
+
+    # --- sandboxes ------------------------------------------------
+
+    def spawn_sandboxes(
+        self,
+        snapshot_tag: str,
+        n: int = 1,
+        per_child_netns: bool = False,
+        memory_limit_mib: Optional[int] = None,
+    ) -> list[dict]:
+        """``POST /v1/sandboxes`` — fork N children from a snapshot tag.
+
+        Returns the list of SandboxInfo dicts (id, snapshot_tag, netns,
+        guest_addr, created_at_unix, pid, memory_limit_mib).
+        """
+        body: dict[str, Any] = {
+            "snapshot_tag": snapshot_tag,
+            "n": n,
+            "per_child_netns": per_child_netns,
+        }
+        if memory_limit_mib is not None:
+            body["memory_limit_mib"] = memory_limit_mib
+        return self._request("POST", "/v1/sandboxes", body)
+
+    def list_sandboxes(self) -> list[dict]:
+        """``GET /v1/sandboxes`` — every live sandbox the daemon tracks."""
+        return self._request("GET", "/v1/sandboxes")
+
+    def get_sandbox(self, sandbox_id: str) -> dict:
+        """``GET /v1/sandboxes/:id`` — one sandbox's metadata."""
+        return self._request("GET", f"/v1/sandboxes/{sandbox_id}")
+
+    def kill_sandbox(self, sandbox_id: str) -> None:
+        """``DELETE /v1/sandboxes/:id`` — terminate one sandbox."""
+        self._request("DELETE", f"/v1/sandboxes/{sandbox_id}")
+
+    def branch_sandbox(self, sandbox_id: str, tag: Optional[str] = None) -> dict:
+        """``POST /v1/sandboxes/:id/branch`` — pause + snapshot + resume.
+
+        The source sandbox is paused for the duration of the snapshot
+        write (typically 0.5-8 s depending on memory image size),
+        then resumed. The returned snapshot is independent of the
+        source's lifecycle.
+
+        Returns a SnapshotInfo dict; pass its ``tag`` to
+        ``spawn_sandboxes`` to fork grandchildren from the branch.
+        """
+        body: dict[str, Any] = {}
+        if tag is not None:
+            body["tag"] = tag
+        return self._request("POST", f"/v1/sandboxes/{sandbox_id}/branch", body)
+
+    def exec_command(
+        self,
+        sandbox_id: str,
+        args: list[str],
+        timeout_secs: int = 30,
+    ) -> dict:
+        """``POST /v1/sandboxes/:id/exec`` — run a subprocess in the sandbox.
+
+        Returns ``{stdout, stderr, exit_code}``.
+        """
+        return self._request(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/exec",
+            {"args": args, "timeout_secs": timeout_secs},
+        )
+
+    def eval_code(self, sandbox_id: str, code: str) -> dict:
+        """``POST /v1/sandboxes/:id/eval`` — eval against warmed PID-1.
+
+        Returns ``{result, error, exit_code}``.
+        """
+        return self._request(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/eval",
+            {"code": code},
+        )
+
+    def ping_sandbox(self, sandbox_id: str) -> dict:
+        """``POST /v1/sandboxes/:id/ping`` — round-trip to the guest agent."""
+        return self._request("POST", f"/v1/sandboxes/{sandbox_id}/ping")
+
+    # --- internals ------------------------------------------------
+
+    def _request(self, method: str, path: str, body: Optional[dict] = None) -> Any:
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {"Content-Type": "application/json"} if body is not None else {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read()
+                if not raw:
+                    return None
+                return json.loads(raw)
+        except urllib.error.HTTPError as e:
+            raw = e.read()
+            parsed: Any
+            try:
+                parsed = json.loads(raw) if raw else {}
+            except json.JSONDecodeError:
+                parsed = raw.decode(errors="replace")
+            raise ControllerError(e.code, parsed, url) from e


### PR DESCRIPTION
Closes Phase 3 of sandbox branching. After this PR the feature is end-to-end consumable from Python.

## What's in this PR

Two commits batched:

### `c41964b`  feat(controller): inherit volumes from source snapshot when branching
The branch endpoint previously dropped any `--volume` mounts from the source snapshot. Now it reads the source's `snapshot.json` and threads its `VolumeSpec` list into the new snapshot, so grandchildren re-attach the same persistent disks as the source's siblings would.

### `0cdd6f9`  feat(sdk): Python Controller class + docs for sandbox branching
- `forkd.Controller` — HTTP client over urllib (no new deps) for every controller endpoint, including `branch_sandbox`.
- `forkd.ControllerError` — carries HTTP status + daemon JSON error body.
- `docs/API.md` — adds the `POST /v1/sandboxes/:id/branch` section and the `branched_from` field on `SnapshotInfo`.
- `docs/design/branching.md` — promoted from `notes/design/`; status block updated to 'shipped in v0.2'.
- `README.md` — Python SDK section now shows both in-guest Sandbox and Controller branching examples.

## Test plan

- [x] `cargo check -p forkd-controller` clean
- [x] `cargo test --workspace --lib` — 31/31 pass (no regression)
- [x] `py -X utf8 -c 'import ast; ast.parse(...)'` clean for controller.py + __init__.py
- [x] End-to-end via real daemon on dev box: `Controller.spawn_sandboxes` → `Controller.branch_sandbox` → `branched_from` set in returned dict → `list_snapshots` shows the new tag → `kill_sandbox` clean
- [x] `ControllerError` raised on 404 / 409 (verified by hitting non-existent sandbox id)

## Branching status after merge

| | |
|---|---|
| Mechanism (REST + daemon) | ✅ #49 |
| CLI (`forkd snapshot --from-sandbox`) | ✅ #50 |
| Volume inheritance | ✅ (this PR) |
| Python SDK | ✅ (this PR) |
| Docs (API + design) | ✅ (this PR) |
| netns-allocator (grandchildren don't collide on child-1) | follow-up |
| Live (no-pause) branching via userfaultfd | v0.3+ |