### PR TITLE
probe: multi-BRANCH pause anomaly is user-space CPU in Firecracker (#118)

### DIFF
--- a/bench/pause-window/PROBE-multi-branch-anomaly.md
+++ b/bench/pause-window/PROBE-multi-branch-anomaly.md
@@ -1,0 +1,153 @@
+# Probe: multi-BRANCH pause growth — root-cause attribution
+
+**Date:** 2026-05-20
+**Refs:** RESULTS-v0.3.md § "What's anomalous (TODO: investigate)", issue #118
+
+## TL;DR
+
+The "BRANCH 3-5 pause jumps to 1.3-1.5s" anomaly is **not an IO problem
+and not a syscall problem**. ≥98% of the growth happens in Firecracker's
+**user-space CPU** inside the `/snapshot/create` handler — syscall count
+and total-time-in-syscalls stay roughly constant across BRANCHes while
+wall time grows linearly.
+
+**Direct implication for #118:**
+
+- **Phase 2 (`io_uring` writer)** addresses a different bottleneck
+  (`std::fs::copy` of the base memory file). It will NOT help this
+  anomaly: the `write` and `fsync` calls during `/snapshot/create` are
+  already cheap (~4-9 µs/call), and their count doesn't grow.
+- **Phase 3 (pre-emptive 1 s tick background snapshot)** would ALSO be
+  hit by this anomaly: snapshotting more often = more snapshots
+  taken = the per-snapshot CPU cost climbing into the same slow regime
+  within the first ~10 ticks.
+
+The real fix likely needs Firecracker patches (or a sidestep of
+`/snapshot/create`). See [next steps](#next-steps).
+
+## Reproduction on dev box
+
+`coding-agent-fork-prewarm-v1` snapshot (a prewarmed VM, smaller than
+the original `mem-2048` from RESULTS-v0.3.md). 10 consecutive
+`diff: true` BRANCHes, 3 s gap, single trial.
+
+Raw data: `/tmp/multi-branch-probe-1779263771/summary.csv` on the dev
+box (snippet):
+
+```
+branch_idx,pause_ms,diff_ms,diff_physical_bytes,strace_calls
+1,351,349,1867776,1078
+2,188,187,389120,709
+3,248,246,798720,861
+4,582,580,434176,732
+5,397,395,417792,734
+6,856,854,389120,717
+7,972,970,425984,734
+8,425,422,380928,715
+9,878,875,708608,835
+10,803,801,385024,709
+```
+
+Pattern: BRANCH 1-5 baseline (~188-397 ms); BRANCH 6-10 elevated
+(~425-972 ms). On the original mem-2048 sweep the jump was sharper
+(BRANCH 3 → 1.5 s); on this smaller / prewarmed snapshot it's
+gradual. Same anomaly, different threshold.
+
+## Attribution
+
+### Where the time goes
+
+`diff_ms` (the `/snapshot/create` API call) is within 1-2 ms of
+`pause_ms` for every BRANCH. So:
+
+- `vm.pause()` + `vm.resume()` overhead: ~1-2 ms total, **not the
+  bottleneck**.
+- The entire growth is inside the single `PUT /snapshot/create` call
+  to Firecracker's HTTP server.
+
+### Where it ISN'T going (ruled out)
+
+1. **Not data volume.** `diff_physical_bytes` is *smaller* in slow
+   BRANCHes (300-700 KB) than in fast BRANCH 1 (1.8 MB).
+2. **Not syscall count.** Total syscalls in the FC process per
+   BRANCH stays in a narrow band (709-1078) regardless of wall
+   time.
+3. **Not syscall time.** `strace -c` aggregate time-in-syscalls is
+   3-10 ms per BRANCH (out of 188-972 ms wall) — at most ~2% of
+   wall time, never the dominant cost.
+
+Per-syscall growth between BRANCH 2 (188 ms wall) and BRANCH 7 (972
+ms wall) on the same source:
+
+| syscall | calls B2 / B7 | µs/call B2 → B7 |
+|---|---|---|
+| `write` | 593 / 605 | 4 → 9 |
+| `fsync` | 3 / 3 | 175 → 574 |
+| `lseek` | 57 / 69 | 1 → 7 |
+| `munmap` | 3 / 3 | 8 → 40 |
+| `open` | 2 / 2 | 29 → 85 |
+
+Even with these per-call increases, total syscall time grows
+3.8 ms → 10 ms — accounting for ~6 ms of the 784 ms wall-time
+delta. **The remaining 778 ms is user-space CPU in Firecracker.**
+
+### What this means
+
+The growth is in Firecracker's snapshot-serialization or
+memory-walking logic, not in the kernel or the disk. Candidates we
+couldn't directly profile (no `perf` for kernel 6.14.0-36 on this
+host):
+
+1. **Vec/HashMap walks growing with snapshot count** — internal
+   metadata structures in FC that get appended on every snapshot.
+2. **VMA fragmentation** — each diff snapshot maps a fresh memory
+   file. mmap walks linear in VMAs, but munmap is in the syscall
+   path (only 4.8× growth, not enough alone).
+3. **KVM bitmap-walk cost growing with ever-dirtied page count** —
+   but this is a kernel-side cost, would show up in `ioctl`. `ioctl`
+   only grew 4 µs/call → 20 µs/call × 6 = 120 µs growth.
+4. **Firecracker's vCPU state harvesting growing** — vsock buffers,
+   block device state, etc. accumulating.
+
+Most consistent with the data: **(1) and (4) — pure userspace CPU
+walking a structure that linearly grows with snapshot count**.
+
+## What this means for #118
+
+The current #118 scoping (Phase 2 = io_uring; Phase 3 = pre-emptive
+background snapshot) was reasonable when we believed the BRANCH-3
+jump was an IO or kernel-bitmap issue. Given this probe:
+
+- **Phase 2's value is now narrower.** It still helps the
+  `std::fs::copy` of the source memory.bin (the background copy in
+  `controller::http::branch_sandbox`'s diff path — a few hundred MB
+  of NVMe-vs-SSD throughput). But it does NOT cut `diff_ms` and
+  therefore does NOT cut `pause_ms` on diff BRANCHes. Worth
+  re-evaluating before committing 1 week of dev time.
+- **Phase 3 needs rethinking.** A 1 s tick of pre-emptive snapshots
+  would themselves accumulate the per-snapshot CPU cost. After
+  10 ticks (10 s) we'd be in the slow regime. Phase 3 should
+  instead drive an upstream FC fix OR cap snapshots per VM and
+  recycle source VMs.
+
+## Next steps
+
+1. **Get `perf` working** (`apt install linux-tools-generic` plus a
+   reboot, OR build perf from source for kernel 6.14.0-36). Profile
+   FC during BRANCH 7. Confirm the user-space culprit (~5 minutes
+   work once perf is available).
+2. **Read Firecracker's `snapshot/create` handler** — locate any
+   data structure that accumulates per snapshot. Patch upstream or
+   document as a known FC limitation.
+3. **Revise #118 scope** based on (1) + (2). Likely outcome:
+   - Phase 2 narrows to "io_uring for the background memory.bin copy
+     in the diff path" — a real but smaller win.
+   - Phase 3 changes from "1 s tick" to "cap per-VM diff BRANCHes
+     to N, recycle source via Full BRANCH + restore beyond N".
+
+## Files
+
+- `bench/pause-window/probe-multi-branch-strace.sh` — the script
+  that produced the dataset above. Strace `-c` summary per BRANCH;
+  cheap; runs in ~50 s for N=10.
+- This document.

