### PR TITLE
bench: pause-window harness + pause_ms instrumentation (#58 → main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,23 @@ jobs:
         run: cargo build --all
       - name: cargo test
         run: cargo test --all
+
+  bench-python:
+    # Pure-stdlib Python tests for bench/pause-window/. No firecracker
+    # or daemon needed — the analyzer runs on synthetic event lists.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: analyze.py unit tests
+        working-directory: bench/pause-window
+        run: python -m unittest test_analyze.py -v
+      - name: agent / echo_server syntax
+        working-directory: bench/pause-window
+        run: |
+          python -m py_compile agent.py
+          python -m py_compile echo_server.py
+      - name: run.sh shellcheck-style parse
+        run: bash -n bench/pause-window/run.sh

--- a/bench/pause-window/README.md
+++ b/bench/pause-window/README.md
@@ -1,0 +1,130 @@
+# Pause-window benchmark
+
+How long does the BRANCH pause window actually hurt? The
+[v0.3 userfaultfd bet](../../docs/ROADMAP.md) commits 4–6 weeks of
+engineering to shrink it. This benchmark is the **problem
+statement**: it quantifies what application-level damage a 0.5–8 s
+pause does to a running agent. Without this number the userfaultfd
+work has no justification; with this number it has a paper §2.
+
+## What it measures
+
+A pretend-agent inside the source sandbox holds an open TCP
+connection to a host-side echo server and sends a timestamped
+16-byte frame every `--interval-ms` (default 100 ms). Mid-run, the
+orchestrator calls `POST /v1/sandboxes/:id/branch`, which pauses
+the source for the duration of the snapshot. The agent keeps
+logging every send / recv / timeout to JSONL.
+
+We then compute, per trial:
+
+| Metric | What it tells us |
+|---|---|
+| Daemon-reported `pause_ms` | Ground truth: `pause() → resume()` envelope on the source VM |
+| App-observed pause | Gap between last pre-pause recv and first post-pause recv |
+| In-flight loss | Pings sent during the pause that never got a response |
+| Connection survived | Did the TCP socket recover, or did the peer / agent give up? |
+| Post-resume RTT p99 | OS retransmit timers / TCP slow-start tail after pause |
+
+The **gap** between daemon-reported and app-observed pause is the
+interesting number — it's the OS retransmit overhead the userfaultfd
+work won't eliminate. If they're nearly equal, the pause-time line
+in our paper *is* the user-visible cost. If they diverge (e.g.,
+app observed 6 s while daemon paused 2 s), we have to explain the
+retransmit-timer story.
+
+## Running one trial
+
+Requires:
+- A forkd-controller running, with `FORKD_URL` + `FORKD_TOKEN` set
+- A snapshot tag with a python3-capable rootfs already built
+  (the `recipes/postgres-fixture/` rootfs works, or any pyagent
+  rootfs from `bench/`)
+- `jq` and `curl` on the host
+
+```bash
+export FORKD_URL=http://127.0.0.1:8889
+export FORKD_TOKEN=$(cat /etc/forkd/token)
+
+# One 60s trial with BRANCH at t=30s
+bench/pause-window/run.sh --snapshot-tag pyagent --duration-s 60 --branch-at-s 30
+```
+
+Output lands in `bench/pause-window/results/<tag>-<unix-ts>/`:
+
+```
+spawn.json     # POST /v1/sandboxes response
+exec.json      # exec output (stdout = agent.jsonl, stderr separate)
+branch.json    # POST /v1/sandboxes/:id/branch response, with pause_ms
+agent.jsonl    # in-sandbox per-frame send/recv events
+server.jsonl   # host-side echo events
+report.json    # parsed metrics
+report.md      # human-readable summary table
+```
+
+`report.md` is what you'd paste into a paper §2 figure caption.
+
+## Sweep across memory sizes (planned)
+
+The pause window scales roughly linearly with the source VM's
+memory image. Run the same trial against rootfses of different
+memory sizes to map the curve:
+
+```bash
+for mem in 256M 1G 2G 8G; do
+  bench/pause-window/run.sh --snapshot-tag "pyagent-$mem" --out "results/$mem/"
+done
+```
+
+A `sweep.py` driver that aggregates the per-trial reports into one
+table is a [v0.3 follow-up](../../docs/ROADMAP.md) — for now the
+single-trial harness is what we need to validate the methodology.
+
+## Two configurations to compare
+
+Run each trial twice with different `--read-timeout-ms`:
+
+| Mode | `--read-timeout-ms` | What it models |
+|---|---|---|
+| Patient agent | 30000 (default) | LLM workflow with long-poll on completions API |
+| Tight agent | 1000 | Agent with sub-second SLAs (real-time streaming, rate-limited) |
+
+The "tight" mode is where the pause window matters most. A 2 s
+pause is tolerable for a patient agent but kills a tight one.
+
+## How the analyzer detects the pause
+
+`analyze.py` doesn't read the daemon log — it works on the agent's
+JSONL alone, to mirror what an external operator could measure.
+
+1. Sort all `recv` events by `t_recv_ms`.
+2. For each adjacent pair, compute the gap in ms.
+3. The largest gap, if it exceeds `BASELINE_MULTIPLIER × interval_ms`
+   (default 3×), is the pause window.
+4. App-observed duration = `gap − interval_ms` (subtracting the
+   one expected gap that always exists between sends).
+5. In-flight loss = sends made between the gap's endpoints that
+   never produced a matching recv (the agent reports these as
+   `timeout` events; we cross-check by `seq` lookup).
+
+Daemon-reported `pause_ms` is passed in separately so the report
+can compare both.
+
+See [`test_analyze.py`](./test_analyze.py) for 14 unit tests
+covering clean runs, paused runs, percentile math, and
+baseline-sensitivity.
+
+## Why not just use `iperf` or `tc netem`?
+
+`iperf` measures throughput; we want round-trip latency tail.
+`tc netem` simulates packet loss / delay but doesn't model the
+specific "OS scheduler suspended, sockets in kernel queue stay
+warm, no app threads to drain them" pattern that BRANCH produces.
+The custom agent + echo server is the smallest faithful model.
+
+## Why not run inside the postgres recipe directly?
+
+We will, in a v0.3 follow-up. For the v0.2-era problem statement
+the synthetic ping/pong is cleaner: one cause of stall, one stream
+of evidence, no postgres-specific quirks (vacuum timing, autovacuum,
+checkpoint flush latency) confusing the picture.

--- a/bench/pause-window/agent.py
+++ b/bench/pause-window/agent.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Pause-window agent — runs INSIDE the source sandbox.
+
+Opens a TCP connection to the host-side echo server, sends a
+timestamped 16-byte frame every PING_INTERVAL_MS, and logs one
+JSON line per round-trip to stdout (the orchestrator captures
+stdout via `forkd-controller exec`).
+
+The script intentionally has zero third-party dependencies so it
+runs on any python:3.12-slim-class rootfs without rebuilding.
+
+JSONL schema (one event per line):
+
+    {"event": "send",    "seq": int, "t_send_ms": int}
+    {"event": "recv",    "seq": int, "t_send_ms": int, "t_recv_ms": int, "rtt_ms": int}
+    {"event": "timeout", "seq": int, "t_send_ms": int}
+    {"event": "error",   "seq": int, "what": str}
+    {"event": "start",   "host": str, "port": int, "interval_ms": int, "duration_s": int}
+    {"event": "stop",    "sent": int, "recv": int, "timeouts": int, "errors": int}
+
+The `recv` event's `rtt_ms` is what the analyzer plots over time.
+Gaps in `recv` events (and matched `timeout` events) are how the
+benchmark detects the BRANCH pause window from the app side.
+"""
+import argparse
+import json
+import socket
+import struct
+import sys
+import time
+from typing import Optional
+
+
+# Frame layout sent on the wire:
+#   [seq: u32 BE][t_send_ms: u64 BE][padding: 4 bytes zero] = 16 bytes
+# The echo server reflects the same 16 bytes verbatim; the agent
+# parses seq + t_send_ms back out to compute RTT.
+FRAME_FMT = "!IQ4s"
+FRAME_SIZE = struct.calcsize(FRAME_FMT)
+assert FRAME_SIZE == 16, FRAME_SIZE
+
+
+def emit(obj: dict) -> None:
+    """Print a JSON event to stdout, flushed."""
+    sys.stdout.write(json.dumps(obj, separators=(",", ":")))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def now_ms() -> int:
+    """Wall-clock ms since the unix epoch. Used end-to-end so the
+    orchestrator can align with daemon-side timestamps."""
+    return int(time.time() * 1000)
+
+
+def run(
+    host: str,
+    port: int,
+    interval_ms: int,
+    duration_s: int,
+    read_timeout_ms: int,
+) -> int:
+    emit(
+        {
+            "event": "start",
+            "host": host,
+            "port": port,
+            "interval_ms": interval_ms,
+            "duration_s": duration_s,
+            "read_timeout_ms": read_timeout_ms,
+        }
+    )
+
+    try:
+        sock = socket.create_connection((host, port), timeout=5.0)
+    except OSError as e:
+        emit({"event": "error", "seq": -1, "what": f"connect: {e}"})
+        return 2
+
+    # TCP_NODELAY so the agent's measurements aren't smeared by
+    # Nagle's algorithm. The frame is 16 bytes — well under MSS,
+    # so without TCP_NODELAY the kernel will buffer it.
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    sock.settimeout(read_timeout_ms / 1000.0)
+
+    deadline = time.monotonic() + duration_s
+    interval = interval_ms / 1000.0
+
+    sent = 0
+    recv = 0
+    timeouts = 0
+    errors = 0
+    seq = 0
+
+    while time.monotonic() < deadline:
+        seq += 1
+        t_send = now_ms()
+        frame = struct.pack(FRAME_FMT, seq & 0xFFFFFFFF, t_send, b"\x00\x00\x00\x00")
+        try:
+            sock.sendall(frame)
+            emit({"event": "send", "seq": seq, "t_send_ms": t_send})
+            sent += 1
+        except OSError as e:
+            errors += 1
+            emit({"event": "error", "seq": seq, "what": f"send: {e}"})
+            break
+
+        # One-shot read of the echo response. We don't pipeline
+        # because that would mask the pause-window stall under
+        # post-resume burst delivery.
+        try:
+            buf = b""
+            while len(buf) < FRAME_SIZE:
+                chunk = sock.recv(FRAME_SIZE - len(buf))
+                if not chunk:
+                    raise OSError("peer closed")
+                buf += chunk
+            t_recv = now_ms()
+            r_seq, r_send_ms, _pad = struct.unpack(FRAME_FMT, buf)
+            if r_seq != seq & 0xFFFFFFFF:
+                # Out-of-order — possible if a stalled response
+                # arrived in the next slot. Log but don't crash.
+                emit(
+                    {
+                        "event": "error",
+                        "seq": seq,
+                        "what": f"seq mismatch: got {r_seq}",
+                    }
+                )
+                errors += 1
+                continue
+            recv += 1
+            emit(
+                {
+                    "event": "recv",
+                    "seq": seq,
+                    "t_send_ms": r_send_ms,
+                    "t_recv_ms": t_recv,
+                    "rtt_ms": t_recv - r_send_ms,
+                }
+            )
+        except socket.timeout:
+            timeouts += 1
+            emit({"event": "timeout", "seq": seq, "t_send_ms": t_send})
+            # Important: continue the loop, don't break. The whole
+            # point of the bench is to see how the agent fares
+            # _through_ a pause.
+        except OSError as e:
+            errors += 1
+            emit({"event": "error", "seq": seq, "what": f"recv: {e}"})
+            # Connection-level failure → stop. This is a data point.
+            break
+
+        # Pace the loop. Slip is okay; we don't try to catch up.
+        time.sleep(interval)
+
+    try:
+        sock.close()
+    except OSError:
+        pass
+
+    emit(
+        {
+            "event": "stop",
+            "sent": sent,
+            "recv": recv,
+            "timeouts": timeouts,
+            "errors": errors,
+        }
+    )
+    return 0
+
+
+def parse_args(argv: Optional[list] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    p.add_argument("--host", required=True, help="Echo server host (reachable from inside the sandbox)")
+    p.add_argument("--port", type=int, required=True, help="Echo server port")
+    p.add_argument(
+        "--interval-ms",
+        type=int,
+        default=100,
+        help="Delay between sends, ms (default 100)",
+    )
+    p.add_argument(
+        "--duration-s",
+        type=int,
+        default=60,
+        help="Total runtime, seconds (default 60)",
+    )
+    p.add_argument(
+        "--read-timeout-ms",
+        type=int,
+        default=30000,
+        help="Per-frame socket read timeout, ms (default 30000 — patient agent)",
+    )
+    return p.parse_args(argv)
+
+
+def main() -> int:
+    args = parse_args()
+    return run(
+        host=args.host,
+        port=args.port,
+        interval_ms=args.interval_ms,
+        duration_s=args.duration_s,
+        read_timeout_ms=args.read_timeout_ms,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/pause-window/analyze.py
+++ b/bench/pause-window/analyze.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Pause-window analyzer — parses the agent + echo-server JSONL logs
+from one trial and emits a summary report.
+
+The core function `analyze()` is a pure function over already-parsed
+event lists so it's testable in isolation (see `test_analyze.py`).
+The CLI shell at the bottom just loads files and prints.
+
+Report shape (JSON):
+
+{
+  "total_duration_ms": int,
+  "sent": int, "recv": int, "timeouts": int, "errors": int,
+  "connection_survived": bool,
+  "pause": {
+    "detected": bool,
+    "app_start_ms": int|null,        // last recv before the gap
+    "app_end_ms":   int|null,        // first recv after the gap
+    "app_duration_ms": int|null,     // gap - baseline_interval
+    "in_flight_lost": int             // pings sent during gap with no recv
+  },
+  "rtt_ms": {
+    "before_p50": float, "before_p99": float,
+    "after_p50":  float, "after_p99":  float,
+    "all_p50":    float, "all_p99":    float
+  },
+  "daemon_pause_ms": int|null        // ground truth from BRANCH response
+}
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+from statistics import median
+from typing import Optional
+
+
+# Two consecutive recvs ~ baseline_interval_ms apart in a healthy stream.
+# A gap > BASELINE_MULTIPLIER * baseline is flagged as a pause.
+BASELINE_MULTIPLIER = 3.0
+
+
+def pct(values, p: float) -> float:
+    """Plain-stdlib percentile, p in [0, 100]. Empty → 0.0."""
+    if not values:
+        return 0.0
+    s = sorted(values)
+    if p <= 0:
+        return float(s[0])
+    if p >= 100:
+        return float(s[-1])
+    # Linear interp, matches numpy.percentile default.
+    idx = (p / 100.0) * (len(s) - 1)
+    lo = int(idx)
+    hi = min(lo + 1, len(s) - 1)
+    frac = idx - lo
+    return float(s[lo] * (1 - frac) + s[hi] * frac)
+
+
+def analyze(
+    agent_events: list,
+    server_events: Optional[list] = None,
+    daemon_pause_ms: Optional[int] = None,
+    baseline_interval_ms: int = 100,
+) -> dict:
+    """Pure-function summary. server_events currently unused but
+    accepted so future analyses (clock-skew estimation, lost-on-
+    server-side counting) can plug in without changing the call
+    site."""
+    _ = server_events  # noqa: reserved for future use
+
+    start = next((e for e in agent_events if e.get("event") == "start"), None)
+    stop = next((e for e in agent_events if e.get("event") == "stop"), None)
+    sends = [e for e in agent_events if e.get("event") == "send"]
+    recvs = [e for e in agent_events if e.get("event") == "recv"]
+    timeouts = [e for e in agent_events if e.get("event") == "timeout"]
+    errors = [e for e in agent_events if e.get("event") == "error"]
+
+    total_duration_ms = 0
+    if sends and recvs:
+        total_duration_ms = max(e["t_recv_ms"] for e in recvs) - min(
+            e["t_send_ms"] for e in sends
+        )
+
+    # Pause detection: find the largest gap between consecutive recv
+    # events. If it exceeds BASELINE_MULTIPLIER × baseline_interval,
+    # call it a pause.
+    pause_app_start = None
+    pause_app_end = None
+    pause_duration = None
+    in_flight_lost = 0
+
+    if len(recvs) >= 2:
+        recvs_sorted = sorted(recvs, key=lambda e: e["t_recv_ms"])
+        gaps = []
+        for a, b in zip(recvs_sorted, recvs_sorted[1:]):
+            gap = b["t_recv_ms"] - a["t_recv_ms"]
+            gaps.append((gap, a, b))
+        gap, a, b = max(gaps, key=lambda x: x[0])
+        threshold = baseline_interval_ms * BASELINE_MULTIPLIER
+        if gap > threshold:
+            pause_app_start = a["t_recv_ms"]
+            pause_app_end = b["t_recv_ms"]
+            pause_duration = max(0, gap - baseline_interval_ms)
+            # Count sends in (pause_start, pause_end) with no
+            # matching recv. Build a recv-seq set for lookup.
+            recv_seqs = {e["seq"] for e in recvs}
+            for s in sends:
+                if pause_app_start < s["t_send_ms"] < pause_app_end:
+                    if s["seq"] not in recv_seqs:
+                        in_flight_lost += 1
+
+    # Connection survived if we got recvs after the pause, OR if
+    # there was no pause at all and the run ended cleanly.
+    connection_survived = False
+    if pause_app_end is not None:
+        post_recvs = [e for e in recvs if e["t_recv_ms"] > pause_app_end]
+        connection_survived = len(post_recvs) > 0
+    elif stop is not None and stop.get("errors", 0) == 0:
+        connection_survived = True
+
+    rtts = [e["rtt_ms"] for e in recvs if "rtt_ms" in e]
+    before = [e["rtt_ms"] for e in recvs if pause_app_start is None or e["t_recv_ms"] <= pause_app_start]
+    after = [e["rtt_ms"] for e in recvs if pause_app_end is not None and e["t_recv_ms"] >= pause_app_end]
+
+    return {
+        "total_duration_ms": int(total_duration_ms),
+        "sent": int(stop["sent"]) if stop else len(sends),
+        "recv": int(stop["recv"]) if stop else len(recvs),
+        "timeouts": int(stop["timeouts"]) if stop else len(timeouts),
+        "errors": int(stop["errors"]) if stop else len(errors),
+        "connection_survived": connection_survived,
+        "pause": {
+            "detected": pause_app_start is not None,
+            "app_start_ms": pause_app_start,
+            "app_end_ms": pause_app_end,
+            "app_duration_ms": pause_duration,
+            "in_flight_lost": in_flight_lost,
+        },
+        "rtt_ms": {
+            "before_p50": round(pct(before, 50), 2),
+            "before_p99": round(pct(before, 99), 2),
+            "after_p50": round(pct(after, 50), 2),
+            "after_p99": round(pct(after, 99), 2),
+            "all_p50": round(pct(rtts, 50), 2),
+            "all_p99": round(pct(rtts, 99), 2),
+        },
+        "daemon_pause_ms": daemon_pause_ms,
+        "_meta": {
+            "baseline_interval_ms": baseline_interval_ms,
+            "baseline_multiplier": BASELINE_MULTIPLIER,
+        },
+    }
+
+
+def load_jsonl(path: Path) -> list:
+    out = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            out.append(json.loads(line))
+    return out
+
+
+def format_md(report: dict) -> str:
+    p = report["pause"]
+    r = report["rtt_ms"]
+    survived = "✅" if report["connection_survived"] else "❌"
+    detected = "yes" if p["detected"] else "no"
+    daemon = f"{report['daemon_pause_ms']} ms" if report["daemon_pause_ms"] is not None else "n/a"
+    app_dur = f"{p['app_duration_ms']} ms" if p["app_duration_ms"] is not None else "n/a"
+
+    return (
+        f"# Pause-window trial report\n\n"
+        f"| Metric | Value |\n"
+        f"|---|---|\n"
+        f"| Sent | {report['sent']} |\n"
+        f"| Received | {report['recv']} |\n"
+        f"| Timeouts | {report['timeouts']} |\n"
+        f"| Errors | {report['errors']} |\n"
+        f"| Connection survived | {survived} |\n"
+        f"| Pause detected | {detected} |\n"
+        f"| Daemon-measured pause | {daemon} |\n"
+        f"| App-observed pause | {app_dur} |\n"
+        f"| In-flight requests lost | {p['in_flight_lost']} |\n"
+        f"| RTT p50 (before pause) | {r['before_p50']} ms |\n"
+        f"| RTT p99 (before pause) | {r['before_p99']} ms |\n"
+        f"| RTT p50 (after pause) | {r['after_p50']} ms |\n"
+        f"| RTT p99 (after pause) | {r['after_p99']} ms |\n"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    p.add_argument("--agent-log", required=True, type=Path)
+    p.add_argument("--server-log", type=Path, default=None)
+    p.add_argument(
+        "--daemon-pause-ms",
+        type=int,
+        default=None,
+        help="Daemon ground-truth pause window from the BRANCH response",
+    )
+    p.add_argument(
+        "--baseline-interval-ms",
+        type=int,
+        default=100,
+        help="Expected interval between recv events (default 100, must match agent --interval-ms)",
+    )
+    p.add_argument("--out-json", type=Path, default=None)
+    p.add_argument("--out-md", type=Path, default=None)
+    args = p.parse_args()
+
+    agent_events = load_jsonl(args.agent_log)
+    server_events = load_jsonl(args.server_log) if args.server_log else None
+    report = analyze(
+        agent_events,
+        server_events,
+        daemon_pause_ms=args.daemon_pause_ms,
+        baseline_interval_ms=args.baseline_interval_ms,
+    )
+
+    if args.out_json:
+        args.out_json.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    if args.out_md:
+        args.out_md.write_text(format_md(report), encoding="utf-8")
+    if not args.out_json and not args.out_md:
+        print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/pause-window/echo_server.py
+++ b/bench/pause-window/echo_server.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Pause-window echo server — runs on the HOST.
+
+TCP server that reflects each 16-byte client frame verbatim. Also
+logs server-side timestamps so we have two independent clocks on
+each round-trip:
+
+    {"event": "accept", "peer": str, "t_ms": int}
+    {"event": "frame",  "peer": str, "seq": int, "t_recv_ms": int, "t_send_ms": int}
+    {"event": "close",  "peer": str, "t_ms": int, "frames": int, "reason": str}
+
+The orchestrator runs this in the background and tail-collects the
+log to disk; the analyzer joins it with the agent log on `seq`.
+
+One-connection-at-a-time is fine for the bench (the agent is the
+sole client) and keeps the server simple. SO_REUSEADDR so quick
+re-runs don't hit `Address in use`.
+"""
+import argparse
+import json
+import socket
+import struct
+import sys
+import threading
+import time
+
+
+FRAME_FMT = "!IQ4s"
+FRAME_SIZE = struct.calcsize(FRAME_FMT)
+
+
+def emit(obj: dict) -> None:
+    sys.stdout.write(json.dumps(obj, separators=(",", ":")))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def handle(conn: socket.socket, peer: str) -> None:
+    conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    emit({"event": "accept", "peer": peer, "t_ms": now_ms()})
+    frames = 0
+    reason = "eof"
+    try:
+        while True:
+            buf = b""
+            while len(buf) < FRAME_SIZE:
+                chunk = conn.recv(FRAME_SIZE - len(buf))
+                if not chunk:
+                    reason = "eof"
+                    raise StopIteration
+                buf += chunk
+            t_recv = now_ms()
+            seq, t_send_ms, _pad = struct.unpack(FRAME_FMT, buf)
+            # Reflect verbatim — the client matches its own
+            # outbound timestamp on the way back.
+            conn.sendall(buf)
+            frames += 1
+            emit(
+                {
+                    "event": "frame",
+                    "peer": peer,
+                    "seq": seq,
+                    "t_recv_ms": t_recv,
+                    "t_send_ms": now_ms(),
+                }
+            )
+    except StopIteration:
+        pass
+    except OSError as e:
+        reason = f"oserror: {e}"
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+        emit({"event": "close", "peer": peer, "t_ms": now_ms(), "frames": frames, "reason": reason})
+
+
+def serve(host: str, port: int, accept_one: bool) -> int:
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        server.bind((host, port))
+    except OSError as e:
+        emit({"event": "error", "what": f"bind {host}:{port}: {e}"})
+        return 2
+    server.listen(4)
+    emit({"event": "listen", "host": host, "port": port})
+
+    try:
+        while True:
+            conn, addr = server.accept()
+            peer = f"{addr[0]}:{addr[1]}"
+            t = threading.Thread(target=handle, args=(conn, peer), daemon=True)
+            t.start()
+            if accept_one:
+                # Wait for the one client to disconnect, then exit
+                # so the orchestrator can collect logs cleanly.
+                t.join()
+                return 0
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        try:
+            server.close()
+        except OSError:
+            pass
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    p.add_argument("--host", default="0.0.0.0", help="Bind host (default 0.0.0.0)")
+    p.add_argument("--port", type=int, default=39999, help="Bind port (default 39999)")
+    p.add_argument(
+        "--accept-one",
+        action="store_true",
+        help="Serve exactly one client connection then exit (used by the bench harness)",
+    )
+    return p.parse_args(argv)
+
+
+def main() -> int:
+    args = parse_args()
+    return serve(args.host, args.port, args.accept_one)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/pause-window/run.sh
+++ b/bench/pause-window/run.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Pause-window benchmark — single-trial orchestrator.
+#
+# Runs ONE trial against a pre-existing forkd-controller daemon
+# and a snapshot tag of your choice. Spins up an echo server on
+# the host, spawns a sandbox from the snapshot, launches the
+# agent inside it via `forkd-controller exec`, triggers BRANCH
+# mid-run, collects logs, and runs the analyzer.
+#
+# Out-of-scope (deliberately):
+#   - Building the rootfs / snapshot. Use the existing
+#     `recipes/postgres-fixture/` or build your own; pass the tag
+#     via --snapshot-tag.
+#   - Multi-trial sweeps across memory sizes. Wrap this script.
+#   - Cross-host coordination. Run on the box where the daemon is.
+#
+# Requires: bash, python3, curl, jq, an authenticated
+# forkd-controller running on $FORKD_URL with bearer $FORKD_TOKEN.
+
+set -euo pipefail
+
+# ---- defaults ---------------------------------------------------------------
+: "${FORKD_URL:=http://127.0.0.1:8889}"
+: "${FORKD_TOKEN:?FORKD_TOKEN must be set (the daemon bearer token)}"
+
+SNAPSHOT_TAG=""
+ECHO_PORT=39999
+INTERVAL_MS=100
+DURATION_S=60
+BRANCH_AT_S=30
+READ_TIMEOUT_MS=30000
+OUT_DIR=""
+PYTHON_BIN="python3"
+ECHO_HOST=""  # auto-detected below
+
+usage() {
+  cat <<EOF
+Usage: $0 --snapshot-tag <tag> [options]
+
+Required:
+  --snapshot-tag <tag>      Source snapshot tag to spawn from
+
+Common options:
+  --out <dir>               Output dir (default: results/<tag>-<unix-ts>/)
+  --duration-s <n>          Agent runtime (default 60)
+  --branch-at-s <n>         Trigger BRANCH N seconds in (default 30)
+  --interval-ms <n>         Agent ping cadence (default 100)
+  --read-timeout-ms <n>     Agent socket read timeout (default 30000)
+  --echo-port <n>           Echo server port (default 39999)
+  --echo-host <ip>          Agent-visible host IP for echo server.
+                            Defaults to the address of the agent-facing
+                            bridge (forkd-br0). Required if auto-detect
+                            fails.
+
+Environment:
+  FORKD_URL     Controller URL (default $FORKD_URL)
+  FORKD_TOKEN   Bearer token (required)
+EOF
+  exit 1
+}
+
+# ---- arg parsing ------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --snapshot-tag)    SNAPSHOT_TAG="$2"; shift 2;;
+    --out)             OUT_DIR="$2"; shift 2;;
+    --duration-s)      DURATION_S="$2"; shift 2;;
+    --branch-at-s)     BRANCH_AT_S="$2"; shift 2;;
+    --interval-ms)     INTERVAL_MS="$2"; shift 2;;
+    --read-timeout-ms) READ_TIMEOUT_MS="$2"; shift 2;;
+    --echo-port)       ECHO_PORT="$2"; shift 2;;
+    --echo-host)       ECHO_HOST="$2"; shift 2;;
+    -h|--help)         usage;;
+    *) echo "unknown arg: $1" >&2; usage;;
+  esac
+done
+[[ -z "$SNAPSHOT_TAG" ]] && usage
+
+# Auto-detect echo host = the host's IP on the forkd bridge. Adjust
+# the interface name if your deployment uses something different.
+if [[ -z "$ECHO_HOST" ]]; then
+  if ip -4 addr show forkd-br0 >/dev/null 2>&1; then
+    ECHO_HOST=$(ip -4 addr show forkd-br0 | awk '/inet /{print $2}' | cut -d/ -f1 | head -1)
+  fi
+fi
+if [[ -z "$ECHO_HOST" ]]; then
+  echo "Could not auto-detect --echo-host. Pass it explicitly." >&2
+  exit 2
+fi
+
+# ---- output dir -------------------------------------------------------------
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="results/${SNAPSHOT_TAG}-$(date +%s)"
+fi
+mkdir -p "$OUT_DIR"
+echo "[run] writing artifacts to $OUT_DIR"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# ---- echo server (background) ----------------------------------------------
+echo "[run] starting echo server on $ECHO_HOST:$ECHO_PORT"
+"$PYTHON_BIN" "$HERE/echo_server.py" \
+  --host "$ECHO_HOST" --port "$ECHO_PORT" --accept-one \
+  > "$OUT_DIR/server.jsonl" 2>&1 &
+ECHO_PID=$!
+trap 'kill $ECHO_PID 2>/dev/null || true' EXIT
+
+# Wait until the listen line is in the log (max 5s).
+for _ in $(seq 1 50); do
+  if grep -q '"event":"listen"' "$OUT_DIR/server.jsonl" 2>/dev/null; then break; fi
+  sleep 0.1
+done
+
+# ---- spawn source sandbox --------------------------------------------------
+echo "[run] spawning source sandbox from snapshot '$SNAPSHOT_TAG'"
+SPAWN_BODY=$(printf '{"snapshot_tag":"%s","n":1,"per_child_netns":true}' "$SNAPSHOT_TAG")
+SPAWN_RESP=$(curl -fsS -H "Authorization: Bearer $FORKD_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$SPAWN_BODY" \
+  "$FORKD_URL/v1/sandboxes")
+SOURCE_ID=$(echo "$SPAWN_RESP" | jq -r '.[0].id')
+echo "[run] source id: $SOURCE_ID"
+echo "$SPAWN_RESP" > "$OUT_DIR/spawn.json"
+
+# Give the guest agent a moment to settle.
+sleep 2
+
+# ---- exec the agent inside the sandbox (blocking) --------------------------
+AGENT_SCRIPT=$(cat "$HERE/agent.py" | base64 -w0)
+echo "[run] starting agent (duration ${DURATION_S}s, branch at ${BRANCH_AT_S}s)"
+EXEC_BODY=$(jq -nc \
+  --argjson timeout $(( DURATION_S + 30 )) \
+  --arg script "$AGENT_SCRIPT" \
+  --arg host "$ECHO_HOST" \
+  --arg port "$ECHO_PORT" \
+  --arg interval "$INTERVAL_MS" \
+  --arg duration "$DURATION_S" \
+  --arg timeout_ms "$READ_TIMEOUT_MS" \
+  '{
+    args: ["sh", "-c", "echo " + $script + " | base64 -d | python3 - --host " + $host + " --port " + $port + " --interval-ms " + $interval + " --duration-s " + $duration + " --read-timeout-ms " + $timeout_ms],
+    timeout_secs: $timeout
+  }')
+
+# Fire the agent in the background so we can BRANCH while it runs.
+(
+  curl -fsS -H "Authorization: Bearer $FORKD_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$EXEC_BODY" \
+    "$FORKD_URL/v1/sandboxes/$SOURCE_ID/exec" \
+    > "$OUT_DIR/exec.json"
+) &
+EXEC_PID=$!
+
+# ---- trigger BRANCH at the chosen offset -----------------------------------
+sleep "$BRANCH_AT_S"
+BRANCH_TAG="branch-pause-$(date +%s)"
+echo "[run] triggering BRANCH → tag=$BRANCH_TAG"
+BRANCH_T_BEFORE=$(date +%s%3N)
+BRANCH_RESP=$(curl -fsS -H "Authorization: Bearer $FORKD_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"tag\":\"$BRANCH_TAG\"}" \
+  "$FORKD_URL/v1/sandboxes/$SOURCE_ID/branch")
+BRANCH_T_AFTER=$(date +%s%3N)
+echo "$BRANCH_RESP" > "$OUT_DIR/branch.json"
+DAEMON_PAUSE_MS=$(echo "$BRANCH_RESP" | jq -r '.pause_ms // empty')
+WALL_BRANCH_MS=$(( BRANCH_T_AFTER - BRANCH_T_BEFORE ))
+echo "[run] daemon pause_ms = ${DAEMON_PAUSE_MS:-n/a}, wall-clock around BRANCH = ${WALL_BRANCH_MS} ms"
+
+# ---- wait for agent to finish ----------------------------------------------
+wait "$EXEC_PID" || true
+jq -r '.stdout' "$OUT_DIR/exec.json" > "$OUT_DIR/agent.jsonl"
+
+# ---- cleanup source sandbox ------------------------------------------------
+echo "[run] tearing down source sandbox"
+curl -fsS -X DELETE -H "Authorization: Bearer $FORKD_TOKEN" \
+  "$FORKD_URL/v1/sandboxes/$SOURCE_ID" || true
+
+# ---- analyze ---------------------------------------------------------------
+echo "[run] analyzing"
+"$PYTHON_BIN" "$HERE/analyze.py" \
+  --agent-log "$OUT_DIR/agent.jsonl" \
+  --server-log "$OUT_DIR/server.jsonl" \
+  --daemon-pause-ms "${DAEMON_PAUSE_MS:-0}" \
+  --baseline-interval-ms "$INTERVAL_MS" \
+  --out-json "$OUT_DIR/report.json" \
+  --out-md "$OUT_DIR/report.md"
+
+echo "[run] done."
+echo
+cat "$OUT_DIR/report.md"

