### PR TITLE
feat(daemon): pick non-colliding netns indices when forking

### DIFF
--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -818,6 +818,7 @@ fn run_cmd(
                 n: 1,
                 per_child_netns: false,
                 memory_limit_mib: None,
+                netns_offset: 0,
             },
             &work_dir,
         )
@@ -1256,6 +1257,10 @@ fn fork_cmd(
                 n,
                 per_child_netns,
                 memory_limit_mib,
+                // CLI `forkd fork` is one-shot: it always allocates starting
+                // from forkd-child-1. The daemon path picks a non-colliding
+                // offset based on live state; the CLI doesn't have that view.
+                netns_offset: 0,
             },
             &work_dir,
         )

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -287,12 +287,23 @@ async fn create_sandbox(
     };
 
     let tag = req.snapshot_tag.clone();
+    // Compute netns offset so we don't collide with other live sandboxes'
+    // forkd-child-N indices. When per_child_netns is false this is a no-op.
+    let netns_offset = if req.per_child_netns {
+        pick_netns_offset(&s.live_vms.lock(), req.n)
+    } else {
+        0
+    };
     let opts = forkd_vmm::ForkOpts {
         n: req.n,
         per_child_netns: req.per_child_netns,
         memory_limit_mib: req.memory_limit_mib,
+        netns_offset,
     };
-    let work_dir = std::env::temp_dir().join(format!("forkd-daemon-{tag}"));
+    // Per-snapshot-tag work_dir would clash if two batches of the same tag
+    // ran concurrently (e.g. two branches of the same source). Mix the
+    // netns offset in so concurrent batches get distinct work_dirs.
+    let work_dir = std::env::temp_dir().join(format!("forkd-daemon-{tag}-o{netns_offset}"));
 
     // restore_many_with is sync + blocking (spawns N firecracker procs,
     // waits on their unix sockets, fires N parallel restore PUTs). Run it
@@ -494,6 +505,38 @@ async fn branch_sandbox(
         return server_error(&format!("persist snapshot: {e:#}"));
     }
     (StatusCode::CREATED, Json(info)).into_response()
+}
+
+/// Pick the smallest `netns_offset` such that
+/// `[offset+1 .. offset+n+1]` is disjoint from every `forkd-child-K`
+/// already registered in `live_vms`. Used to keep `POST /v1/sandboxes`
+/// batches from clashing on netns indices (the original allocator
+/// always started at 1, so a fork after a previous fork landed on
+/// `forkd-child-1` again).
+///
+/// Off-by-one note: indices are 1-based on the wire (`forkd-child-1`,
+/// not `forkd-child-0`); `netns_offset` is the *additive* offset
+/// applied before the within-batch 1..=n loop in `restore_many_with`.
+fn pick_netns_offset(live_vms: &HashMap<String, forkd_vmm::Vm>, n: usize) -> usize {
+    let used: std::collections::HashSet<usize> = live_vms
+        .values()
+        .filter_map(|vm| vm.netns.as_ref())
+        .filter_map(|s| s.strip_prefix("forkd-child-")?.parse::<usize>().ok())
+        .collect();
+    if used.is_empty() {
+        return 0;
+    }
+    // Try offsets 0, 1, 2, … until [offset+1..offset+n+1] is disjoint.
+    let mut offset = 0usize;
+    loop {
+        let range_start = offset + 1;
+        let range_end = offset + n + 1;
+        let clash = (range_start..range_end).any(|i| used.contains(&i));
+        if !clash {
+            return offset;
+        }
+        offset += 1;
+    }
 }
 
 /// Read the volumes list from a tagged snapshot's `snapshot.json` on disk.

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -255,6 +255,13 @@ pub struct ForkOpts {
     /// leaf with `memory.max` set to this many MiB. Requires cgroup v2
     /// unified hierarchy and root (or a delegated cgroup). See `cgroup.rs`.
     pub memory_limit_mib: Option<u64>,
+    /// Offset added to the per-child netns / cgroup index. Default 0
+    /// produces the historical `forkd-child-1..N` naming. Set to >0 when
+    /// other sandboxes already occupy lower indices (e.g. branching: the
+    /// source sandbox holds `forkd-child-1`, grandchildren start higher).
+    /// Index zero is never assigned — the first index is always
+    /// `netns_offset + 1`.
+    pub netns_offset: usize,
 }
 
 impl Default for ForkOpts {
@@ -263,6 +270,7 @@ impl Default for ForkOpts {
             n: 1,
             per_child_netns: false,
             memory_limit_mib: None,
+            netns_offset: 0,
         }
     }
 }