--- a/bench/pause-window/RESULTS-v0.3.md
+++ b/bench/pause-window/RESULTS-v0.3.md
@@ -346,6 +346,13 @@ firecracker that scales with the number of snapshots taken.
 Not investigated yet. Still ~10× better than Full mode (14 s) so it
 doesn't block v0.3.1, but worth profiling. Filed for follow-up.
 
+**Update 2026-05-20:** initial probe in
+[`PROBE-multi-branch-anomaly.md`](./PROBE-multi-branch-anomaly.md)
+attributes the growth to **user-space CPU inside Firecracker's
+`/snapshot/create` handler** — not IO, not syscalls. Direct
+implication: re-scope #118 Phase 2 (io_uring) and Phase 3 (pre-emptive
+snapshot) before implementing.
+
 The first-BRANCH-only restriction is gone in v0.3.1.
 
 ## Methodology notes

--- a/bench/pause-window/probe-multi-branch-strace.sh
+++ b/bench/pause-window/probe-multi-branch-strace.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# probe-multi-branch-strace.sh — strace firecracker through N consecutive
+# diff BRANCHes to see what syscall growth accounts for the BRANCH 3+
+# pause-time anomaly documented in RESULTS-v0.3.md.
+#
+# Output: one strace-counts file per BRANCH (per-syscall totals between
+# BRANCH-start and BRANCH-done as observed by the curl client).
+#
+# Usage:
+#   sudo bash bench/pause-window/probe-multi-branch-strace.sh
+#
+# Reads from env:
+#   FORKD_URL, FORKD_TOKEN_FILE, TAG, N_BRANCHES, GAP_SECS
+#
+# Output dir: $OUT_DIR (default /tmp/multi-branch-probe-<unix>)
+set -euo pipefail
+
+FORKD_URL=${FORKD_URL:-http://127.0.0.1:8889}
+FORKD_TOKEN=${FORKD_TOKEN:-$(cat "${FORKD_TOKEN_FILE:-/etc/forkd/token}" 2>/dev/null || echo "")}
+TAG=${TAG:-coding-agent-fork-prewarm-v1}
+N_BRANCHES=${N_BRANCHES:-10}
+GAP_SECS=${GAP_SECS:-3}
+OUT_DIR=${OUT_DIR:-/tmp/multi-branch-probe-$(date +%s)}
+mkdir -p "$OUT_DIR"
+
+auth=(-H "Authorization: Bearer $FORKD_TOKEN")
+
+echo "[probe] out_dir=$OUT_DIR tag=$TAG n=$N_BRANCHES" >&2
+
+# Spawn the source sandbox; capture FC pid via the daemon.
+echo "[probe] spawning source..." >&2
+spawn=$(curl -fsS "${auth[@]}" -H "Content-Type: application/json" \
+  -d "{\"snapshot_tag\":\"$TAG\",\"n\":1,\"per_child_netns\":true}" \
+  "$FORKD_URL/v1/sandboxes")
+sb_id=$(echo "$spawn" | jq -r '.[0].id')
+fc_pid=$(echo "$spawn" | jq -r '.[0].pid')
+echo "[probe] sandbox=$sb_id fc_pid=$fc_pid" >&2
+sleep 2
+
+# Pre-flight check: confirm FC pid is alive
+if ! sudo kill -0 "$fc_pid" 2>/dev/null; then
+  echo "[probe] FC pid $fc_pid not alive; aborting" >&2
+  exit 1
+fi
+
+# Strace summary per BRANCH: start strace -c in background, do the BRANCH,
+# detach (SIGINT), capture the per-syscall counts.
+echo "branch_idx,pause_ms,diff_ms,diff_physical_bytes,strace_total_us,strace_calls" > "$OUT_DIR/summary.csv"
+
+for i in $(seq 1 "$N_BRANCHES"); do
+  sleep "$GAP_SECS"
+  strace_log="$OUT_DIR/branch-$i.strace"
+
+  # Attach strace with -c (summary mode) to the FC pid. Run async so the
+  # BRANCH call can proceed; detach with SIGINT once the BRANCH returns.
+  sudo strace -c -p "$fc_pid" -o "$strace_log" 2>/dev/null &
+  strace_pid=$!
+  # Give strace a moment to attach
+  sleep 0.2
+
+  btag="probe-${i}-$(date +%s%N)"
+  resp=$(curl -fsS "${auth[@]}" -H "Content-Type: application/json" \
+    -d "{\"tag\":\"$btag\",\"diff\":true}" \
+    "$FORKD_URL/v1/sandboxes/$sb_id/branch")
+
+  # Detach strace and let it write the summary
+  sudo kill -INT "$strace_pid" 2>/dev/null || true
+  wait "$strace_pid" 2>/dev/null || true
+
+  pause_ms=$(echo "$resp" | jq -r '.pause_ms // empty')
+  diff_ms=$(echo "$resp" | jq -r '.diff_ms // empty')
+  diff_phys=$(echo "$resp" | jq -r '.diff_physical_bytes // empty')
+
+  # Pull "total" row from strace -c output. Columns:
+  # % time | seconds | usecs/call | calls | errors | syscall
+  # We want column 2 (seconds spent in syscalls) → us, and column 4 (calls).
+  total_line=$(grep -E "^[0-9.]+\s+[0-9.]+\s+[0-9]+" "$strace_log" | tail -1)
+  total_us=$(echo "$total_line" | awk '{printf "%d", $2 * 1000000}')
+  total_calls=$(echo "$total_line" | awk '{print $4}')
+
+  echo "$i,$pause_ms,$diff_ms,$diff_phys,$total_us,$total_calls" >> "$OUT_DIR/summary.csv"
+  echo "[probe] branch $i: pause=${pause_ms}ms diff=${diff_ms}ms strace_calls=$total_calls" >&2
+done
+
+# Cleanup
+curl -fsS -X DELETE "${auth[@]}" "$FORKD_URL/v1/sandboxes/$sb_id" > /dev/null || true
+echo "" >&2
+echo "[probe] done. summary at $OUT_DIR/summary.csv" >&2
+echo "[probe] per-branch strace at $OUT_DIR/branch-*.strace" >&2


### PR DESCRIPTION
## Summary
First investigation step for #118. The "BRANCH 3-5 pause jumps to 1.3-1.5s" anomaly documented in [`RESULTS-v0.3.md`](https://github.com/deeplethe/forkd/blob/main/bench/pause-window/RESULTS-v0.3.md) is **not IO, not syscalls** — it's user-space CPU inside Firecracker's `/snapshot/create` handler.

## What I measured
10 consecutive `diff: true` BRANCHes on `coding-agent-fork-prewarm-v1`, with `strace -c` on the FC process per BRANCH.

| | BRANCH 2 (fast) | BRANCH 7 (slow) |
|---|---|---|
| wall time (pause_ms) | 188 ms | 972 ms |
| time-in-syscalls (strace -c total) | 3.8 ms | 10.0 ms |
| syscall count | 709 | 734 |
| diff_physical_bytes | 389 KB | 426 KB |

→ ≥98% of the 784 ms wall-time growth is user-space CPU in FC's `/snapshot/create`. Not data volume. Not syscall volume. Not syscall cost.

## Direct implication for #118
- **Phase 2 (`io_uring` writer)**: addresses IO, but this anomaly is not IO. Phase 2 still helps the `std::fs::copy` of the source memory.bin in the diff-mode background copy — a real but smaller win.
- **Phase 3 (1 s pre-emptive tick background snapshot)**: would itself hit the per-snapshot CPU growth and reach the slow regime within ~10 ticks. Needs rethinking — probably an upstream FC patch OR cap diff BRANCHes per VM and recycle source via Full BRANCH + restore.

## What's in this PR (zero code changes)
- `bench/pause-window/probe-multi-branch-strace.sh` — script (rerunnable; 10 BRANCHes in ~50s)
- `bench/pause-window/PROBE-multi-branch-anomaly.md` — full writeup with data, attribution logic, and recommended next steps
- `bench/pause-window/RESULTS-v0.3.md` — pointer added to the probe doc

## Next steps (separate ticket)
1. Install/build `perf` for kernel 6.14.0-36 on the dev box; profile FC during BRANCH 7 to identify the exact function.
2. Read FC's `/snapshot/create` for a structure that grows with snapshot count.
3. Re-scope #118 Phase 2 + Phase 3 based on (1) + (2).

## Test plan
- [x] Anomaly reproduced on dev box (gradual growth from BRANCH 6)
- [x] Strace attribution confirmed CPU-not-syscall
- [ ] Per-function attribution (needs perf — separate ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)