### PR TITLE
docs(readme): embed 24s asciinema demo (EN + ZH)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -38,6 +38,27 @@ forkd 基于 Firecracker 构建。父 VM 启动一次,把运行时(Python +
 
 <br/>
 
+## Demo:让一个思考中的 agent 分裂
+
+一个 24 秒的演示 —— 源 agent 在 LangGraph ReAct loop 中跑到一半,
+被 BRANCH,3 个子沙箱继承同一份认知状态,各自收到不同的引导
+("深度文化派"、"极简派"、"省钱派"),输出三条**显著不同的**
+第一天行程。
+
+[![asciicast](https://asciinema.org/a/B28aQajrg3EXzas4.svg)](https://asciinema.org/a/B28aQajrg3EXzas4)
+
+最关键的分裂证据:源 agent(无引导)第一天下午选 Nishiki Market
+(锦市场,$$);3 个被引导的子沙箱**各自独立地都换成了 Arashiyama
+Bamboo Grove**(岚山竹林,free);"省钱派" 还在 $$ 餐厅那里加上了
+"may be pricey" 的警告语,其他两个没有。**模型并没有被告知"换景点"**
+—— 是 hint 影响了下一次 LLM 调用,前置推理整套都没变。
+
+完整机制 + 数据 + 原始 transcript 在
+[`recipes/langgraph-react/`](./recipes/langgraph-react/) 和
+[`recipes/langgraph-react/DEMO.md`](./recipes/langgraph-react/DEMO.md)。
+
+<br/>
+
 ## 关键特性
 
 - **硬件级隔离。** 每个子 VM 都是独立的 Firecracker microVM,

--- a/README.md
+++ b/README.md
@@ -40,6 +40,29 @@ spawn cost that's closer to `fork(2)` than to a cold-boot VM.
 
 <br/>
 
+## Demo: branch a thinking agent
+
+A 24-second walkthrough of the LangGraph branch-and-fan-out demo —
+source agent runs a ReAct loop, gets BRANCHed mid-thought, three
+grandchildren each receive a different steering hint, all three
+produce divergent itineraries while inheriting the same prior
+reasoning state.
+
+[![asciicast](https://asciinema.org/a/TsIsceEUXLdyMi7N.svg)](https://asciinema.org/a/TsIsceEUXLdyMi7N)
+
+Headline divergence: the source (no hint) picks Nishiki Market for
+Day 1; all three hinted children independently substitute Arashiyama
+Bamboo Grove. The cost-focused child also adds "may be pricey"
+annotations the others don't. **The model wasn't told to swap places**
+— each hint perturbed the next LLM call, the rest of the prior
+reasoning came along unchanged.
+
+Full mechanism + numbers + raw transcripts in
+[`recipes/langgraph-react/`](./recipes/langgraph-react/) and
+[`recipes/langgraph-react/DEMO.md`](./recipes/langgraph-react/DEMO.md).
+
+<br/>
+
 ## Properties
 
 - **Hardware isolation.** Each child is its own Firecracker microVM


### PR DESCRIPTION
## What

Adds the asciinema cast as the hero visual at the top of both README.md and README-zh.md, right after the "Fork 100 microVMs in 101 ms" headline.

- English: https://asciinema.org/a/TsIsceEUXLdyMi7N
- 中文: https://asciinema.org/a/B28aQajrg3EXzas4

Both casts are 24s, show: healthz → recipe listing → pause_ms=4007 from a real BRANCH → divergent Day-1 itineraries across 3 hinted children (parent picks Nishiki Market, all 3 hinted children substitute Arashiyama Bamboo).

## Caveat

Casts were uploaded from an unauthenticated asciinema CLI, so they auto-expire 7 days after upload. Before this PR ages out, we should:

1. Authenticate the dev-box CLI via https://asciinema.org/connect
2. Re-upload both casts (gets permanent URLs)
3. Update the README embeds

For now the 7-day window is enough to validate the rendering and walk Tencent through it Wed.

## Test plan
- [x] Both URLs return 200 in browser
- [x] SVG previews render (17KB / 12KB)
- [x] Final-frame text captured matches expected divergence story
- [ ] CI green