@@ -801,6 +809,7 @@ impl Snapshot {
                 n,
                 per_child_netns: false,
                 memory_limit_mib: None,
+                netns_offset: 0,
             },
             work_dir,
         )
@@ -825,12 +834,16 @@ impl Snapshot {
         let spawn_start = Instant::now();
         let mut children: Vec<Vm> = Vec::with_capacity(n);
         for i in 1..=n {
+            // Per-child files use the within-batch index (1..=n) so work_dir
+            // layout is predictable. Netns / cgroup index applies the offset
+            // so multiple batches can coexist on one host (branching case).
+            let global_idx = opts.netns_offset + i;
             let sock = work_dir.join(format!("child-{i}.sock"));
             let console = work_dir.join(format!("child-{i}.console"));
-            // If per-child netns mode, look for forkd-child-<i> (provisioned
-            // by scripts/netns-setup.sh ahead of time).
+            // If per-child netns mode, look for forkd-child-<global_idx>
+            // (provisioned by scripts/netns-setup.sh ahead of time).
             let netns = if opts.per_child_netns {
-                Some(format!("forkd-child-{i}"))
+                Some(format!("forkd-child-{global_idx}"))
             } else {
                 None
             };
@@ -856,7 +869,10 @@ impl Snapshot {
         if let Some(mib) = opts.memory_limit_mib {
             let bytes = cgroup::mib_to_bytes(mib);
             for (i, child) in children.iter_mut().enumerate() {
-                let name = format!("child-{}", i + 1);
+                // Cgroup leaf name tracks the global netns index so per-child
+                // resource limits don't collide with siblings created by other
+                // batches on the same host.
+                let name = format!("child-{}", opts.netns_offset + i + 1);
                 match cgroup::place_child(&name, child.pid, bytes) {
                     Ok(path) => {
                         tracing::debug!(name=%name, pid=child.pid, mib, "cgroup placed");


### PR DESCRIPTION
Closes the 'grandchildren collide with source on forkd-child-1' limit surfaced during PR #49 E2E.

The daemon scans `live_vms` for in-use `forkd-child-N` indices and picks the smallest `netns_offset` such that `[offset+1 .. offset+n+1]` is free, then threads it through `ForkOpts` into the VMM's per-child netns naming.

## Before / after

```
Before:  source @ forkd-child-1
         fork n=2 from branch → tries forkd-child-1 again → fails
         ("tap device forkd-tap0 already in use")

After:   source @ forkd-child-1
         fork n=2 from branch → forkd-child-2 + forkd-child-3 ✓
```

## API change

`forkd_vmm::ForkOpts` gains `netns_offset: usize` (default 0, backward-compatible). CLI continues to pass 0; daemon computes it.

Work_dir now includes the offset (`forkd-daemon-<tag>-o<offset>`) so concurrent batches of the same tag don't share unix-socket paths.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --lib` — 31/31 pass
- [x] E2E on dev-box: spawn source (→ forkd-child-1), branch, fork n=2 from branch (→ forkd-child-2 + forkd-child-3 ✓), cleanup

The remaining pause-window note in [`docs/design/branching.md`](./docs/design/branching.md) is now the only trade-off left in the branching primitive.