### PR TITLE
feat(mcp): forkd-mcp v0.2.0 — branch_sandbox + v0.3 options (closes #113)

### DIFF
--- a/sdk/mcp/README.md
+++ b/sdk/mcp/README.md
@@ -11,13 +11,23 @@ Once registered, the agent can:
 | Tool | What |
 |---|---|
 | `list_snapshots` | See available parent templates |
-| `spawn_sandboxes` | Fork N children from a template |
+| `create_snapshot` | Build a new snapshot from kernel + rootfs (v0.2.0+) |
+| `spawn_sandboxes` | Fork N children from a template. Accepts `prewarm: bool` (v0.2.0+) |
+| `branch_sandbox` | **Branch a running sandbox into a new tag (v0.2.0+).** Accepts `diff: bool` for v0.3's 6-15× source-pause reduction on typical agent workloads (143× ceiling). |
 | `list_sandboxes` | List live sandboxes |
 | `get_sandbox` | Inspect one sandbox by id |
 | `exec_command` | Run a shell command in a sandbox |
 | `eval_code` | Evaluate Python against the warmed PID-1 |
+| `wait_for_text` | Poll a file in the guest for a marker string (v0.2.0+) |
 | `ping_sandbox` | Health-check a sandbox |
 | `kill_sandbox` | Terminate one sandbox |
+
+The killer one is **`branch_sandbox`**: pause a running agent
+sandbox, snapshot, fan out N children that inherit the source's
+exact state and diverge under copy-on-write. Modal does this as
+their proprietary moat; forkd is the open-source equivalent. See
+[`bench/pause-window/RESULTS-v0.3.md`](../../bench/pause-window/RESULTS-v0.3.md)
+for the measured numbers.
 
 Each tool maps 1:1 onto a forkd-controller REST endpoint
 ([`docs/API.md`](../../docs/API.md)). The server is stateless; the
@@ -76,6 +86,52 @@ claude mcp add forkd --env FORKD_URL=http://127.0.0.1:8889 \
 ```
 
 Verify with `claude mcp list`.
+
+## Register with Cursor
+
+Add to `~/.cursor/mcp.json` (or per-workspace `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "forkd": {
+      "command": "forkd-mcp",
+      "env": {
+        "FORKD_URL": "http://127.0.0.1:8889",
+        "FORKD_TOKEN": "<contents-of-/etc/forkd/token>"
+      }
+    }
+  }
+}
+```
+
+Restart Cursor (or hit "Refresh" on the MCP settings page).
+
+## Register with Cline
+
+In the Cline extension settings, open "MCP Servers" → "Edit MCP
+Settings" and add:
+
+```json
+{
+  "mcpServers": {
+    "forkd": {
+      "command": "forkd-mcp",
+      "env": {
+        "FORKD_URL": "http://127.0.0.1:8889",
+        "FORKD_TOKEN": "<contents-of-/etc/forkd/token>"
+      },
+      "disabled": false,
+      "autoApprove": ["list_snapshots", "list_sandboxes", "get_sandbox", "ping_sandbox"]
+    }
+  }
+}
+```
+
+The `autoApprove` list is read-only tools that don't need
+per-call confirmation. Mutating tools (`spawn_sandboxes`,
+`branch_sandbox`, `exec_command`, `kill_sandbox`,
+`create_snapshot`) always prompt by default.
 
 ## Smoke test
 

--- a/sdk/mcp/forkd_mcp/server.py
+++ b/sdk/mcp/forkd_mcp/server.py
@@ -60,6 +60,7 @@ def spawn_sandboxes(
     n: int = 1,
     per_child_netns: bool = False,
     memory_limit_mib: int = 256,
+    prewarm: bool = False,
 ) -> list[dict[str, Any]]:
     """Fork N children from a parent snapshot.
 
@@ -70,6 +71,12 @@ def spawn_sandboxes(
             network namespace forkd-child-<i>. The host must have run
             scripts/netns-setup.sh N first.
         memory_limit_mib: Cgroup memory.max for each child.
+        prewarm: When true, the daemon performs a throwaway snapshot
+            immediately after restore to amortize the cold-cache
+            penalty. Relocates the cold cost from the first BRANCH on
+            this sandbox to creation time — useful when you have a
+            BRANCH SLO and fan out N>=3 from the same source. Default
+            false. See bench/pause-window/RESULTS-v0.2.md.
 
     Returns the spawned SandboxInfo objects (one per child) with their
     id, pid, guest_addr, etc.
@@ -79,11 +86,170 @@ def spawn_sandboxes(
         "n": n,
         "per_child_netns": per_child_netns,
         "memory_limit_mib": memory_limit_mib,
+        "prewarm": prewarm,
     }
     with _client() as c:
         r = c.post("/v1/sandboxes", json=body)
         r.raise_for_status()
         return r.json()
+
+
+@mcp.tool()
+def branch_sandbox(
+    sandbox_id: str,
+    tag: str | None = None,
+    diff: bool = False,
+    measure_diff: bool = False,
+) -> dict[str, Any]:
+    """Branch a running sandbox into a new snapshot.
+
+    Pauses the source sandbox briefly, snapshots its memory + vCPU
+    state, and resumes the source. The resulting snapshot is a new
+    tag that any later spawn_sandboxes call can use as its
+    snapshot_tag — fan out N children that all inherit the source's
+    exact state at branch time.
+
+    This is forkd's core primitive. Modal does this as their
+    proprietary moat; forkd is the open-source equivalent.
+
+    Args:
+        sandbox_id: Id of the source sandbox (see list_sandboxes).
+        tag: Optional name for the new snapshot. When unset the
+            daemon generates `branch-<sandbox-id>-<unix-ts>`.
+        diff: When true (v0.3+), use Firecracker's Diff snapshot
+            mode instead of writing the full memory.bin under pause.
+            The user-visible source-pause window collapses to the
+            diff write (~200 ms idle source, 6-15x speedup on
+            typical agent workloads, up to 143x ceiling on 4 GiB SSD
+            idle source). Multi-BRANCH supported in v0.3.1+ via the
+            previous-output chain. See
+            bench/pause-window/RESULTS-v0.3.md.
+        measure_diff: Measurement-only hook. Take a Diff snapshot
+            inside the existing Full pause to report what diff
+            would have cost, without changing semantics. Mutually
+            exclusive with `diff` (400 if both set).
+
+    Returns SnapshotInfo: tag, dir, pause_ms, plus diff_ms /
+    diff_physical_bytes / diff_logical_bytes when diff or
+    measure_diff was set.
+    """
+    body: dict[str, Any] = {}
+    if tag is not None:
+        body["tag"] = tag
+    if diff:
+        body["diff"] = True
+    if measure_diff:
+        body["measure_diff"] = True
+    with _client() as c:
+        r = c.post(f"/v1/sandboxes/{sandbox_id}/branch", json=body)
+        r.raise_for_status()
+        return r.json()
+
+
+@mcp.tool()
+def create_snapshot(
+    tag: str,
+    kernel: str,
+    rootfs: str,
+    rw: bool = False,
+    tap: str | None = None,
+    boot_wait_secs: int = 10,
+) -> dict[str, Any]:
+    """Build a parent snapshot from a kernel + rootfs.
+
+    Boots a fresh VM with the given kernel + rootfs, waits
+    `boot_wait_secs` for the guest to settle, snapshots it, and
+    registers the snapshot under `tag` so later spawn_sandboxes
+    calls can fork children from it.
+
+    Args:
+        tag: Name to register the snapshot under (alnum + dash/
+            underscore, 1-64 chars).
+        kernel: Host path to a vmlinux kernel image.
+        rootfs: Host path to a rootfs image (.ext4 for writable,
+            .squashfs for read-only).
+        rw: When true, mount the rootfs read-write. Auto-enabled
+            for .ext4 paths.
+        tap: Optional host tap device to attach as guest eth0
+            (create with scripts/host-tap.sh).
+        boot_wait_secs: Seconds to wait for the guest to settle
+            before snapshotting. Bumped to 30+ for snapshots that
+            need to warm up large Python packages.
+
+    Returns SnapshotInfo. The snapshot is durable across daemon
+    restarts.
+    """
+    body: dict[str, Any] = {
+        "tag": tag,
+        "kernel": kernel,
+        "rootfs": rootfs,
+        "rw": rw,
+        "boot_wait_secs": boot_wait_secs,
+    }
+    if tap is not None:
+        body["tap"] = tap
+    with _client() as c:
+        r = c.post("/v1/snapshots", json=body)
+        r.raise_for_status()
+        return r.json()
+
+
+@mcp.tool()
+def wait_for_text(
+    sandbox_id: str,
+    path: str,
+    marker: str,
+    timeout_secs: float = 60,
+    poll_interval_ms: int = 200,
+) -> dict[str, Any]:
+    """Poll a file inside a sandbox until it contains a marker string.
+
+    Common pattern: agent writes its progress to a stdout log inside
+    the guest; the orchestrator (you, the MCP client) polls until a
+    marker like "READY_TO_BRANCH" appears, then triggers branch.
+    Avoids busy-waiting from outside the daemon's exec round-trip.
+
+    Args:
+        sandbox_id: Target sandbox.
+        path: Absolute path inside the guest of the file to poll.
+        marker: Substring to wait for. Returned as-is when found.
+        timeout_secs: Max wall-clock seconds to wait. Default 60.
+        poll_interval_ms: How often to re-check. Default 200 ms.
+
+    Returns: {"found": bool, "elapsed_ms": int, "last_excerpt": str}.
+    When found is false, last_excerpt contains the last ~256 bytes
+    of the file so you can see what's actually being written.
+    """
+    import time
+
+    deadline = time.monotonic() + timeout_secs
+    last_excerpt = ""
+    started = time.monotonic()
+    while time.monotonic() < deadline:
+        # Use exec_command for one-shot read; daemon's exec returns
+        # stdout+exit, and a short tail of the target file is cheap.
+        with _client() as c:
+            r = c.post(
+                f"/v1/sandboxes/{sandbox_id}/exec",
+                json={
+                    "args": ["sh", "-c", f"tail -c 4096 {path} 2>/dev/null || true"],
+                    "timeout_secs": 5,
+                },
+            )
+            r.raise_for_status()
+            last_excerpt = r.json().get("stdout", "") or ""
+            if marker in last_excerpt:
+                return {
+                    "found": True,
+                    "elapsed_ms": int((time.monotonic() - started) * 1000),
+                    "last_excerpt": last_excerpt[-256:],
+                }
+        time.sleep(poll_interval_ms / 1000)
+    return {
+        "found": False,
+        "elapsed_ms": int((time.monotonic() - started) * 1000),
+        "last_excerpt": last_excerpt[-256:],
+    }
 
 
 @mcp.tool()

--- a/sdk/mcp/pyproject.toml
+++ b/sdk/mcp/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "forkd-mcp"
-version = "0.1.0"
-description = "Model Context Protocol server for forkd microVM sandboxes"
+version = "0.2.0"
+description = "Model Context Protocol server for forkd microVM sandboxes (BRANCH, diff snapshots, prewarm)"
 readme = "README.md"
 authors = [{name = "Deeplethe", email = "info@deeplethe.com"}]
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Closes #113 (item 1 of [meta #112](https://github.com/deeplethe/forkd/issues/112)).

## What

Adds the killer tool v0.1.0 was missing: `branch_sandbox`. Plus v0.3-era options and an agent-friendly polling helper.

### New tools

- **`branch_sandbox(id, tag, diff, measure_diff)`** — pause + snapshot + resume a running sandbox. The flagship primitive. With `diff: true` (v0.3+), source-pause collapses to sub-second.
- **`create_snapshot(tag, kernel, rootfs, ...)`** — `POST /v1/snapshots` wrapper.
- **`wait_for_text(id, path, marker, timeout, poll_interval)`** — poll a guest file for a marker string. Common agent orchestration pattern.

### Updated tools

- **`spawn_sandboxes`** gains `prewarm: bool` to amortize cold-cache penalty.

### Bumps + publish

- `sdk/mcp/pyproject.toml`: 0.1.0 → 0.2.0
- Tag `mcp-v0.2.0` after merge will trigger publish-pypi-mcp.yml

### README

- Tool table grows with new tools + v0.3 context.
- Adds Cursor + Cline registration sections.
- Killer-feature paragraph points at RESULTS-v0.3.md.

## Smoke test

\`\`\`
$ python3.13 -c 'import asyncio; from forkd_mcp.server import mcp; tools = asyncio.run(mcp.list_tools()); print(len(tools))'
11
\`\`\`

All 11 tools register cleanly on dev box.

## Next steps

After merge: tag `mcp-v0.2.0` → publish to PyPI → users can `pip install forkd-mcp==0.2.0` and `claude mcp add forkd -- forkd-mcp`.