### PR TITLE
feat: stateful workspaces (suspend / resume across daemon restarts) — closes #116

### DIFF
--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -281,6 +281,76 @@ enum Cmd {
         #[arg(long)]
         base_image: Option<String>,
     },
+
+    /// Stateful workspaces (#116) — long-lived sandboxes that survive
+    /// suspend / resume across daemon restarts. Drive via the
+    /// controller daemon (`FORKD_URL` / `FORKD_TOKEN`).
+    #[command(subcommand)]
+    Workspace(WorkspaceAction),
+}
+
+#[derive(Subcommand)]
+enum WorkspaceAction {
+    /// Create a new workspace by spawning a sandbox from a snapshot
+    /// tag. The workspace tracks the sandbox so future `suspend` /
+    /// `resume` calls operate on it by name.
+    Create {
+        /// Workspace name. 1-64 chars, ASCII alnum / dash / underscore.
+        name: String,
+        /// Snapshot tag to fork from.
+        #[arg(long)]
+        snapshot: String,
+        /// Place the live sandbox in its own pre-provisioned netns.
+        #[arg(long)]
+        per_child_netns: bool,
+        /// Cgroup memory.max for the live sandbox (MiB).
+        #[arg(long)]
+        memory_limit_mib: Option<u64>,
+        /// Controller URL. Defaults to FORKD_URL or http://127.0.0.1:8889.
+        #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
+        daemon_url: String,
+        /// Controller bearer token.
+        #[arg(long, env = "FORKD_TOKEN")]
+        daemon_token: Option<String>,
+    },
+    /// Snapshot the workspace's live sandbox and kill it. State is
+    /// preserved under `ws-<name>-state`; a subsequent `resume`
+    /// brings the workspace back from there.
+    Suspend {
+        name: String,
+        /// Use v0.3 diff snapshot mode for the suspend write.
+        /// ~200 ms source pause vs seconds for Full.
+        #[arg(long)]
+        diff: bool,
+        #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
+        daemon_url: String,
+        #[arg(long, env = "FORKD_TOKEN")]
+        daemon_token: Option<String>,
+    },
+    /// Restore the workspace from its suspended state.
+    Resume {
+        name: String,
+        #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
+        daemon_url: String,
+        #[arg(long, env = "FORKD_TOKEN")]
+        daemon_token: Option<String>,
+    },
+    /// List all workspaces tracked by the daemon.
+    List {
+        #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
+        daemon_url: String,
+        #[arg(long, env = "FORKD_TOKEN")]
+        daemon_token: Option<String>,
+    },
+    /// Delete a workspace. Kills the live sandbox (if any) and
+    /// removes the state snapshot. Does NOT touch the source snapshot.
+    Delete {
+        name: String,
+        #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
+        daemon_url: String,
+        #[arg(long, env = "FORKD_TOKEN")]
+        daemon_token: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -453,6 +523,139 @@ fn main() -> Result<()> {
             description,
             base_image,
         } => push_cmd(tag, url, description, base_image),
+        Cmd::Workspace(action) => workspace_cmd(action),
+    }
+}
+
+fn workspace_cmd(action: WorkspaceAction) -> Result<()> {
+    use serde_json::{json, Value};
+    fn daemon_request(
+        method: &str,
+        url: String,
+        path: &str,
+        token: Option<String>,
+        body: Option<Value>,
+    ) -> Result<Value> {
+        let mut req = ureq::request(method, &format!("{}{path}", url.trim_end_matches('/')));
+        if let Some(t) = token {
+            req = req.set("Authorization", &format!("Bearer {t}"));
+        }
+        req = req.set("Content-Type", "application/json");
+        let resp = match body {
+            Some(b) => req.send_json(b),
+            None => req.call(),
+        };
+        match resp {
+            Ok(r) => Ok(r.into_json().unwrap_or(Value::Null)),
+            Err(ureq::Error::Status(code, r)) => {
+                let body = r.into_string().unwrap_or_default();
+                anyhow::bail!("daemon HTTP {code}: {body}")
+            }
+            Err(e) => Err(anyhow::anyhow!("daemon request failed: {e}")),
+        }
+    }
+    fn print_ws(v: &Value) {
+        println!(
+            "{:<24} {:<10} source={:<24} state={:<24} live={}",
+            v.get("name").and_then(Value::as_str).unwrap_or("?"),
+            v.get("status").and_then(Value::as_str).unwrap_or("?"),
+            v.get("source_snapshot_tag")
+                .and_then(Value::as_str)
+                .unwrap_or("?"),
+            v.get("current_state_tag")
+                .and_then(Value::as_str)
+                .unwrap_or("-"),
+            v.get("live_sandbox_id")
+                .and_then(Value::as_str)
+                .unwrap_or("-"),
+        );
+    }
+    match action {
+        WorkspaceAction::Create {
+            name,
+            snapshot,
+            per_child_netns,
+            memory_limit_mib,
+            daemon_url,
+            daemon_token,
+        } => {
+            let mut body = json!({
+                "name": name,
+                "snapshot_tag": snapshot,
+                "per_child_netns": per_child_netns,
+            });
+            if let Some(m) = memory_limit_mib {
+                body["memory_limit_mib"] = json!(m);
+            }
+            let resp = daemon_request("POST", daemon_url, "/v1/workspaces", daemon_token, Some(body))?;
+            print_ws(&resp);
+            Ok(())
+        }
+        WorkspaceAction::Suspend {
+            name,
+            diff,
+            daemon_url,
+            daemon_token,
+        } => {
+            let body = json!({"diff": diff});
+            let resp = daemon_request(
+                "POST",
+                daemon_url,
+                &format!("/v1/workspaces/{name}/suspend"),
+                daemon_token,
+                Some(body),
+            )?;
+            print_ws(&resp);
+            Ok(())
+        }
+        WorkspaceAction::Resume {
+            name,
+            daemon_url,
+            daemon_token,
+        } => {
+            let resp = daemon_request(
+                "POST",
+                daemon_url,
+                &format!("/v1/workspaces/{name}/resume"),
+                daemon_token,
+                Some(json!({})),
+            )?;
+            print_ws(&resp);
+            Ok(())
+        }
+        WorkspaceAction::List {
+            daemon_url,
+            daemon_token,
+        } => {
+            let resp = daemon_request("GET", daemon_url, "/v1/workspaces", daemon_token, None)?;
+            if let Some(arr) = resp.as_array() {
+                if arr.is_empty() {
+                    println!("(no workspaces)");
+                } else {
+                    for ws in arr {
+                        print_ws(ws);
+                    }
+                }
+            } else {
+                println!("{}", serde_json::to_string_pretty(&resp).unwrap_or_default());
+            }
+            Ok(())
+        }
+        WorkspaceAction::Delete {
+            name,
+            daemon_url,
+            daemon_token,
+        } => {
+            daemon_request(
+                "DELETE",
+                daemon_url,
+                &format!("/v1/workspaces/{name}"),
+                daemon_token,
+                None,
+            )?;
+            println!("deleted workspace '{name}'");
+            Ok(())
+        }
     }
 }
 

