### PR TITLE
docs: propagate storage-bound pause framing across 4 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 
 - **`recipes/langgraph-react/`** — branch-and-fan-out demo of a
   real LangGraph-style ReAct agent. Source agent runs 2 ReAct
-  steps with tool calls, BRANCH pauses it for ~4 s, 3 grandchildren
+  steps with tool calls, BRANCH pauses it (~4 s on SATA SSD,
+  ~160 ms on tmpfs), 3 grandchildren
   spawn with different steering hints, each produces a different
   itinerary inheriting the same prior cognitive state. Full writeup
   + asciinema cast embedded in README + first real-run artifacts
@@ -52,9 +53,12 @@ Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 
 ### Benchmarks
 
-- **`bench/pause-window/RESULTS-v0.2.md`** — first-cut measurement:
-  mean BRANCH pause **4.26 s ± 0.41 s** for a 513 MiB source.
-  5/5 connection survival, 0 in-flight loss. Surprising mechanism:
+- **`bench/pause-window/RESULTS-v0.2.md`** — first-cut measurement
+  shows pause is storage-bound: **163 ms ± 7 ms on tmpfs**
+  (4 trials), **4.26 s ± 0.41 s on SATA SSD** (5 trials) for the
+  same 513 MiB source. Same forkd code; only `--snapshot-root`
+  differs. 5/5 connection survival, 0 in-flight loss across SSD
+  trials. Surprising mechanism:
   in-guest agents are pause-blind because kvmclock's monotonic
   catch-up on resume races recv data delivery; the recv returns
   data before its timeout timer can fire. The userfaultfd bet's

--- a/docs/INTEGRATION-CUBESANDBOX.md
+++ b/docs/INTEGRATION-CUBESANDBOX.md
@@ -70,7 +70,10 @@ The most interesting divergence:
   Pauses the source VM, writes a snapshot, resumes the source,
   and `mmap`s the snapshot into N children. The
   [pause-window benchmark](../bench/pause-window/RESULTS-v0.2.md)
-  measures the cost: about 4 seconds of pause on a 513 MiB source.
+  measures **163 ms ± 7 ms** for a 513 MiB source on tmpfs-backed
+  snapshot storage. The same code on SATA SSD storage degrades
+  to 4.26 s ± 0.41 s; the gap is entirely the fsync write
+  throughput of the storage layer.
 - CubeSandbox: pause and resume endpoints exist
   (`/sandboxes/:id/pause`, `/sandboxes/:id/resume`), but
   fork-from-snapshot is on the roadmap, not shipped. From the
@@ -169,7 +172,7 @@ deepest difference is what the snapshot is for:
 | Source VM state at capture | Live: open TCP, in-flight syscalls | Quiesced (no in-flight I/O) |
 | Device-state requirement | Must serialize pending requests | Must serialize clean state |
 | Failure handling | Partial snapshot rollback | Failure invalidates template, rebuild |
-| Optimization target | Minimize pause window (we hit ~4 s) | Minimize clone latency (they hit <60 ms) |
+| Optimization target | Minimize pause window (we hit 163 ms on tmpfs, 4.26 s on SATA SSD) | Minimize clone latency (they hit <60 ms) |
 | Lifecycle | Snapshot lives briefly, between BRANCH and spawn | Snapshot lives indefinitely as template |
 
 CubeSandbox's current pause/resume path captures a template

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,14 +20,17 @@ sandbox while `vm.snapshot_to()` writes `memory.bin` — typically
 TCP keepalives and progress; it's also the only remaining trade-off
 in the branching primitive (see `docs/design/branching.md`).
 
-**First-cut measurement (forkd v0.2, 5 trials).** For a 513 MiB
-source running a TCP ping/pong agent: pause is **4.26 s ± 0.41 s**.
-External observers see the full gap. **In-guest** agents are nearly
-pause-blind — connection survival 5/5, in-flight loss 0/5, post-
-resume RTT returns to baseline — because kvmclock's monotonic
-catch-up on resume races the recv data delivery (the data arrives
-in the socket buffer before the timeout timer can fire). Full
-methodology + raw data + paper §2 seed in
+**First-cut measurement (forkd v0.2).** Pause window is dominated
+by snapshot-write throughput, not by VMM control-path work.
+For a 513 MiB source running a TCP ping/pong agent:
+**163 ms ± 7 ms on tmpfs-backed snapshot storage** (4 trials),
+degrading to **4.26 s ± 0.41 s on SATA SSD with fsync** (5
+trials). Same forkd code, only the storage backend differs.
+External observers see the full gap; in-guest agents are nearly
+pause-blind (connection survival 5/5, in-flight loss 0/5,
+post-resume RTT returns to baseline) because kvmclock's
+monotonic catch-up on resume races the recv data delivery. Full
+methodology and raw data in
 [`bench/pause-window/RESULTS-v0.2.md`](../bench/pause-window/RESULTS-v0.2.md).
 
 **Idea.** Register the source VM's guest memory with `userfaultfd`,

--- a/recipes/langgraph-react/DEMO.md
+++ b/recipes/langgraph-react/DEMO.md
@@ -9,7 +9,7 @@ comparison so you can see what changes when you swap models.
 
 ## TL;DR for a tweet thread
 
-> 🍴 forkd just forked a running ReAct agent in **4 seconds**.
+> 🍴 forkd just forked a running ReAct agent: **163 ms** pause on tmpfs-backed snapshot storage, **4 s** on the SATA SSD this demo recorded against. Same code, only the disk differs.
 >
 > A source agent had spent 2 steps gathering weather + place
 > data for a Kyoto + Osaka trip. We BRANCHed it and spawned 3
@@ -42,7 +42,7 @@ comparison so you can see what changes when you swap models.
 
 | Metric | Value |
 |---|---|
-| Daemon-measured pause window | **4007 ms** |
+| Daemon-measured pause window | **4007 ms** (SATA SSD storage; see [RESULTS-v0.2.md](../../bench/pause-window/RESULTS-v0.2.md) for 163 ms on tmpfs) |
 | Memory image size | 513 MiB |
 | Grandchildren spawned | 3 |
 | Steering hints applied | 3 (one per child) |


### PR DESCRIPTION
After PRs #86/#88 made tmpfs (163 ms) the lead number in the benchmark, four other docs still quoted 4 s in isolation:

- `docs/INTEGRATION-CUBESANDBOX.md` (Fork-on-write section + use-case table)
- `docs/ROADMAP.md` (v0.3 userfaultfd entry)
- `CHANGELOG.md` (Unreleased entries; 0.1.4 historical entry left intact)
- `recipes/langgraph-react/DEMO.md` (tweet headline + run table)

All now mention both backends with explicit storage context. No new measurements; consistent framing across the docs that link to each other.