### PR TITLE
release: v0.3.0 — diff snapshots, 6-143x BRANCH pause reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ Notable changes per release. forkd follows [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 1.0; until then, the minor version can break compatibility.
 
-## Unreleased — 0.1.5 (in flight)
+## 0.3.0 — 2026-05-19
+
+**Headline: source-pause window for BRANCH drops 6-143× depending on workload.**
+Idle 4 GiB SSD source: 29 s → 205 ms = 143×.
+Typical agent workload (30-300 MiB dirty footprint on 2 GiB source): 6-15×.
+Crossover at ~65 % source RAM dirty. Honest curve and practical
+guidance in
+[`bench/pause-window/RESULTS-v0.3.md`](./bench/pause-window/RESULTS-v0.3.md).
+
+This release also bundles v0.2.5's prewarm fix (#100) — variance
+reduction for BRANCH pause on cold-cache hits, sandbox-creation
+trade-off — and the v0.3-cycle scaffolding for the deferred live-fork
+plan (#101, kept as honest record + revival starting point).
 
 ### v0.3 phase 1: diff snapshots — 4 GiB SSD source pause 29 s → 205 ms (143×)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/deeplethe/forkd"


### PR DESCRIPTION
Workspace version bump 0.1.4 → 0.3.0. CHANGELOG entry promoted from Unreleased to a released 0.3.0 header with today's date.

## What 0.3.0 ships
- v0.3 phase 1: diff snapshots — source pause 29 s → 205 ms (143x best case), 6-15x typical agent workload
- v0.2.5: prewarm fix (variance reduction, cold-cache trade-off)
- v0.3 scaffolding (deferred uffd_wp work, issue #101)

## Headlines for the release notes
- Idle 4 GiB SSD: 29 s → 205 ms = **143x**
- Typical agent workload (30-300 MiB dirty): **6-15x**
- Crossover at ~65 % source RAM dirty

Full curve + practical guidance in bench/pause-window/RESULTS-v0.3.md.

After merge: tag v0.3.0, gh release create, draft release notes pulling from CHANGELOG.