--- a/bench/pause-window/test_analyze.py
+++ b/bench/pause-window/test_analyze.py
@@ -1,0 +1,209 @@
+"""
+Unit tests for analyze.py — runs on synthetic event lists so we
+don't need a real firecracker / KVM to exercise the analysis path.
+
+CI runs this via `python -m unittest`. Keeping zero third-party
+deps so it works in the same environment as the agent itself.
+"""
+import unittest
+
+from analyze import analyze, pct
+
+
+def synth_clean_run(n_pings: int = 100, interval_ms: int = 100, rtt_ms: int = 2):
+    """A trial with no pause: pings every interval, all answered."""
+    events = [{"event": "start", "interval_ms": interval_ms}]
+    for seq in range(1, n_pings + 1):
+        t_send = seq * interval_ms
+        t_recv = t_send + rtt_ms
+        events.append({"event": "send", "seq": seq, "t_send_ms": t_send})
+        events.append(
+            {
+                "event": "recv",
+                "seq": seq,
+                "t_send_ms": t_send,
+                "t_recv_ms": t_recv,
+                "rtt_ms": rtt_ms,
+            }
+        )
+    events.append(
+        {
+            "event": "stop",
+            "sent": n_pings,
+            "recv": n_pings,
+            "timeouts": 0,
+            "errors": 0,
+        }
+    )
+    return events
+
+
+def synth_paused_run(
+    pre_pings: int = 30,
+    pause_ms: int = 2000,
+    post_pings: int = 30,
+    in_flight_during_pause: int = 5,
+    interval_ms: int = 100,
+    rtt_ms: int = 2,
+):
+    """Pre-pause traffic, then a gap that swallows `in_flight_during_pause`
+    sends, then resumed traffic with answers."""
+    events = [{"event": "start", "interval_ms": interval_ms}]
+    t = 0
+    seq = 0
+
+    # Pre-pause: send + recv pairs.
+    for _ in range(pre_pings):
+        seq += 1
+        t += interval_ms
+        events.append({"event": "send", "seq": seq, "t_send_ms": t})
+        events.append(
+            {
+                "event": "recv",
+                "seq": seq,
+                "t_send_ms": t,
+                "t_recv_ms": t + rtt_ms,
+                "rtt_ms": rtt_ms,
+            }
+        )
+
+    last_pre_recv_ms = t + rtt_ms
+
+    # During the pause: sends with no recvs. These are the in-flight
+    # losses the agent reports as timeouts (we model them as `send`
+    # with no matching `recv`).
+    for _ in range(in_flight_during_pause):
+        seq += 1
+        t += interval_ms
+        events.append({"event": "send", "seq": seq, "t_send_ms": t})
+
+    # Resumed traffic. Jump time forward so the first post-recv
+    # creates the gap we want.
+    first_post_recv_ms = last_pre_recv_ms + pause_ms
+    t = first_post_recv_ms
+    for i in range(post_pings):
+        seq += 1
+        t_send = first_post_recv_ms + i * interval_ms
+        events.append({"event": "send", "seq": seq, "t_send_ms": t_send})
+        events.append(
+            {
+                "event": "recv",
+                "seq": seq,
+                "t_send_ms": t_send,
+                "t_recv_ms": t_send + rtt_ms,
+                "rtt_ms": rtt_ms,
+            }
+        )
+
+    events.append(
+        {
+            "event": "stop",
+            "sent": seq,
+            "recv": pre_pings + post_pings,
+            "timeouts": in_flight_during_pause,
+            "errors": 0,
+        }
+    )
+    return events
+
+
+class PercentileTests(unittest.TestCase):
+    def test_empty_returns_zero(self):
+        self.assertEqual(pct([], 50), 0.0)
+
+    def test_p50_on_known_distribution(self):
+        # [1..9], p50 = 5.0
+        self.assertEqual(pct(list(range(1, 10)), 50), 5.0)
+
+    def test_p99_top_bound(self):
+        # p99 of [1..100] is 99.01 with linear interp
+        self.assertAlmostEqual(pct(list(range(1, 101)), 99), 99.01, places=2)
+
+    def test_p0_and_p100_clamp(self):
+        self.assertEqual(pct([1, 2, 3], 0), 1.0)
+        self.assertEqual(pct([1, 2, 3], 100), 3.0)
+
+
+class AnalyzeCleanRunTests(unittest.TestCase):
+    def setUp(self):
+        self.events = synth_clean_run(n_pings=100)
+
+    def test_no_pause_detected(self):
+        r = analyze(self.events)
+        self.assertFalse(r["pause"]["detected"])
+
+    def test_counts_match(self):
+        r = analyze(self.events)
+        self.assertEqual(r["sent"], 100)
+        self.assertEqual(r["recv"], 100)
+        self.assertEqual(r["timeouts"], 0)
+        self.assertEqual(r["errors"], 0)
+        self.assertEqual(r["pause"]["in_flight_lost"], 0)
+
+    def test_connection_survived(self):
+        r = analyze(self.events)
+        self.assertTrue(r["connection_survived"])
+
+    def test_rtt_consistent(self):
+        r = analyze(self.events)
+        self.assertEqual(r["rtt_ms"]["all_p50"], 2)
+        # No after-pause segment when no pause; key still present.
+        self.assertEqual(r["rtt_ms"]["after_p50"], 0.0)
+
+
+class AnalyzePausedRunTests(unittest.TestCase):
+    def setUp(self):
+        self.events = synth_paused_run(
+            pre_pings=30,
+            pause_ms=2000,
+            post_pings=30,
+            in_flight_during_pause=5,
+        )
+
+    def test_pause_detected(self):
+        r = analyze(self.events)
+        self.assertTrue(r["pause"]["detected"])
+
+    def test_pause_duration_in_range(self):
+        r = analyze(self.events)
+        # We modelled 2000 ms gap minus 100 ms baseline = 1900 ms,
+        # plus the recv-to-recv jitter we built in.
+        self.assertGreaterEqual(r["pause"]["app_duration_ms"], 1800)
+        self.assertLessEqual(r["pause"]["app_duration_ms"], 2100)
+
+    def test_in_flight_loss_counted(self):
+        r = analyze(self.events)
+        self.assertEqual(r["pause"]["in_flight_lost"], 5)
+
+    def test_connection_survived_with_post_recvs(self):
+        r = analyze(self.events)
+        self.assertTrue(r["connection_survived"])
+
+    def test_daemon_pause_threaded_through(self):
+        r = analyze(self.events, daemon_pause_ms=1750)
+        self.assertEqual(r["daemon_pause_ms"], 1750)
+        # And the report distinguishes app-observed from daemon-measured.
+        self.assertNotEqual(r["pause"]["app_duration_ms"], r["daemon_pause_ms"])
+
+
+class AnalyzeBaselineSensitivityTests(unittest.TestCase):
+    def test_short_blip_at_lower_baseline_now_detects(self):
+        # A 200 ms gap is normal at baseline=100 (≤3x), but anomalous
+        # at baseline=30 (>3x). Same data, different verdict — the
+        # baseline param has to actually take effect.
+        events = [
+            {"event": "start"},
+            {"event": "send", "seq": 1, "t_send_ms": 0},
+            {"event": "recv", "seq": 1, "t_send_ms": 0, "t_recv_ms": 5, "rtt_ms": 5},
+            {"event": "send", "seq": 2, "t_send_ms": 205},
+            {"event": "recv", "seq": 2, "t_send_ms": 205, "t_recv_ms": 210, "rtt_ms": 5},
+            {"event": "stop", "sent": 2, "recv": 2, "timeouts": 0, "errors": 0},
+        ]
+        r_loose = analyze(events, baseline_interval_ms=100)
+        self.assertFalse(r_loose["pause"]["detected"])
+        r_tight = analyze(events, baseline_interval_ms=30)
+        self.assertTrue(r_tight["pause"]["detected"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/forkd-controller/src/api.rs
+++ b/crates/forkd-controller/src/api.rs
@@ -33,6 +33,15 @@ pub struct SnapshotInfo {
     /// kernel + rootfs via `POST /v1/snapshots`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branched_from: Option<String>,
+    /// For BRANCH-produced snapshots: the source-VM pause window in
+    /// milliseconds, measured around `pause() → resume()`. This is
+    /// the daemon's ground-truth time the source was inactive — the
+    /// application-observed pause (TCP stalls, missed pings) can
+    /// be longer due to OS retransmit timers and shorter for
+    /// short-pause workloads if the agent times its own retries.
+    /// None for non-BRANCH snapshots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pause_ms: Option<u64>,
 }
 
 /// `POST /v1/sandboxes/:id/branch` — pause a running sandbox, snapshot

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -265,6 +265,7 @@ async fn create_snapshot(
         dir: snap_dir.display().to_string(),
         created_at_unix: unix_now(),
         branched_from: None,
+        pause_ms: None,
     };
     if let Err(e) = s.registry.insert_snapshot(info.clone()) {
         return server_error(&format!("persist snapshot: {e:#}"));
@@ -543,9 +544,19 @@ async fn branch_sandbox(
     let snap_dir_for_task = snap_dir.clone();
     let id_for_log = id.clone();
     let task_result = tokio::task::spawn_blocking(
-        move || -> (forkd_vmm::Vm, anyhow::Result<forkd_vmm::Snapshot>) {
+        move || -> (
+            forkd_vmm::Vm,
+            anyhow::Result<forkd_vmm::Snapshot>,
+            Option<u64>,
+        ) {
+            let mut pause_ms: Option<u64> = None;
             let snap_result = (|| -> anyhow::Result<forkd_vmm::Snapshot> {
                 std::fs::create_dir_all(&snap_dir_for_task)?;
+                // pause→resume window is the value the v0.3 userfaultfd
+                // bet wants to shrink. Measure both around the entire
+                // snapshot, since the user's source VM is unavailable the
+                // whole time.
+                let pause_start = std::time::Instant::now();
                 vm.pause()?;
                 let snap = vm.snapshot_to(
                     snap_dir_for_task.join("vmstate"),
@@ -559,21 +570,30 @@ async fn branch_sandbox(
                 // (most likely still paused). We log and continue rather than
                 // returning Err, because the user's primary expectation (a valid
                 // new snapshot) has been met.
-                if let Err(e) = vm.resume() {
+                let resume_result = vm.resume();
+                pause_ms = Some(pause_start.elapsed().as_millis() as u64);
+                if let Err(e) = resume_result {
                     tracing::warn!(
                         sandbox = %id_for_log,
+                        pause_ms = pause_ms.unwrap_or(0),
                         error = %e,
                         "branch: source sandbox failed to resume after snapshot; snapshot file is intact"
+                    );
+                } else {
+                    tracing::info!(
+                        sandbox = %id_for_log,
+                        pause_ms = pause_ms.unwrap_or(0),
+                        "branch: source paused/resumed cleanly"
                     );
                 }
                 Ok(snap)
             })();
-            (vm, snap_result)
+            (vm, snap_result, pause_ms)
         },
     )
     .await;
 
-    let (vm_back, snap_or_err) = match task_result {
+    let (vm_back, snap_or_err, pause_ms) = match task_result {
         Ok(t) => t,
         Err(e) => {
             // Blocking task panicked; we lost the Vm value. The OS still has the
@@ -619,6 +639,7 @@ async fn branch_sandbox(
         dir: snap_dir.display().to_string(),
         created_at_unix: unix_now(),
         branched_from: Some(id.clone()),
+        pause_ms,
     };
     if let Err(e) = s.registry.insert_snapshot(info.clone()) {
         return server_error(&format!("persist snapshot: {e:#}"));

--- a/docs/API.md
+++ b/docs/API.md
@@ -182,12 +182,15 @@ Request:
   `^[A-Za-z0-9_][A-Za-z0-9._-]{0,63}$`.
 
 Response (201 Created): [`SnapshotInfo`](#snapshotinfo) with
-`branched_from` set to the source sandbox id.
+`branched_from` set to the source sandbox id and `pause_ms`
+populated with the measured pause window in milliseconds.
 
 Errors:
 
 - `404 Not Found` — source sandbox id not in `live_vms`
 - `409 Conflict` — tag already exists on disk; `DELETE` it first
+- `409 Conflict` — a BRANCH for this exact tag is already in flight
+- `503 Service Unavailable` — daemon at branch concurrency cap (default 4)
 - `500 Internal Server Error` — pause / snapshot / resume failure
 
 **Pause-window semantics.** The source sandbox is paused at the vCPU
@@ -228,7 +231,8 @@ rationale, use cases, and follow-up roadmap.
   "tag": "py",
   "dir": "/var/lib/forkd/snapshots/py",
   "created_at_unix": 1717000000,
-  "branched_from": "sb-67a1b3-0000"
+  "branched_from": "sb-67a1b3-0000",
+  "pause_ms": 1820
 }
 ```
 
@@ -237,6 +241,11 @@ rationale, use cases, and follow-up roadmap.
   (carrying the source sandbox id) only when the snapshot was
   produced via `POST /v1/sandboxes/:id/branch`. Use this field to
   trace snapshot lineage / audit.
+- `pause_ms` is the measured source-VM pause window in milliseconds
+  (`pause() → resume()` envelope). Omitted for snapshots not produced
+  via BRANCH. This is the daemon's ground truth; the *application*-
+  observed pause (TCP stalls, missed pings) can be longer due to OS
+  retransmit timers.
 
 ## ErrorBody
 


### PR DESCRIPTION
Promote #58 from dev to main.

## Summary
- BRANCH responses now expose `pause_ms` (the `pause()→resume()` envelope on the source VM)
- New `bench/pause-window/` harness: synthetic agent + echo server + analyzer + 14 unit tests
- CI gains a `bench-python` job

This is the methodology that justifies (or refutes) the v0.3 userfaultfd bet. Actually running it on the dev box and writing up the numbers is the next PR.

## Test plan
- [x] All Rust tests green on dev
- [x] Python unit tests green on dev (14/14)
- [ ] CI green on this PR