### PR TITLE
security: validate snapshot_tag + token guards (#54 → main)

### DIFF
--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -130,6 +130,13 @@ async fn create_snapshot(
         return bad_request(&format!("rootfs not found: {}", rootfs.display()));
     }
 
+    // Cap boot_wait_secs so a hostile caller can't tie up a daemon worker
+    // for u64::MAX seconds. 60 s is well above the largest measured boot
+    // time in our recipes (postgres-fixture warms up in ~10 s).
+    if req.boot_wait_secs > 60 {
+        return bad_request("boot_wait_secs must be ≤ 60");
+    }
+
     let snap_dir = s.snapshot_root.join(&req.tag);
     if snap_dir.join("vmstate").exists() {
         return bad_request(&format!(
@@ -256,6 +263,15 @@ async fn create_sandbox(
     }
     if req.n > 1000 {
         return bad_request("n must be ≤ 1000 (sanity cap)");
+    }
+    // Validate snapshot_tag BEFORE any filesystem op. Without this, a tag
+    // like `../../etc` makes `snapshot_root.join(tag)` traverse outside
+    // snapshot_root (Rust's Path::join doesn't normalise `..`), and the
+    // unvalidated tag would also persist into SandboxInfo.snapshot_tag,
+    // later feeding `read_snapshot_volumes` and letting an attacker pick
+    // the JSON file the daemon parses for grandchild volume specs.
+    if !is_safe_tag(&req.snapshot_tag) {
+        return bad_request("snapshot_tag must be 1-64 chars, ASCII alnum or dash/underscore");
     }
 
     // Snapshot can come either from the daemon's registry (created via
@@ -546,6 +562,13 @@ fn read_snapshot_volumes(
     snapshot_root: &std::path::Path,
     tag: &str,
 ) -> anyhow::Result<Vec<forkd_vmm::VolumeSpec>> {
+    // Defense in depth: every caller is expected to have validated `tag` via
+    // `is_safe_tag` before persisting it, but if a future caller forgets, or
+    // a registry row gets reconstructed from an older state.json written
+    // before tag validation existed, refuse to dereference the join.
+    if !is_safe_tag(tag) {
+        anyhow::bail!("refusing to read snapshot with unsafe tag (defense in depth)");
+    }
     let path = snapshot_root.join(tag).join("snapshot.json");
     if !path.exists() {
         return Ok(Vec::new());
@@ -869,6 +892,74 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn create_sandbox_rejects_unsafe_snapshot_tag_traversal() {
+        // Regression: `create_sandbox` previously skipped `is_safe_tag` on the
+        // request body's `snapshot_tag`. A traversing value like
+        // `../../etc/passwd` would fall through to the disk-fallback branch
+        // where `snapshot_root.join(tag)` produces a path that std::fs syscalls
+        // resolve outside snapshot_root. The 404-from-vmstate-existence-check
+        // partially limited impact, but the unvalidated tag also got persisted
+        // into SandboxInfo.snapshot_tag and later flowed into
+        // `read_snapshot_volumes`, where it would parse attacker-chosen JSON
+        // files as forkd_vmm::Snapshot and inherit their volumes into branches.
+        //
+        // Expect 400 (input validation), not 404 (file-existence oracle).
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sandboxes")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"snapshot_tag":"../../etc/passwd","n":1}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_rejects_boot_wait_over_cap() {
+        // Regression: `boot_wait_secs` was untyped u64 with no cap, so a
+        // hostile caller could pass u64::MAX to tie up a daemon worker.
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/snapshots")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"tag":"ok","kernel":"/dev/null","rootfs":"/dev/null","boot_wait_secs":999999}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn create_sandbox_rejects_unsafe_snapshot_tag_chars() {
+        // Defense in depth: also reject tags containing characters that aren't
+        // ASCII alnum / dash / underscore (matches `is_safe_tag`'s contract).
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sandboxes")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"snapshot_tag":"tag with space","n":1}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/crates/forkd-controller/src/lib.rs
+++ b/crates/forkd-controller/src/lib.rs
@@ -79,9 +79,7 @@ pub async fn run_daemon(cfg: DaemonConfig) -> Result<()> {
             let raw = std::fs::read_to_string(p)
                 .with_context(|| format!("read token file {}", p.display()))?;
             let tok = raw.trim().to_string();
-            if tok.is_empty() {
-                anyhow::bail!("token file {} is empty", p.display());
-            }
+            validate_token(&tok).with_context(|| format!("validate token from {}", p.display()))?;
             tracing::info!(token_file = %p.display(), "bearer-token auth enabled");
             AuthConfig::with_token(tok)
         }
@@ -184,4 +182,71 @@ fn spawn_shutdown_signal(handle: Handle) {
         }
         handle.graceful_shutdown(Some(Duration::from_secs(30)));
     });
+}
+
+/// Reject tokens that are empty, obvious placeholders, or below a minimum
+/// entropy budget. Pure function so it's exercised by unit tests without
+/// having to spin up the daemon.
+fn validate_token(tok: &str) -> Result<()> {
+    if tok.is_empty() {
+        anyhow::bail!("token is empty");
+    }
+    // Reject the literal placeholder shipped in packaging/k8s/. A user who
+    // runs `kubectl apply -f` without first running the documented
+    // `sed`/Secret-replacement step would otherwise get a daemon protected
+    // only by a publicly-known bearer token.
+    if tok.starts_with("REPLACE_ME") || tok.starts_with("CHANGE_ME") {
+        anyhow::bail!(
+            "token still contains the manifest placeholder ({tok}); \
+             replace it with a real 32-byte secret before starting the daemon"
+        );
+    }
+    // Reject suspiciously short tokens — sufficient entropy is the user's
+    // responsibility, but anything under 16 bytes is almost certainly a
+    // copy-paste mistake rather than a deliberate choice.
+    if tok.len() < 16 {
+        anyhow::bail!(
+            "token is only {} bytes; use at least 16 bytes of high-entropy randomness",
+            tok.len()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_token;
+
+    #[test]
+    fn rejects_empty_token() {
+        assert!(validate_token("").is_err());
+    }
+
+    #[test]
+    fn rejects_replace_me_placeholder() {
+        // Regression: this exact string is shipped in packaging/k8s/
+        // forkd-controller.yaml.
+        let err =
+            validate_token("REPLACE_ME_WITH_32_BYTES_BASE64").expect_err("placeholder accepted");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("placeholder"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn rejects_change_me_variant() {
+        assert!(validate_token("CHANGE_ME_PLEASE").is_err());
+    }
+
+    #[test]
+    fn rejects_too_short_token() {
+        assert!(validate_token("short").is_err());
+        // 15 bytes is one under the cap.
+        assert!(validate_token("123456789012345").is_err());
+    }
+
+    #[test]
+    fn accepts_realistic_token() {
+        // 32 hex chars = 16 bytes of entropy if random.
+        assert!(validate_token("a1b2c3d4e5f60718293a4b5c6d7e8f90").is_ok());
+    }
 }

--- a/crates/forkd-controller/tests/http_integration.rs
+++ b/crates/forkd-controller/tests/http_integration.rs
@@ -138,7 +138,7 @@ async fn end_to_end_version_round_trips() {
 
 #[tokio::test]
 async fn end_to_end_auth_rejects_missing_token() {
-    let d = TestDaemon::start_with_token("s3cret").await;
+    let d = TestDaemon::start_with_token("s3cret-test-token-1234567890").await;
     // /healthz is intentionally exempt — load balancers must probe.
     let h = reqwest::get(format!("{}/healthz", d.base)).await.unwrap();
     assert_eq!(h.status(), 200);
@@ -149,11 +149,11 @@ async fn end_to_end_auth_rejects_missing_token() {
 
 #[tokio::test]
 async fn end_to_end_auth_accepts_valid_token() {
-    let d = TestDaemon::start_with_token("s3cret").await;
+    let d = TestDaemon::start_with_token("s3cret-test-token-1234567890").await;
     let client = reqwest::Client::new();
     let resp = client
         .get(format!("{}/version", d.base))
-        .bearer_auth("s3cret")
+        .bearer_auth("s3cret-test-token-1234567890")
         .send()
         .await
         .unwrap();

--- a/packaging/k8s/forkd-controller.yaml
+++ b/packaging/k8s/forkd-controller.yaml
@@ -44,6 +44,10 @@ type: Opaque
 stringData:
   # Replace with `head -c 32 /dev/urandom | base64`. The controller
   # reads /etc/forkd/token; clients pass it as `Authorization: Bearer`.
+  # The daemon REFUSES to start if this value is left at the literal
+  # placeholder (any string beginning with "REPLACE_ME" or "CHANGE_ME"
+  # is rejected at startup) — so forgetting this step is a noisy fail,
+  # not a silent compromise.
   token: REPLACE_ME_WITH_32_BYTES_BASE64
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Promote #54 from dev to main.

## Summary
- HIGH (post-auth): path traversal in `POST /v1/sandboxes` via unvalidated `req.snapshot_tag`
- HIGH: K8s manifest placeholder bearer token (`REPLACE_ME_*`) now refused at daemon startup
- LOW: `boot_wait_secs` capped at 60s (was uncapped u64)

Bug was reproduced via failing tests (commit 424e4a7) before the fix landed — public CI log: https://github.com/deeplethe/forkd/actions/runs/25987955183

## Test plan
- [x] All controller + integration tests pass on dev
- [ ] CI green on this PR