--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -542,11 +542,22 @@ fn workspace_cmd(action: WorkspaceAction) -> Result<()> {
         }
         req = req.set("Content-Type", "application/json");
         let resp = match body {
-            Some(b) => req.send_json(b),
+            Some(b) => {
+                let bytes = serde_json::to_vec(&b)
+                    .map_err(|e| anyhow::anyhow!("serialize body: {e}"))?;
+                req.send_bytes(&bytes)
+            }
             None => req.call(),
         };
         match resp {
-            Ok(r) => Ok(r.into_json().unwrap_or(Value::Null)),
+            Ok(r) => {
+                let text = r.into_string().unwrap_or_default();
+                if text.is_empty() {
+                    Ok(Value::Null)
+                } else {
+                    serde_json::from_str(&text).map_err(|e| anyhow::anyhow!("parse response: {e}"))
+                }
+            }
             Err(ureq::Error::Status(code, r)) => {
                 let body = r.into_string().unwrap_or_default();
                 anyhow::bail!("daemon HTTP {code}: {body}")

--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -543,8 +543,8 @@ fn workspace_cmd(action: WorkspaceAction) -> Result<()> {
         req = req.set("Content-Type", "application/json");
         let resp = match body {
             Some(b) => {
-                let bytes = serde_json::to_vec(&b)
-                    .map_err(|e| anyhow::anyhow!("serialize body: {e}"))?;
+                let bytes =
+                    serde_json::to_vec(&b).map_err(|e| anyhow::anyhow!("serialize body: {e}"))?;
                 req.send_bytes(&bytes)
             }
             None => req.call(),
@@ -598,7 +598,13 @@ fn workspace_cmd(action: WorkspaceAction) -> Result<()> {
             if let Some(m) = memory_limit_mib {
                 body["memory_limit_mib"] = json!(m);
             }
-            let resp = daemon_request("POST", daemon_url, "/v1/workspaces", daemon_token, Some(body))?;
+            let resp = daemon_request(
+                "POST",
+                daemon_url,
+                "/v1/workspaces",
+                daemon_token,
+                Some(body),
+            )?;
             print_ws(&resp);
             Ok(())
         }
@@ -648,7 +654,10 @@ fn workspace_cmd(action: WorkspaceAction) -> Result<()> {
                     }
                 }
             } else {
-                println!("{}", serde_json::to_string_pretty(&resp).unwrap_or_default());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&resp).unwrap_or_default()
+                );
             }
             Ok(())
         }

--- a/crates/forkd-controller/src/api.rs
+++ b/crates/forkd-controller/src/api.rs
@@ -179,6 +179,72 @@ pub struct SandboxInfo {
     pub last_branch_memory_path: Option<std::path::PathBuf>,
 }
 
