### PR TITLE
feat(hub): coding-agent-fork pack (#94 → main)

### DIFF
--- a/docs/HUB.md
+++ b/docs/HUB.md
@@ -30,11 +30,19 @@ you run your own (e.g., internal mirror, or your own fork's recipes).
 
 | Name | Description | Memory | Pack size |
 |---|---|---:|---:|
-| `deeplethe/langgraph-react` | ReAct agent for the branch-and-fan-out demo | 513 MiB | 14.5 MiB |
+| `deeplethe/langgraph-react` | ReAct agent for the branch-and-fan-out demo (Python 3.12 + requests) | 513 MiB | 14.5 MiB |
+| `deeplethe/coding-agent-fork` | Pre-warmed snapshot: `/tmp/workspace` already has the buggy mathy package, 50 MiB synthetic vendored.bin, `__pycache__` populated. Children boot 'ready to BRANCH'. | 513 MiB | 67.6 MiB |
 
 More recipes (`postgres-fixture`, `python-numpy`, `agent-workbench`)
-will land here as `recipes/<name>/build.sh` matures + we automate the
-publishing pipeline.
+will land here as `recipes/<name>/build.sh` matures and we automate
+the publishing pipeline.
+
+The `coding-agent-fork` pack is intentionally larger than
+`langgraph-react`: it carries a 50 MiB synthetic `vendored.bin` of
+random bytes that zstd cannot compress. The point of including it is
+to demonstrate that a pre-warmed snapshot can ship MiB-scale binary
+state byte-identically to every child sandbox via copy-on-write,
+which a parallel-prompt API call cannot replicate.
 
 ## Publishing a new pack
 

--- a/registry.json
+++ b/registry.json
@@ -26,6 +26,31 @@
           "release_tag": "hub-langgraph-react-v1"
         }
       }
+    },
+    "deeplethe/coding-agent-fork": {
+      "description": "Pre-warmed snapshot for the coding-agent-fork demo: /tmp/workspace populated with the buggy mathy package, 50 MiB synthetic vendored.bin, __pycache__ from an initial failing test run. Pull this and children boot already 'ready to BRANCH'.",
+      "versions": {
+        "latest": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-coding-agent-fork-v1/coding-agent-fork.forkd-snapshot.tar.zst",
+          "sha256": "a809eba528ef49cdef571b4a76a95b7fa94faf73d7906eca981dadac6640b85c",
+          "size_bytes": 70906122,
+          "memory_mib": 513,
+          "base_image": "python:3.12-slim",
+          "recipe_path": "recipes/coding-agent-fork",
+          "created_at": "2026-05-18T19:00:00Z",
+          "release_tag": "hub-coding-agent-fork-v1"
+        },
+        "v1": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-coding-agent-fork-v1/coding-agent-fork.forkd-snapshot.tar.zst",
+          "sha256": "a809eba528ef49cdef571b4a76a95b7fa94faf73d7906eca981dadac6640b85c",
+          "size_bytes": 70906122,
+          "memory_mib": 513,
+          "base_image": "python:3.12-slim",
+          "recipe_path": "recipes/coding-agent-fork",
+          "created_at": "2026-05-18T19:00:00Z",
+          "release_tag": "hub-coding-agent-fork-v1"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Promote #94. After this merges, registry.json on main carries N=2 packs and `forkd pull deeplethe/coding-agent-fork` resolves via the default registry URL.