### PR TITLE
release: 0.1.4 (#62 → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ Notable changes per release. forkd follows [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 1.0; until then, the minor version can break compatibility.
 
+## 0.1.4 — 2026-05-17
+
+### Security
+
+- **`create_sandbox` snapshot_tag validation gap** (MEDIUM-HIGH,
+  post-auth, fixed in PR #54). `POST /v1/sandboxes` accepted
+  `req.snapshot_tag` from the request body and joined it directly
+  into `snapshot_root` without calling `is_safe_tag` — unlike sister
+  handlers `delete_snapshot` and `branch_sandbox` which both
+  validated. The unvalidated tag also persisted into
+  `SandboxInfo.snapshot_tag` and later flowed into
+  `read_snapshot_volumes` during BRANCH, which `serde_json::from_str`'d
+  the file at `<snapshot_root>/<tag>/snapshot.json` — letting an
+  authenticated attacker control volume mounts of grandchild VMs.
+  Full advisory:
+  [docs/SECURITY.md → 2026-05-17](./docs/SECURITY.md#past-advisories).
+- **K8s manifest placeholder bearer token**. The shipped
+  `packaging/k8s/forkd-controller.yaml` ships `token: REPLACE_ME_*`.
+  Users who forget to `sed` it before `kubectl apply` would get a
+  daemon protected only by a publicly-known token. Fixed: daemon
+  refuses to start if the token begins with `REPLACE_ME` /
+  `CHANGE_ME` or is shorter than 16 bytes.
+- **`boot_wait_secs` cap**. `POST /v1/snapshots` previously accepted
+  any `u64`. Clamped to 60 s.
+
+### Reliability
+
+- **BRANCH concurrency caps** (PR #56). Two `POST /branch` calls on
+  the same target tag now serialise via a per-tag in-flight set
+  (second gets 409) — previously both could pass the
+  `vmstate.exists()` TOCTOU and clobber each other. The daemon also
+  admits at most `DEFAULT_BRANCH_CONCURRENCY` (4) BRANCHes
+  simultaneously; excess gets 503. Both bounds use an RAII
+  `BranchSlot` guard so every error path releases cleanly.
+
+### Observability
+
+- **`pause_ms` on BRANCH responses** (PR #58). `SnapshotInfo` now
+  carries an optional `pause_ms` populated by `branch_sandbox` with
+  the measured `pause() → resume()` envelope on the source VM.
+  Also emitted as a structured `tracing::info!` event. Powers the
+  new `bench/pause-window/` harness.
+
+### Benchmarks
+
+- **Pause-window harness + first-cut results**. New
+  `bench/pause-window/` directory with a synthetic ping/pong agent,
+  host-side echo server, orchestrator, and pure-function analyzer
+  (14 unit tests, covered by a new `bench-python` CI job). 5
+  trials on real hardware (513 MiB source): mean pause
+  **4.26 s ± 0.41 s**, **0 in-flight loss, 5/5 connection survival**.
+  Surprising mechanism (in-guest agents are nearly pause-blind via
+  kvmclock catch-up) documented in
+  [`bench/pause-window/RESULTS-v0.2.md`](./bench/pause-window/RESULTS-v0.2.md).
+
 ## 0.1.3 — 2026-05-14
 
 ### Security

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/deeplethe/forkd"

--- a/README-zh.md
+++ b/README-zh.md
@@ -447,9 +447,12 @@ Roadmap 和正在追踪的工作都在 [GitHub issues](https://github.com/deeple
 版本变更记录:[CHANGELOG.md](./CHANGELOG.md)。
 安全策略与历史漏洞通告:[docs/SECURITY.md](./docs/SECURITY.md)。
 
-> **0.1.3 包含一个安全修复**。`--tag` 处理有 path-traversal,
-> 影响 0.1.0–0.1.2,请升级。完整公告见
+> **0.1.4 包含 daemon 侧安全修复**。`POST /v1/sandboxes` 的
+> `snapshot_tag` 校验缺失(任意路径 → 控制 grandchild VM
+> volumes)和 K8s manifest 接受字面占位符 bearer token —— 两个 HIGH
+> 影响 0.1.0–0.1.3,请升级。完整公告见
 > [docs/SECURITY.md#past-advisories](./docs/SECURITY.md#past-advisories)。
+> 0.1.3 此前还修复了 CLI `--tag` path-traversal(影响 0.1.0–0.1.2)。
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -490,10 +490,13 @@ Issue-level tracking: [GitHub issues](https://github.com/deeplethe/forkd/issues)
 Release notes per version: [CHANGELOG.md](./CHANGELOG.md).
 Security posture and past advisories: [docs/SECURITY.md](./docs/SECURITY.md).
 
-> **0.1.3 contains a security fix.** A path-traversal in `--tag`
-> handling affected 0.1.0–0.1.2; users on those versions should
-> upgrade. Full advisory in
+> **0.1.4 contains daemon security fixes.** Two HIGH-class
+> validation gaps in `POST /v1/sandboxes` (path-traversal via
+> `snapshot_tag`) and `packaging/k8s/` (placeholder bearer token
+> accepted at startup) affected 0.1.0–0.1.3 inclusive; users on
+> those versions should upgrade. Full advisories in
 > [docs/SECURITY.md#past-advisories](./docs/SECURITY.md#past-advisories).
+> 0.1.3 also fixed a CLI `--tag` path-traversal (affected 0.1.0–0.1.2).
 
 <br/>
 

--- a/sdk/python/forkd/__init__.py
+++ b/sdk/python/forkd/__init__.py
@@ -14,5 +14,5 @@ Most agent runtimes use both: ``Controller`` to spawn / branch / kill,
 from .controller import Controller, ControllerError
 from .sandbox import CommandResult, Sandbox
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __all__ = ["Sandbox", "CommandResult", "Controller", "ControllerError"]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "forkd"
-version = "0.1.3"
+version = "0.1.4"
 description = "Open-source fork-on-write microVM sandbox primitive (E2B-compatible surface)"
 readme = "README.md"
 authors = [{name = "Deeplethe", email = "info@deeplethe.com"}]


### PR DESCRIPTION
Promote #62 to main so we can push the v0.1.4 tag.