### PR TITLE
feat: forkd Hub MVP (#70 → main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,25 @@ Measured CoW overhead at N=100 is **0.12 MiB / child** on top of the parent ([be
 
 Requires: x86_64 Linux with KVM, Ubuntu 22.04 or newer.
 
+### Fastest path — pull a pre-built snapshot from the Hub
+
+```bash
+pip install forkd
+sudo bash scripts/setup-host.sh           # KVM + tap device, one-time
+sudo bash scripts/netns-setup.sh 3        # per-child network namespaces
+
+# 14.5 MiB pack (a Python 3.12 + LangGraph-ready snapshot) → 15s download.
+forkd pull deeplethe/langgraph-react
+
+# Fork 3 children sharing the parent's memory.
+sudo -E forkd fork --tag langgraph -n 3 --per-child-netns
+```
+
+See [`docs/HUB.md`](./docs/HUB.md) for the registry model + how to
+publish your own snapshot pack.
+
+### From-source path — build your own warmed parent
+
 ```bash
 # 1. Host setup: KVM, Firecracker, Rust, KSM, hugepages, tap device.
 sudo bash scripts/setup-host.sh

--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -574,45 +574,105 @@ fn unpack_into(
     Ok(())
 }
 
-const DEFAULT_HUB_URL: &str = "https://forkd-hub.deeplethe.com";
+/// Where `forkd pull <owner>/<name>` resolves names to download URLs by
+/// default. Points at the registry.json maintained in the main repo.
+/// Override with `--hub <url>` or `FORKD_HUB_URL` if you run your own
+/// registry.
+const DEFAULT_HUB_REGISTRY_URL: &str =
+    "https://raw.githubusercontent.com/deeplethe/forkd/main/registry.json";
+
+#[derive(serde::Deserialize)]
+struct Registry {
+    #[allow(dead_code)]
+    schema_version: u32,
+    packages: std::collections::HashMap<String, RegistryPackage>,
+}
+
+#[derive(serde::Deserialize)]
+struct RegistryPackage {
+    #[allow(dead_code)]
+    description: Option<String>,
+    versions: std::collections::HashMap<String, RegistryVersion>,
+}
+
+#[derive(serde::Deserialize)]
+struct RegistryVersion {
+    url: String,
+    /// Hex-encoded SHA-256 of the pack. Verified after download; mismatch aborts.
+    #[serde(default)]
+    sha256: Option<String>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    size_bytes: Option<u64>,
+}
 
 fn pull_cmd(target: String, tag: Option<String>, force: bool, hub: Option<String>) -> Result<()> {
     if let Some(ref t) = tag {
         validate_tag(t)?;
     }
-    let url = resolve_target_url(&target, hub.as_deref())?;
+    let (url, expected_sha256) = resolve_target(&target, hub.as_deref())?;
     let tmp_pack = std::env::temp_dir().join(format!("forkd-pull-{}.tar.zst", std::process::id()));
     // Clean tmp_pack whether download or unpack fails — both paths used
     // to leak /tmp/forkd-pull-<pid>.tar.zst on error.
-    let result = (|| {
+    let result = (|| -> Result<()> {
         let bytes = hub::download(&url, &tmp_pack)?;
         eprintln!("✓ downloaded {} ({})", hub::human_bytes(bytes), url);
+        if let Some(expected) = expected_sha256 {
+            let actual = hub::sha256_file(&tmp_pack)?;
+            if !actual.eq_ignore_ascii_case(&expected) {
+                bail!(
+                    "sha256 mismatch — registry says {expected}, downloaded file is {actual}.\n\
+                     Refusing to unpack. This means either the registry is stale or the \
+                     download was tampered with."
+                );
+            }
+            eprintln!("✓ sha256 verified ({})", &actual[..16]);
+        }
         unpack_cmd(tmp_pack.clone(), tag, force)
     })();
     let _ = std::fs::remove_file(&tmp_pack);
     result
 }
 
-fn resolve_target_url(target: &str, hub_base: Option<&str>) -> Result<String> {
+/// Resolve a pull target. Returns (download_url, optional_expected_sha256).
+///
+/// - HTTP(S) URL: passed through unchanged, no integrity check
+/// - `<owner>/<name>` or `<owner>/<name>@<version>`: looked up in the
+///   registry.json at `hub_base` (or `DEFAULT_HUB_REGISTRY_URL`). Picks
+///   the "latest" version if `@<version>` is absent.
+fn resolve_target(target: &str, hub_base: Option<&str>) -> Result<(String, Option<String>)> {
     if target.starts_with("http://") || target.starts_with("https://") {
-        return Ok(target.to_string());
+        return Ok((target.to_string(), None));
     }
-    // Short form: owner/tag
     if target.contains('/') && !target.contains(' ') {
-        let base = hub_base.unwrap_or(DEFAULT_HUB_URL).trim_end_matches('/');
-        let slug: String = target
-            .chars()
-            .map(|c| {
-                if c.is_alphanumeric() || c == '/' {
-                    c
-                } else {
-                    '-'
-                }
-            })
-            .collect();
-        return Ok(format!("{base}/{slug}.forkd-snapshot.tar.zst"));
+        let (name, version) = match target.split_once('@') {
+            Some((n, v)) => (n.to_string(), v.to_string()),
+            None => (target.to_string(), "latest".to_string()),
+        };
+        let registry_url = hub_base.unwrap_or(DEFAULT_HUB_REGISTRY_URL);
+        let registry = fetch_registry(registry_url)?;
+        let pkg = registry.packages.get(&name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "package '{name}' not in registry at {registry_url}. \
+                 Run `curl {registry_url}` to see what's available."
+            )
+        })?;
+        let ver = pkg.versions.get(&version).ok_or_else(|| {
+            let avail: Vec<&String> = pkg.versions.keys().collect();
+            anyhow::anyhow!("package '{name}' has no version '{version}'. Available: {avail:?}")
+        })?;
+        return Ok((ver.url.clone(), ver.sha256.clone()));
     }
-    bail!("invalid pull target '{target}'; expected an https URL or `<owner>/<tag>` short form")
+    bail!("invalid pull target '{target}'; expected an https URL or `<owner>/<name>[@<version>]` short form")
+}
+
+fn fetch_registry(url: &str) -> Result<Registry> {
+    eprintln!("→ resolving via {url}");
+    let tmp = std::env::temp_dir().join(format!("forkd-registry-{}.json", std::process::id()));
+    let _ = hub::download(url, &tmp).with_context(|| format!("fetch registry {url}"))?;
+    let raw = std::fs::read_to_string(&tmp).with_context(|| "read downloaded registry")?;
+    let _ = std::fs::remove_file(&tmp);
+    serde_json::from_str(&raw).with_context(|| "parse registry.json")
 }
 
 fn push_cmd(

--- a/docs/HUB.md
+++ b/docs/HUB.md
@@ -1,0 +1,133 @@
+# forkd Hub
+
+The Hub is forkd's namespace-resolved snapshot registry. It turns a
+10-step recipe-building experience into a one-liner:
+
+```bash
+pip install forkd
+forkd pull deeplethe/langgraph-react       # downloads the pack
+sudo forkd fork --tag langgraph -n 3       # branches it
+```
+
+## How it works
+
+The Hub is intentionally simple — no central service, no auth, no
+cost. Three pieces:
+
+1. **`registry.json`** at the root of this repo (`raw.githubusercontent.com/deeplethe/forkd/main/registry.json`)
+   maps `<owner>/<name>` to a download URL + sha256.
+2. **`.forkd-snapshot.tar.zst` packs** are attached to GitHub Releases
+   with the tag scheme `hub-<name>-v<N>`. GitHub gives us free
+   unlimited public-asset hosting.
+3. **`forkd pull`** in the CLI fetches `registry.json`, looks up the
+   package, downloads the asset, verifies sha256, unpacks into
+   `$XDG_DATA_HOME/forkd/snapshots/<tag>/`.
+
+Override the registry URL with `--hub <url>` or `FORKD_HUB_URL` if
+you run your own (e.g., internal mirror, or your own fork's recipes).
+
+## What's currently published
+
+| Name | Description | Memory | Pack size |
+|---|---|---:|---:|
+| `deeplethe/langgraph-react` | ReAct agent for the branch-and-fan-out demo | 513 MiB | 14.5 MiB |
+
+More recipes (`postgres-fixture`, `python-numpy`, `agent-workbench`)
+will land here as `recipes/<name>/build.sh` matures + we automate the
+publishing pipeline.
+
+## Publishing a new pack
+
+```bash
+# 1) Build your snapshot locally (see recipes/<name>/build.sh)
+sudo forkd snapshot --tag mything --kernel ... --rootfs ...
+
+# 2) Pack it
+sudo HOME=$HOME forkd pack \
+    --tag mything \
+    --description "what this is" \
+    --base-image python:3.12-slim \
+    --out /tmp/mything.forkd-snapshot.tar.zst
+
+# 3) sha256 + size
+sha256sum /tmp/mything.forkd-snapshot.tar.zst
+wc -c   /tmp/mything.forkd-snapshot.tar.zst
+
+# 4) Create the GitHub release
+gh release create hub-mything-v1 \
+    /tmp/mything.forkd-snapshot.tar.zst \
+    --target main \
+    --title "Hub: <yourorg>/mything v1" \
+    --notes "..."
+
+# 5) Add an entry to registry.json:
+#    - "url" = the release asset download URL
+#    - "sha256" = the hex digest from step 3
+#    - "size_bytes" = the byte count from step 3
+#
+# 6) Open a PR to deeplethe/forkd updating registry.json.
+#    Once merged, your pack is `forkd pull <yourorg>/mything`-able.
+```
+
+## Schema (`registry.json`)
+
+```jsonc
+{
+  "schema_version": 1,
+  "packages": {
+    "<owner>/<name>": {
+      "description": "human-readable, shows up in `forkd images --hub`",
+      "versions": {
+        "<version>": {
+          "url":         "https://...",     // required, download URL
+          "sha256":      "<hex digest>",    // optional but recommended
+          "size_bytes":  12345,             // optional, used for progress estimates
+          "memory_mib":  513,               // optional, expected guest RAM
+          "base_image":  "python:3.12-slim",// optional, audit trail
+          "recipe_path": "recipes/<name>",  // optional, source-of-truth recipe
+          "created_at":  "2026-05-18T...",  // optional, ISO 8601
+          "release_tag": "hub-<name>-v1"    // optional, audit trail
+        }
+      }
+    }
+  }
+}
+```
+
+Every package must have a `"latest"` version. Additional named
+versions (`"v1"`, `"v2"`, ...) let users pin via
+`forkd pull <owner>/<name>@v1`.
+
+## Security model
+
+- **Public read.** Anyone can pull any pack listed in `registry.json`.
+- **Push via PR.** Adding a pack means opening a PR to this repo. A
+  maintainer reviews the URL + sha256 + the recipe that produced it.
+- **No signing yet.** The sha256 in `registry.json` is integrity, not
+  authenticity. v0.x is OSS-first, single-trust-domain (this repo);
+  v1.0 will add Sigstore / cosign signatures.
+- **Trust model.** Pulling a pack and running it as a sandbox = trusting
+  the publisher. The pack contains a guest kernel image + rootfs that
+  will be booted under KVM. If the publisher is hostile, KVM is the
+  only thing between them and your host. forkd's threat model is no
+  weaker than "you ran a Docker image from this registry" — but also no
+  stronger.
+
+## Why GitHub Releases?
+
+It's the cheapest, most reliable distribution layer for a v0.x OSS
+project:
+
+- **Free.** Public repos have unlimited release asset storage and
+  bandwidth.
+- **Stable.** Asset URLs don't rotate. Once published, the URL works
+  forever.
+- **2 GiB per file.** Our biggest current pack is 15 MiB; the largest
+  realistic forkd pack (a 4 GiB warm parent) compresses to ~300 MiB.
+  Comfortably under.
+- **No vendor lock-in.** If we outgrow it, change the `url` field in
+  `registry.json`; clients don't have to upgrade.
+
+If you need higher-volume / private hosting, run your own registry
+that serves a `registry.json` and point `FORKD_HUB_URL` at it. The
+client doesn't care.

--- a/registry.json
+++ b/registry.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "forkd hub registry. forkd CLI fetches this file when resolving `forkd pull <owner>/<name>`. Schema documented in docs/HUB.md. Edit + PR to publish a new pack.",
+  "schema_version": 1,
+  "packages": {
+    "deeplethe/langgraph-react": {
+      "description": "ReAct agent demo for the branch-and-fan-out story. Python 3.12 + requests. Used by the README demo cast.",
+      "versions": {
+        "latest": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-langgraph-react-v1/langgraph-react.forkd-snapshot.tar.zst",
+          "sha256": "96dae77acc588da68fc7e01ec4a93a5b37a0b193c83ab3c42e5de419909f2c76",
+          "size_bytes": 15196791,
+          "memory_mib": 513,
+          "base_image": "python:3.12-slim",
+          "recipe_path": "recipes/langgraph-react",
+          "created_at": "2026-05-18T05:25:00Z",
+          "release_tag": "hub-langgraph-react-v1"
+        },
+        "v1": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-langgraph-react-v1/langgraph-react.forkd-snapshot.tar.zst",
+          "sha256": "96dae77acc588da68fc7e01ec4a93a5b37a0b193c83ab3c42e5de419909f2c76",
+          "size_bytes": 15196791,
+          "memory_mib": 513,
+          "base_image": "python:3.12-slim",
+          "recipe_path": "recipes/langgraph-react",
+          "created_at": "2026-05-18T05:25:00Z",
+          "release_tag": "hub-langgraph-react-v1"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Promote #70 from dev to main. registry.json becomes live at raw.githubusercontent.com/deeplethe/forkd/main/registry.json.