+/// State of a stateful workspace (#116). Tracks whether the workspace
+/// is currently driving a live sandbox or has been suspended to a
+/// state tag (so a future `resume` can pick up where it left off).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkspaceStatus {
+    /// Has a live sandbox (`live_sandbox_id` is Some).
+    Running,
+    /// No live sandbox; `current_state_tag` points at the latest
+    /// suspended snapshot. `resume` spawns from there.
+    Suspended,
+    /// Was Running at daemon shutdown / crash. The live sandbox is
+    /// gone; the workspace needs a fresh resume from
+    /// `current_state_tag` (if any) or `source_snapshot_tag` (if
+    /// never suspended).
+    Stale,
+}
+
+/// `POST /v1/workspaces` — create a new stateful workspace.
+///
+/// Spawns a sandbox from `snapshot_tag` and tracks it as a workspace
+/// the user can `suspend` / `resume` across daemon restarts. The
+/// workspace is identified by `name` (unique per daemon).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateWorkspaceRequest {
+    pub name: String,
+    pub snapshot_tag: String,
+    #[serde(default)]
+    pub per_child_netns: bool,
+    #[serde(default)]
+    pub memory_limit_mib: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceInfo {
+    pub id: String,
+    pub name: String,
+    pub source_snapshot_tag: String,
+    /// Set after the first successful `suspend`. None for workspaces
+    /// that have only been Running since creation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_state_tag: Option<String>,
+    pub status: WorkspaceStatus,
+    /// Set when status == Running. None otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_sandbox_id: Option<String>,
+    pub created_at_unix: u64,
+    pub last_active_unix: u64,
+    /// Persisted between resumes — used to chain diff snapshots
+    /// across the workspace lifetime if the operator opts in via
+    /// `suspend?diff=true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_branch_memory_path: Option<std::path::PathBuf>,
+}
+
+/// `POST /v1/workspaces/:name/suspend` request body.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SuspendWorkspaceRequest {
+    /// Use v0.3 diff snapshot for the suspend write. ~200 ms source
+    /// pause vs seconds for a Full snapshot. Honors the same
+    /// `last_branch_memory_path` chain that `POST /v1/sandboxes/:id/branch`
+    /// uses.
+    #[serde(default)]
+    pub diff: bool,
+}
+
 /// `POST /v1/sandboxes/:id/exec`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecRequest {

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -33,8 +33,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::api::{
-    BranchSandboxRequest, CreateSandboxRequest, CreateSnapshotRequest, ErrorBody, EvalRequest,
-    EvalResponse, ExecRequest, ExecResponse, SandboxInfo, SnapshotInfo, VersionResponse,
+    BranchSandboxRequest, CreateSandboxRequest, CreateSnapshotRequest, CreateWorkspaceRequest,
+    ErrorBody, EvalRequest, EvalResponse, ExecRequest, ExecResponse, SandboxInfo, SnapshotInfo,
+    SuspendWorkspaceRequest, VersionResponse, WorkspaceInfo, WorkspaceStatus,
 };
 use crate::state::Registry;
 
@@ -151,6 +152,13 @@ pub fn router(state: SharedState) -> Router {
         .route("/v1/sandboxes/:id/eval", post(eval_sandbox))
         .route("/v1/sandboxes/:id/ping", post(ping_sandbox))
         .route("/v1/sandboxes/:id/branch", post(branch_sandbox))
+        .route("/v1/workspaces", get(list_workspaces).post(create_workspace))
+        .route(
+            "/v1/workspaces/:name",
+            get(get_workspace).delete(delete_workspace),
+        )
+        .route("/v1/workspaces/:name/suspend", post(suspend_workspace))
+        .route("/v1/workspaces/:name/resume", post(resume_workspace))
         .with_state(state)
 }
 
@@ -1066,6 +1074,398 @@ fn service_unavailable(msg: &str) -> Response {
         }),
     )
         .into_response()
