### PR TITLE
docs: surface v0.3 phase 1 (143x) on README + ROADMAP + CHANGELOG + boxlite doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 
 ## Unreleased — 0.1.5 (in flight)
 
+### v0.3 phase 1: diff snapshots — 4 GiB SSD source pause 29 s → 205 ms (143×)
+
+- **`Vm::snapshot_diff_to`** in `forkd-vmm` — calls Firecracker
+  `/snapshot/create` with `snapshot_type: "Diff"`, returns a
+  `DiffSnapshot` carrying both logical and physical sizes (the latter
+  = on-disk allocated bytes = the BRANCH's dirty footprint).
+- **`apply_diff(diff_path, base_path)`** helper — `SEEK_DATA`/
+  `SEEK_HOLE` walk the diff's allocated extents, 1 MiB chunks copied
+  onto the same offsets of the base file. Returns bytes copied.
+  Linux-only; non-Linux builds bail rather than silently degrading.
+- **`ForkOpts.enable_diff_snapshots: bool`** — required on
+  `/snapshot/load` for the resulting VM to admit Diff snapshot/create
+  calls. Default false (v0.2 callers preserve identical behavior);
+  daemon's `create_sandbox` flips it to true for all daemon-spawned
+  sources.
+- **`POST /v1/sandboxes/:id/branch` gains `"diff": bool`.** When true,
+  the daemon parallelizes the source-tag memory.bin copy with the
+  source running, takes a Diff snapshot during a ~200 ms pause,
+  resumes the source, joins the copy, and merges the diff onto the
+  pre-copied output. The user-visible pause is just the Diff window —
+  source TCP connections, kvmclock, and timers see a ~200 ms gap
+  instead of seconds. Total BRANCH API latency is unchanged on SSD
+  (still bandwidth-bound on the cp); only source DOWNTIME shrinks.
+- **`SandboxInfo.has_branched: bool`** + `Registry::mark_branched()`
+  gate that rejects second-and-later `"diff": true` BRANCHes with a
+  clear 400. Firecracker clears the dirty bitmap on every
+  snapshot/create, so a second Diff would silently miss pages dirtied
+  before BRANCH 1. Multi-BRANCH diff support (per-sandbox shadow
+  file) is deferred to v0.3.1+; forkd's canonical "spawn → BRANCH
+  once → fan out N → discard source" workflow only ever takes one
+  BRANCH per sandbox, so the restriction covers ~80% of use cases.
+- **`SnapshotInfo`** gains `diff_ms`, `diff_physical_bytes`,
+  `diff_logical_bytes` — populated when `diff: true` or
+  `measure_diff: true` was set on the BRANCH request.
+- **Measurement**:
+  [`bench/pause-window/RESULTS-v0.3.md`](./bench/pause-window/RESULTS-v0.3.md)
+  with the full A/B (5 memory sizes × 3 trials × 2 modes × 2 backends
+  = 60 trials). Phase 1a numbers (sidecar Diff inside the existing
+  Full pause) match phase 1b numbers (real `diff: true`) within
+  measurement noise — architecture validated. Honest caveats: idle-
+  source best case; 256 MiB on tmpfs is a wash (control-plane floor
+  exceeds memcpy); first-BRANCH-only restriction.
+- **Sweep scripts**: `sweep-diff.sh` (phase 1a sidecar timing) and
+  `sweep-diff-real.sh` (phase 1b real A/B). Raw data CSVs checked in.
+
 ### v0.3 scaffolding (deferred — kept as honest record)
 
 > **Deferred to v0.4+.** Live-fork via memfd + uffd_wp is tracked in

--- a/README-zh.md
+++ b/README-zh.md
@@ -468,25 +468,30 @@ Roadmap 和正在追踪的工作都在 [GitHub issues](https://github.com/deeple
 版本变更记录:[CHANGELOG.md](./CHANGELOG.md)。
 安全策略与历史漏洞通告:[docs/SECURITY.md](./docs/SECURITY.md)。
 
-**v0.3 在做** —— 不动 Firecracker,把 pause-window 砍下来。
-当前测量: 513 MiB 源在 tmpfs 上 163 ms、在 SATA SSD 上 4.26 s,
-详见 [`bench/pause-window/RESULTS-v0.2.md`](./bench/pause-window/RESULTS-v0.2.md)。
-v0.3 叠加三个工程优化(全部基于 Firecracker 已有 API):
+**v0.3 phase 1 已 ship** —— diff-snapshot BRANCH 把源 VM 的暂停
+时间从 **29.3 秒砍到 205 毫秒（143x）**(4 GiB SSD 源,空闲)。
+完整表格和诚实 caveat 见
+[`bench/pause-window/RESULTS-v0.3.md`](./bench/pause-window/RESULTS-v0.3.md);
+60 个 trial 的 sweep 原始数据在 `bench/pause-window/diff-real-sweep-*.csv`。
+通过 `POST /v1/sandboxes/:id/branch` 请求体加 `"diff": true` 开启。
 
-1. **Diff snapshots** —— `enable_diff_snapshots` + `track_dirty_pages`,
-   接进 BRANCH 路径。重复 fan-out 时 5–10x。
-2. **NVMe + io_uring snapshot writer** —— 513 MiB 在 SATA 上从 4s
-   降到 ~400 ms。
-3. **Pre-emptive background snapshot** —— 用 tick 后台刷脏页,
-   pause-window 受 tick 间隔限制,不受源 VM 内存大小限制。
+胜的是源 VM 的**停机时间**,不是 BRANCH API 的总延迟:source
+的 memory.bin cp 在后台和 source 并行跑,然后 diff 窗口关闭、
+source 恢复、diff 合到事先 cp 出来的输出上。源 VM 的 TCP 连接、
+kvmclock、定时器只看到 ~200ms 的 gap 而不是 29 秒。BRANCH API
+本身的总时间还是被 cp 带宽限制——这个 trade-off 对"长跑 agent
+的 live BRANCH"是甜区。
 
-更大的 v0.4+ 候选 —— 基于 memfd + uffd_wp 的 live-fork,目标
-pause ~30 ms 不随内存大小变 —— 现在 defer 到
+限制: v0.3.0 的 diff 模式只支持 sandbox 的**第一次** BRANCH
+(Firecracker 在每次 snapshot/create 都清脏页 bitmap;多次
+BRANCH 需要 per-sandbox shadow file,defer 到 v0.3.1+)。
+设计文档和 defer 原因:
+[`docs/design/diff-snapshots.md`](./docs/design/diff-snapshots.md)。
+
+更大的 v0.4+ 候选——基于 memfd + uffd_wp 的 live-fork——还在
 [issue #101](https://github.com/deeplethe/forkd/issues/101)。
-原因: source 运行后 dirty pages 的同步机制没想清楚,不值得
-为它投几周维护 Firecracker fork。设计文档和 scaffolding
-(`crates/forkd-uffd/`、`firecracker-patch/`、
-`MemoryBackend::Userfault` enum) 留在仓库里作为诚实记录。
+scaffolding (`crates/forkd-uffd/`、`firecracker-patch/`、
+`MemoryBackend::Userfault` enum) 留作起点。
 
 > **0.1.4 包含 daemon 侧安全修复**。`POST /v1/sandboxes` 的
 > `snapshot_tag` 校验缺失(任意路径 → 控制 grandchild VM

--- a/README.md
+++ b/README.md
@@ -542,28 +542,33 @@ Issue-level tracking: [GitHub issues](https://github.com/deeplethe/forkd/issues)
 Release notes per version: [CHANGELOG.md](./CHANGELOG.md).
 Security posture and past advisories: [docs/SECURITY.md](./docs/SECURITY.md).
 
-**v0.3 work in flight** — cutting pause-window without forking
-Firecracker. Today's measurement: 163 ms (tmpfs) to 4.26 s (SATA SSD)
-for a 513 MiB source — see
-[`bench/pause-window/RESULTS-v0.2.md`](./bench/pause-window/RESULTS-v0.2.md).
-v0.3 stacks three engineering wins (all built on the existing
-Firecracker API):
+**v0.3 phase 1 shipped** — diff-snapshot BRANCH cuts source-pause
+window from **29.3 s to 205 ms (143×) on a 4 GiB SSD source** (idle).
+Full table and honest caveats in
+[`bench/pause-window/RESULTS-v0.3.md`](./bench/pause-window/RESULTS-v0.3.md);
+60-trial sweep raw data in `bench/pause-window/diff-real-sweep-*.csv`.
+Opt in by setting `"diff": true` on `POST /v1/sandboxes/:id/branch`.
 
-1. **Diff snapshots** — `enable_diff_snapshots` + `track_dirty_pages`,
-   wired into BRANCH for repeated fan-out. 5–10× on 2nd+ BRANCH.
-2. **NVMe + io_uring snapshot writer** — ~400 ms for 513 MiB vs. 4 s
-   on SATA today.
-3. **Pre-emptive background snapshot** — pause-window bounded by tick
-   interval, not by source memory size.
+The win is the source's **downtime**, not the total BRANCH API
+latency: a background `cp` of the source's memory.bin runs in
+parallel with the source itself, then the diff window closes,
+source resumes, the diff is merged onto the pre-copied output.
+Source TCP connections, kvmclock, and timers see a ~200 ms gap
+instead of 29 s. Total BRANCH API time is still bandwidth-bound
+on the cp; the trade-off favors live BRANCH from a long-running
+agent.
 
-The bigger v0.4+ candidate, live-fork via memfd + uffd_wp targeting
-~30 ms pause regardless of memory size, is tracked in
-[issue #101](https://github.com/deeplethe/forkd/issues/101). It's
-deferred because the source-divergence sync mechanism hasn't been
-sketched concretely enough to commit to weeks of Firecracker fork
-maintenance. Design doc + scaffolding (`crates/forkd-uffd/`,
-`firecracker-patch/`, `MemoryBackend::Userfault` enum) stay in the
-repo as honest record.
+Restrictions: diff mode is valid only for the first BRANCH per
+sandbox in v0.3.0 (Firecracker's dirty bitmap is cleared on every
+snapshot/create; multi-BRANCH support needs a per-sandbox shadow
+file, deferred to v0.3.1+). Phase 1's design and the deferral
+reasoning: [`docs/design/diff-snapshots.md`](./docs/design/diff-snapshots.md).
+
+The bigger v0.4+ candidate, live-fork via memfd + uffd_wp, is
+tracked in [issue #101](https://github.com/deeplethe/forkd/issues/101).
+Scaffolding (`crates/forkd-uffd/`, `firecracker-patch/`,
+`MemoryBackend::Userfault` enum) stays as a starting point if/when
+the cost-benefit changes.
 
 > **0.1.4 contains daemon security fixes.** Two HIGH-class
 > validation gaps in `POST /v1/sandboxes` (path-traversal via

--- a/docs/INTEGRATION-BOXLITE.md
+++ b/docs/INTEGRATION-BOXLITE.md
@@ -140,42 +140,39 @@ this whole project is named after.
 
 ### What's in flight on the forkd side
 
-The motivating measurement is in
-[`bench/pause-window/RESULTS-v0.2.md`](../bench/pause-window/RESULTS-v0.2.md):
-pause-window is storage-bound and ranges from 163 ms (tmpfs) to 4.26 s
-(SATA SSD) for a 513 MiB source. v0.3 picks engineering wins that
-stack and don't require forking Firecracker:
+**v0.3 phase 1 just shipped.** Diff-snapshot BRANCH cuts source-pause
+window from 29.3 s to 205 ms (**143×**) on a 4 GiB SSD idle source —
+60-trial sweep in
+[`bench/pause-window/RESULTS-v0.3.md`](../bench/pause-window/RESULTS-v0.3.md).
+Source TCP connections, kvmclock, and timers see a ~200 ms gap
+instead of seconds. Restriction: v0.3.0 supports diff for the first
+BRANCH per sandbox; multi-BRANCH support (per-sandbox shadow file)
+is deferred to v0.3.1+.
 
-- **Diff snapshots** — wire forkd's BRANCH path to use Firecracker's
-  existing `enable_diff_snapshots` + `track_dirty_pages`. Repeated
-  fan-out from the same source only writes pages dirtied since the
-  last snapshot. Expected 5-10x on the 2nd+ BRANCH.
-- **NVMe + io_uring snapshot writer** — daemon flag that uses
-  io_uring for memory.bin writes when available. Expected SSD 10×+
-  (~400 ms for 513 MiB, vs. 4.26 s on SATA today).
+Remaining v0.3 engineering wins, none of which require a Firecracker
+fork:
+
+- **NVMe + io_uring snapshot writer** — daemon flag for memory.bin
+  writes. Expected SSD 10×+ on the underlying full-copy path.
 - **Pre-emptive background snapshot** — background thread flushes
-  dirty pages on a 1 s tick; at BRANCH, only flush what's dirty since
-  the last tick. Pause window bounded by tick interval regardless of
-  source size.
+  dirty pages on a 1 s tick; at BRANCH, only flush what's dirty
+  since the last tick. Bounds pause-window regardless of source
+  size, including non-first BRANCHes.
 - **Cross-system benchmark** — same hardware, same recipes, forkd
-  v0.2 / v0.3 + boxlite (when shipped) + CubeSandbox + Modal-style
-  baseline. Measurement worth publishing on its own.
+  v0.3 + boxlite (when shipped) + CubeSandbox + Modal-style
+  baseline. The 143× number deserves a head-to-head story.
 
 The original v0.3 plan was a memfd + uffd_wp live-fork architecture
 targeting ~30 ms pause regardless of memory size. We deferred that to
-v0.4+ because (a) the source-divergence sync mechanism hasn't been
+v0.4+ because (a) the source-divergence sync mechanism hadn't been
 sketched concretely enough to commit weeks to maintaining a
 Firecracker fork, and (b) the engineering wins above get most of the
-perceived value (sub-second pause on commodity SSD) at a fraction of
-the cost. The deferral is tracked in
+perceived value at a fraction of the cost — phase 1's 143× confirms
+that intuition. The deferral is tracked in
 [issue #101](https://github.com/deeplethe/forkd/issues/101); the
 scaffolding (design doc, `forkd-uffd` handshake crate,
-`firecracker-patch/`) stays in the repo as honest record.
-
-Mentioning this here for the same reason boxlite's docs would mention
-**its** v-next work — most of the technical conversation between the
-two projects is going to be about what's about to ship, not what's
-shipped.
+`firecracker-patch/`) stays in the repo as honest record + revival
+starting point.
 
 ## Integration patterns
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,16 +39,17 @@ from that earlier plan (the design doc, `crates/forkd-uffd/`,
 `MemoryBackend::Userfault` enum, `firecracker-patch/`) is preserved
 as record.
 
-| Phase | What | Expected win | ETA |
+| Phase | What | Measured / expected | Status |
 |---|---|---|---|
-| 1 | **Diff snapshots.** Firecracker already supports `enable_diff_snapshots: true` + `track_dirty_pages`. Wire forkd's BRANCH path to take diff snapshots when a parent exists for the source, so repeated fan-out from the same source only writes pages dirtied since the last snapshot. | 5–10x on 2nd+ BRANCH from the same source. Typical agent fan-out (1 source, N children, fork after some work) hits this case. | 3–5 days |
-| 2 | **NVMe + io_uring snapshot writer.** Document the storage-tier choice, ship a daemon flag that uses io_uring for the memory.bin write when available. NVMe + io_uring already approximates what's achievable without changing the snapshot algorithm. | SSD 10×+ (~400 ms for 513 MiB, vs. 4.26 s today on SATA). | 1 week incl. measurement |
-| 3 | **Pre-emptive background snapshot.** Background thread writes source's dirty pages to a staging memory.bin on a tick (1 s default). At BRANCH, only flush what's dirty since the last tick. Source's pause window becomes O(tick) instead of O(source memory). | Pause window bounded by tick interval (~50 ms for 1 s tick on a typical workload) regardless of source size. | 1–2 weeks |
-| 4 | **Measurement + RESULTS-v0.3.md.** A/B numbers for each phase plus the stacked combo. Reuses the v0.2 bench harness. | Documentation. | 3 days |
+| 1 | **Diff snapshots.** `POST /v1/sandboxes/:id/branch` with `"diff": true`. Parallel cp + Diff during pause + apply on resume. | **Source pause 29.3 s → 205 ms (143×) on 4 GiB SSD; 1.19 s → 190 ms (6.3×) on tmpfs.** First-BRANCH-only in v0.3.0; phase 1d (per-sandbox shadow) lifts that. | **Shipped (PR #102).** See [`docs/design/diff-snapshots.md`](./design/diff-snapshots.md) + [`bench/pause-window/RESULTS-v0.3.md`](../bench/pause-window/RESULTS-v0.3.md). |
+| 2 | **NVMe + io_uring snapshot writer.** Daemon flag for memory.bin writes. Targets the underlying full-copy path (still bottlenecks total BRANCH API latency on SSD even with diff mode). | Expected SSD 10×+ on the full-copy backbone. | Pending. |
+| 3 | **Pre-emptive background snapshot.** Background thread flushes dirty pages on a 1 s tick; at BRANCH, only flush what's dirty since the last tick. Bounds pause-window regardless of source size, including non-first BRANCHes. | Expected pause ≈ tick interval. | Pending. |
+| 4 | **Measurement + RESULTS-v0.3.md.** A/B numbers for each phase plus the stacked combo. | Phase 1 measured (60 trials, 5 sizes × 2 backends × 2 modes × 3 trials). Phase 2/3 measurement pending. | Phase 1 done. |
 
-Phases 1 and 2 are independently shippable. Phase 3 builds on phase 1's dirty-tracking
-plumbing. The combination should reduce typical-workflow pause-window from seconds to
-tens of milliseconds without changing the trust story (still vanilla Firecracker).
+Phase 1 covered forkd's killer use case (live BRANCH from a long-running source, where
+source downtime matters more than total API latency). Phases 2 and 3 close the gap for
+the remaining workloads (multi-BRANCH source, total-API-latency-sensitive callers).
+The combination keeps the trust story unchanged (still vanilla Firecracker).
 
 **Out of scope for v0.3.** Live-fork via memfd + uffd_wp (deferred, see
 [#101](https://github.com/deeplethe/forkd/issues/101)). Cross-host live branching


### PR DESCRIPTION
Follow-up to PR #102 (v0.3 phase 1 shipped). Updates the front-door docs so the headline number — **source pause 29.3 s → 205 ms (143×) on 4 GiB SSD** — is visible without hunting through ``RESULTS-v0.3.md``.

## Files
- ``README.md`` + ``README-zh.md``: 'v0.3 in flight' → 'v0.3 phase 1 shipped' with the 143× number, the honest trade-off (source downtime drops, total API latency unchanged), and the first-BRANCH-only restriction.
- ``CHANGELOG.md``: Adds the v0.3 phase 1 entry directly above the deferred-scaffolding banner so readers see what landed first.
- ``docs/ROADMAP.md``: Phase 1 marked Shipped with measured numbers in the Status column; phases 2 (NVMe + io_uring) and 3 (pre-emptive background snapshot) stay Pending.
- ``docs/INTEGRATION-BOXLITE.md``: 'What's in flight' subsection updated for Wednesday's Dorian conversation — phase 1's measured 143× is now the lead.

No code changes. CI should be fmt + clippy + tests pass (no Rust touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)