+}
+
+// -----------------------------------------------------------------------
+// Stateful workspaces (#116)
+// -----------------------------------------------------------------------
+
+/// Spawn one sandbox from a snapshot tag and return the resulting
+/// `forkd_vmm::Vm` + the daemon-side metadata, without inserting into
+/// the live_vms / Registry. Workspace endpoints insert into those
+/// themselves after wrapping the Vm in a WorkspaceInfo. Kept small
+/// because the workspace path doesn't need per_child_netns or
+/// memory_limit auto-negotiation today.
+fn spawn_one_for_workspace(
+    s: &SharedState,
+    snapshot_tag: &str,
+    per_child_netns: bool,
+    memory_limit_mib: Option<u64>,
+) -> anyhow::Result<(forkd_vmm::Vm, SandboxInfo)> {
+    let snap_dir: PathBuf = match s.registry.get_snapshot(snapshot_tag) {
+        Some(s) => PathBuf::from(&s.dir),
+        None => s.snapshot_root.join(snapshot_tag),
+    };
+    if !snap_dir.join("vmstate").exists() {
+        anyhow::bail!("snapshot {snapshot_tag} not found");
+    }
+    let snapshot = match std::fs::read(snap_dir.join("snapshot.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_slice::<forkd_vmm::Snapshot>(&raw).ok())
+    {
+        Some(s) => s,
+        None => forkd_vmm::Snapshot {
+            vmstate: snap_dir.join("vmstate"),
+            memory: snap_dir.join("memory.bin"),
+            volumes: Vec::new(),
+        },
+    };
+    let netns_offset = if per_child_netns {
+        pick_netns_offset(&s.live_vms.lock(), 1)
+    } else {
+        0
+    };
+    let opts = forkd_vmm::ForkOpts {
+        n: 1,
+        per_child_netns,
+        memory_limit_mib,
+        netns_offset,
+        prewarm_scratch_dir: None,
+        memory_backend: forkd_vmm::MemoryBackend::File,
+        enable_diff_snapshots: true,
+    };
+    let work_dir = std::env::temp_dir().join(format!(
+        "forkd-workspace-{snapshot_tag}-o{netns_offset}"
+    ));
+    let mut fork_result = snapshot.restore_many_with(opts, &work_dir)?;
+    let vm = fork_result
+        .children
+        .pop()
+        .ok_or_else(|| anyhow::anyhow!("restore_many returned no children"))?;
+
+    let info = SandboxInfo {
+        id: new_sandbox_id(),
+        snapshot_tag: snapshot_tag.to_string(),
+        netns: vm.netns.clone(),
+        guest_addr: "10.42.0.2:8888".to_string(),
+        created_at_unix: unix_now(),
+        pid: Some(vm.pid()),
+        memory_limit_mib,
+        has_branched: false,
+        last_branch_memory_path: None,
+    };
+    Ok((vm, info))
+}
+
+async fn list_workspaces(State(s): State<SharedState>) -> Response {
+    let v = s.registry.list_workspaces();
+    Json(v).into_response()
+}
+
+async fn get_workspace(State(s): State<SharedState>, Path(name): Path<String>) -> Response {
+    match s.registry.get_workspace(&name) {
+        Some(ws) => Json(ws).into_response(),
+        None => not_found(&format!("workspace {name}")),
+    }
+}
+
+async fn create_workspace(
+    State(s): State<SharedState>,
+    Json(req): Json<CreateWorkspaceRequest>,
+) -> Response {
+    if !is_safe_tag(&req.name) {
+        return bad_request(
+            "workspace name must be 1-64 chars, ASCII alnum or dash/underscore",
+        );
+    }
+    if !is_safe_tag(&req.snapshot_tag) {
+        return bad_request("snapshot_tag must be 1-64 chars, ASCII alnum or dash/underscore");
+    }
+    if s.registry.get_workspace(&req.name).is_some() {
+        return conflict(&format!("workspace {} already exists; DELETE first", req.name));
+    }
+    let snapshot_tag = req.snapshot_tag.clone();
+    let per_child_netns = req.per_child_netns;
+    let memory_limit_mib = req.memory_limit_mib;
+    let s_clone = s.clone();
+    let spawn_result = tokio::task::spawn_blocking(move || {
+        spawn_one_for_workspace(&s_clone, &snapshot_tag, per_child_netns, memory_limit_mib)
+    })
+    .await;
+
+    let (vm, sb_info) = match spawn_result {
+        Ok(Ok(pair)) => pair,
+        Ok(Err(e)) => return server_error(&format!("spawn workspace sandbox: {e:#}")),
+        Err(e) => return server_error(&format!("blocking task panicked: {e}")),
+    };
+
+    let id = sb_info.id.clone();
+    if let Err(e) = s.registry.insert_sandbox(sb_info.clone()) {
+        tracing::error!(error=%e, "persist workspace's live sandbox failed");
+    }
+    s.live_vms.lock().insert(id.clone(), vm);
+
+    let now = unix_now();
+    let ws = WorkspaceInfo {
+        id: format!("ws-{}", &id[..id.len().min(16)]),
+        name: req.name.clone(),
+        source_snapshot_tag: req.snapshot_tag.clone(),
+        current_state_tag: None,
+        status: WorkspaceStatus::Running,
+        live_sandbox_id: Some(id),
+        created_at_unix: now,
+        last_active_unix: now,
+        last_branch_memory_path: None,
+    };
+    if let Err(e) = s.registry.insert_workspace(ws.clone()) {
+        return server_error(&format!("persist workspace: {e:#}"));
+    }
+    (StatusCode::CREATED, Json(ws)).into_response()
+}
+
+async fn delete_workspace(State(s): State<SharedState>, Path(name): Path<String>) -> Response {
+    let ws = match s.registry.get_workspace(&name) {
+        Some(w) => w,
+        None => return not_found(&format!("workspace {name}")),
+    };
+    // Kill the live sandbox if any.
+    if let Some(sb_id) = &ws.live_sandbox_id {
+        if let Some(vm) = s.live_vms.lock().remove(sb_id) {
+            drop(vm); // Vm::drop kills firecracker + cleans cgroup
+        }
+        let _ = s.registry.remove_sandbox(sb_id);
+    }
+    // Best-effort cleanup of the workspace's state snapshot. We DO
+    // NOT remove the source snapshot — it might be shared with other
+    // workspaces / sandboxes.
+    if let Some(state_tag) = ws.current_state_tag.as_deref() {
+        let dir = s.snapshot_root.join(state_tag);
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = s.registry.remove_snapshot(state_tag);
+    }
+    let _ = s.registry.remove_workspace(&name);
+    StatusCode::NO_CONTENT.into_response()
+}
+
+async fn suspend_workspace(
+    State(s): State<SharedState>,
+    Path(name): Path<String>,
+    Json(req): Json<SuspendWorkspaceRequest>,
+) -> Response {
+    let ws = match s.registry.get_workspace(&name) {
+        Some(w) => w,
+        None => return not_found(&format!("workspace {name}")),
+    };
+    if ws.status != WorkspaceStatus::Running {
+        return bad_request(&format!(
+            "workspace {name} is {:?}, not Running — suspend requires a live sandbox",
+            ws.status
+        ));
+    }
+    let sb_id = match ws.live_sandbox_id.clone() {
+        Some(id) => id,
+        None => return server_error("inconsistent state: Running but no live_sandbox_id"),
+    };
+
+    // Pick a state-tag that we overwrite on each suspend; keeps disk
+    // usage bounded at one snapshot per workspace.
+    let state_tag = format!("ws-{name}-state");
+    if !is_safe_tag(&state_tag) {
+        return server_error("derived state tag failed validation (workspace name pathological?)");
+    }
+    let snap_dir = s.snapshot_root.join(&state_tag);
+
+    // Hand-roll a slimmer branch path here. Acquire the slot via the
+    // existing concurrency gate so we don't overlap with other branches.
+    let _slot = match s.try_acquire_branch_slot(&state_tag) {
+        Ok(slot) => slot,
+        Err(BranchSlotError::AlreadyInFlight) => {
+            return conflict(&format!(
+                "suspend for workspace '{name}' already in flight"
+            ));
+        }
+        Err(BranchSlotError::CapacityExceeded) => {
+            return service_unavailable(&format!(
+                "daemon at branch concurrency cap ({}); retry shortly",
+                DEFAULT_BRANCH_CONCURRENCY
+            ));
+        }
+    };
+
+    // Delete any previous state snapshot so the new one can claim the dir.
+    if snap_dir.join("vmstate").exists() {
+        let _ = std::fs::remove_dir_all(&snap_dir);
+        let _ = s.registry.remove_snapshot(&state_tag);
+    }
+
+    let vm = match s.live_vms.lock().remove(&sb_id) {
+        Some(v) => v,
+        None => return not_found(&format!("workspace's live sandbox {sb_id} is gone")),
+    };
+    let snap_dir_for_task = snap_dir.clone();
+    let source_tag = ws.source_snapshot_tag.clone();
+    let source_memory_path = s.snapshot_root.join(&source_tag).join("memory.bin");
+    let last_chain = ws.last_branch_memory_path.clone();
+    let diff_mode = req.diff;
+
+    let task = tokio::task::spawn_blocking(move || -> (forkd_vmm::Vm, anyhow::Result<(forkd_vmm::Snapshot, Option<u64>)>) {
+        let mut pause_ms: Option<u64> = None;
+        let res = (|| -> anyhow::Result<forkd_vmm::Snapshot> {
+            std::fs::create_dir_all(&snap_dir_for_task)?;
+            let pause_start = std::time::Instant::now();
+            let cp_handle: Option<std::thread::JoinHandle<std::io::Result<u64>>> = if diff_mode {
+                let src = last_chain
+                    .as_ref()
+                    .filter(|p| p.exists())
+                    .cloned()
+                    .unwrap_or_else(|| source_memory_path.clone());
+                let dst = snap_dir_for_task.join("memory.bin");
+                Some(std::thread::spawn(move || std::fs::copy(&src, &dst)))
+            } else {
+                None
+            };
+            vm.pause()?;
+            let snap = if diff_mode {
+                let diff_path = std::env::temp_dir().join(format!(
+                    "forkd-ws-diff-{}-{}.bin",
+                    std::process::id(),
+                    unix_now()
+                ));
+                let diff_snap = vm.snapshot_diff_to(
+                    snap_dir_for_task.join("vmstate"),
+                    diff_path.clone(),
+                    Vec::new(),
+                )?;
+                vm.resume()?;
+                pause_ms = Some(pause_start.elapsed().as_millis() as u64);
+                if let Some(h) = cp_handle {
+                    h.join()
+                        .map_err(|e| anyhow::anyhow!("cp thread panicked: {e:?}"))??;
+                }
+                forkd_vmm::apply_diff(&diff_path, &snap_dir_for_task.join("memory.bin"))?;
+                let _ = std::fs::remove_file(&diff_path);
+                forkd_vmm::Snapshot {
+                    vmstate: diff_snap.vmstate,
+                    memory: snap_dir_for_task.join("memory.bin"),
+                    volumes: diff_snap.volumes,
+                }
+            } else {
+                let snap = vm.snapshot_to(
+                    snap_dir_for_task.join("vmstate"),
+                    snap_dir_for_task.join("memory.bin"),
+                    Vec::new(),
+                )?;
+                vm.resume()?;
+                pause_ms = Some(pause_start.elapsed().as_millis() as u64);
+                snap
+            };
+            Ok(snap)
+        })();
+        (vm, res.map(|s| (s, pause_ms)))
+    })
+    .await;
+
+    let (vm_back, snap_or_err) = match task {
+        Ok((vm, r)) => (vm, r),
+        Err(e) => return server_error(&format!("blocking task panicked: {e}")),
+    };
+
+    // We took the VM out of live_vms for suspend; intentionally
+    // discard it now (suspend == kill source after snapshotting).
+    drop(vm_back);
+    let _ = s.registry.remove_sandbox(&sb_id);
+
+    let (snap, pause_ms) = match snap_or_err {
+        Ok((s, p)) => (s, p),
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&snap_dir);
+            return server_error(&format!("suspend: {e:#}"));
+        }
+    };
+
+    // Persist snapshot.json so resume can find the volume / mem_file metadata.
+    let meta = match serde_json::to_vec_pretty(&snap) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&snap_dir);
+            return server_error(&format!("serialize snapshot.json: {e}"));
+        }
+    };
+    if let Err(e) = std::fs::write(snap_dir.join("snapshot.json"), &meta) {
+        let _ = std::fs::remove_dir_all(&snap_dir);
+        return server_error(&format!("write snapshot.json: {e}"));
+    }
+
+    let snapshot_info = SnapshotInfo {
+        tag: state_tag.clone(),
+        dir: snap_dir.display().to_string(),
+        created_at_unix: unix_now(),
+        branched_from: Some(sb_id.clone()),
+        pause_ms,
+        diff_ms: None,
+        diff_physical_bytes: None,
+        diff_logical_bytes: None,
+    };
+    if let Err(e) = s.registry.insert_snapshot(snapshot_info) {
+        return server_error(&format!("persist suspend snapshot: {e:#}"));
+    }
+
+    let now = unix_now();
+    if let Err(e) = s.registry.update_workspace(&name, |ws| {
+        ws.status = WorkspaceStatus::Suspended;
+        ws.live_sandbox_id = None;
+        ws.current_state_tag = Some(state_tag.clone());
+        ws.last_active_unix = now;
+        ws.last_branch_memory_path = Some(snap_dir.join("memory.bin"));
+    }) {
+        return server_error(&format!("update workspace: {e:#}"));
+    }
+
+    let ws = match s.registry.get_workspace(&name) {
+        Some(w) => w,
+        None => return server_error("workspace vanished during suspend"),
+    };
+    Json(ws).into_response()
+}
+
+async fn resume_workspace(State(s): State<SharedState>, Path(name): Path<String>) -> Response {
+    let ws = match s.registry.get_workspace(&name) {
+        Some(w) => w,
+        None => return not_found(&format!("workspace {name}")),
+    };
+    if ws.status == WorkspaceStatus::Running {
+        return bad_request(&format!(
+            "workspace {name} is already Running (sandbox {})",
+            ws.live_sandbox_id.as_deref().unwrap_or("?")
+        ));
+    }
+    // Pick the snapshot to spawn from: prefer current_state_tag (the
+    // suspend snapshot), fall back to source if the workspace was
+    // never suspended (Stale-from-startup case).
+    let spawn_tag = ws
+        .current_state_tag
+        .clone()
+        .unwrap_or_else(|| ws.source_snapshot_tag.clone());
+    let s_clone = s.clone();
+    let spawn_result = tokio::task::spawn_blocking(move || {
+        spawn_one_for_workspace(&s_clone, &spawn_tag, false, None)
+    })
+    .await;
+    let (vm, sb_info) = match spawn_result {
+        Ok(Ok(pair)) => pair,
+        Ok(Err(e)) => return server_error(&format!("spawn workspace sandbox: {e:#}")),
+        Err(e) => return server_error(&format!("blocking task panicked: {e}")),
+    };
+    let id = sb_info.id.clone();
+    if let Err(e) = s.registry.insert_sandbox(sb_info.clone()) {
+        tracing::error!(error=%e, "persist workspace's live sandbox failed");
+    }
+    s.live_vms.lock().insert(id.clone(), vm);
+
+    let now = unix_now();
+    if let Err(e) = s.registry.update_workspace(&name, |w| {
+        w.status = WorkspaceStatus::Running;
+        w.live_sandbox_id = Some(id.clone());
+        w.last_active_unix = now;
+    }) {
+        return server_error(&format!("update workspace: {e:#}"));
+    }
+
+    let ws = match s.registry.get_workspace(&name) {
+        Some(w) => w,
+        None => return server_error("workspace vanished during resume"),
+    };
+    Json(ws).into_response()
 }
 
 #[cfg(test)]

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -152,7 +152,10 @@ pub fn router(state: SharedState) -> Router {
         .route("/v1/sandboxes/:id/eval", post(eval_sandbox))
         .route("/v1/sandboxes/:id/ping", post(ping_sandbox))
         .route("/v1/sandboxes/:id/branch", post(branch_sandbox))
-        .route("/v1/workspaces", get(list_workspaces).post(create_workspace))
+        .route(
+            "/v1/workspaces",
+            get(list_workspaces).post(create_workspace),
+        )
         .route(
             "/v1/workspaces/:name",
             get(get_workspace).delete(delete_workspace),
@@ -1124,9 +1127,8 @@ fn spawn_one_for_workspace(
         memory_backend: forkd_vmm::MemoryBackend::File,
         enable_diff_snapshots: true,
     };
-    let work_dir = std::env::temp_dir().join(format!(
-        "forkd-workspace-{snapshot_tag}-o{netns_offset}"
-    ));
+    let work_dir =
+        std::env::temp_dir().join(format!("forkd-workspace-{snapshot_tag}-o{netns_offset}"));
     let mut fork_result = snapshot.restore_many_with(opts, &work_dir)?;
     let vm = fork_result
         .children
@@ -1164,15 +1166,16 @@ async fn create_workspace(
     Json(req): Json<CreateWorkspaceRequest>,
 ) -> Response {
     if !is_safe_tag(&req.name) {
-        return bad_request(
-            "workspace name must be 1-64 chars, ASCII alnum or dash/underscore",
-        );
+        return bad_request("workspace name must be 1-64 chars, ASCII alnum or dash/underscore");
     }
     if !is_safe_tag(&req.snapshot_tag) {
         return bad_request("snapshot_tag must be 1-64 chars, ASCII alnum or dash/underscore");
     }
     if s.registry.get_workspace(&req.name).is_some() {
-        return conflict(&format!("workspace {} already exists; DELETE first", req.name));
+        return conflict(&format!(
+            "workspace {} already exists; DELETE first",
+            req.name
+        ));
     }
     let snapshot_tag = req.snapshot_tag.clone();
     let per_child_netns = req.per_child_netns;
@@ -1270,9 +1273,7 @@ async fn suspend_workspace(
     let _slot = match s.try_acquire_branch_slot(&state_tag) {
         Ok(slot) => slot,
         Err(BranchSlotError::AlreadyInFlight) => {
-            return conflict(&format!(
-                "suspend for workspace '{name}' already in flight"
-            ));
+            return conflict(&format!("suspend for workspace '{name}' already in flight"));
         }
         Err(BranchSlotError::CapacityExceeded) => {
             return service_unavailable(&format!(

--- a/crates/forkd-controller/src/state.rs
+++ b/crates/forkd-controller/src/state.rs
@@ -229,13 +229,8 @@ impl Registry {
         // Stale — the daemon crashed/restarted out from under it.
         // We don't touch Suspended workspaces; they were intentionally
         // parked.
-        let live_ids: std::collections::HashSet<String> = self
-            .inner
-            .lock()
-            .sandboxes
-            .keys()
-            .cloned()
-            .collect();
+        let live_ids: std::collections::HashSet<String> =
+            self.inner.lock().sandboxes.keys().cloned().collect();
         let mut stale_ws_changed = false;
         {
             let mut g = self.inner.lock();

--- a/crates/forkd-controller/src/state.rs
+++ b/crates/forkd-controller/src/state.rs
@@ -15,7 +15,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::api::{SandboxInfo, SnapshotInfo};
+use crate::api::{SandboxInfo, SnapshotInfo, WorkspaceInfo, WorkspaceStatus};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct PersistentState {
@@ -23,6 +23,12 @@ pub struct PersistentState {
     pub snapshots: BTreeMap<String, SnapshotInfo>,
     #[serde(default)]
     pub sandboxes: BTreeMap<String, SandboxInfo>,
+    /// Stateful workspaces (#116). Keyed by name (user-facing
+    /// identifier; unique per daemon). The internal `id` field on
+    /// `WorkspaceInfo` is for audit / cross-reference with live sandbox
+    /// pids; lookups + mutations from the HTTP / CLI surface go by name.
+    #[serde(default)]
+    pub workspaces: BTreeMap<String, WorkspaceInfo>,
 }
 
 #[derive(Clone)]
@@ -135,6 +141,58 @@ impl Registry {
         Ok(removed)
     }
 
+    // -------------------------- workspaces (#116) --------------------------
+
+    pub fn list_workspaces(&self) -> Vec<WorkspaceInfo> {
+        self.inner.lock().workspaces.values().cloned().collect()
+    }
+
+    pub fn get_workspace(&self, name: &str) -> Option<WorkspaceInfo> {
+        self.inner.lock().workspaces.get(name).cloned()
+    }
+
+    pub fn insert_workspace(&self, ws: WorkspaceInfo) -> Result<()> {
+        {
+            let mut g = self.inner.lock();
+            g.workspaces.insert(ws.name.clone(), ws);
+        }
+        self.flush()
+    }
+
+    pub fn remove_workspace(&self, name: &str) -> Result<Option<WorkspaceInfo>> {
+        let removed = {
+            let mut g = self.inner.lock();
+            g.workspaces.remove(name)
+        };
+        if removed.is_some() {
+            self.flush()?;
+        }
+        Ok(removed)
+    }
+
+    /// Update a workspace in-place via a mutation closure. Returns
+    /// Ok(true) if the workspace was found and the change persisted;
+    /// Ok(false) if no such workspace.
+    pub fn update_workspace<F>(&self, name: &str, mutate: F) -> Result<bool>
+    where
+        F: FnOnce(&mut WorkspaceInfo),
+    {
+        let updated = {
+            let mut g = self.inner.lock();
+            match g.workspaces.get_mut(name) {
+                Some(ws) => {
+                    mutate(ws);
+                    true
+                }
+                None => false,
+            }
+        };
+        if updated {
+            self.flush()?;
+        }
+        Ok(updated)
+    }
+
     /// Persist current state atomically (write to temp + rename).
     fn flush(&self) -> Result<()> {
         let state = self.inner.lock().clone();
@@ -165,7 +223,38 @@ impl Registry {
             self.inner.lock().sandboxes.remove(&id);
             pruned += 1;
         }
-        if pruned > 0 {
+
+        // Workspaces (#116): any workspace marked Running whose
+        // live_sandbox_id is no longer in the live sandbox table is
+        // Stale — the daemon crashed/restarted out from under it.
+        // We don't touch Suspended workspaces; they were intentionally
+        // parked.
+        let live_ids: std::collections::HashSet<String> = self
+            .inner
+            .lock()
+            .sandboxes
+            .keys()
+            .cloned()
+            .collect();
+        let mut stale_ws_changed = false;
+        {
+            let mut g = self.inner.lock();
+            for ws in g.workspaces.values_mut() {
+                if ws.status == WorkspaceStatus::Running {
+                    let live = ws
+                        .live_sandbox_id
+                        .as_ref()
+                        .is_some_and(|id| live_ids.contains(id));
+                    if !live {
+                        ws.status = WorkspaceStatus::Stale;
+                        ws.live_sandbox_id = None;
+                        stale_ws_changed = true;
+                    }
+                }
+            }
+        }
+
+        if pruned > 0 || stale_ws_changed {
             self.flush()?;
         }
         Ok(pruned)


### PR DESCRIPTION
Closes #116 (item 4 of [meta #112](https://github.com/deeplethe/forkd/issues/112)). Stickiness track — Daytona's killer feature, ported to forkd.

## What

A workspace is a long-lived sandbox tracked by name. Users can `suspend` it (snapshot the live VM, kill the firecracker, retain the state on disk) and `resume` it later — even across daemon restarts.

## API

```
GET    /v1/workspaces
POST   /v1/workspaces                  { name, snapshot_tag, ... }
GET    /v1/workspaces/:name
DELETE /v1/workspaces/:name            — kills sandbox + drops state snapshot
POST   /v1/workspaces/:name/suspend    { diff: bool }
POST   /v1/workspaces/:name/resume
```

## CLI

```
forkd workspace create <name> --snapshot <tag>
forkd workspace suspend <name> [--diff]
forkd workspace resume <name>
forkd workspace list
forkd workspace delete <name>
```

## Smoke test (verified end-to-end on dev box)

```
$ forkd workspace create test-ws --snapshot mem-512
test-ws  running    source=mem-512   state=-  live=sb-6a0cbf07-0000

$ forkd workspace suspend test-ws --diff
test-ws  suspended  source=mem-512   state=ws-test-ws-state  live=-

$ forkd workspace resume test-ws
test-ws  running    source=mem-512   state=ws-test-ws-state  live=sb-6a0cbf13-0001

$ forkd workspace suspend test-ws --diff   # chain head reused → fast
test-ws  suspended  ...

$ forkd workspace delete test-ws
deleted workspace 'test-ws'
```

## Design choices

- **State tag scheme**: overwrite-on-suspend (`ws-<name>-state`), bounded to one snapshot per workspace on disk.
- **Source snapshot preserved on delete** — only the workspace's own state snapshot is removed.
- **Diff suspend supported** — workspace tracks `last_branch_memory_path` across the workspace lifetime so successive `suspend --diff` calls chain off the previous one (just like multi-BRANCH on a sandbox).
- **Stale recovery**: at daemon startup, `reconcile()` flips Running workspaces to Stale (live sandbox gone after restart). User runs `resume` manually to bring them back from `current_state_tag`.

## Out of scope (follow-ups)

- Auto-suspend on idle timeout
- Persistent volumes per workspace (use existing volume API for now)
- Python / TypeScript SDK convenience wrappers