### PR TITLE
docs: feature the 4 integration recipes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,20 @@ The server exposes `spawn_sandboxes`, `exec_command`, `eval_code`,
 and five other tools — the agent can fork and drive forkd microVMs
 directly. See [`sdk/mcp/README.md`](./sdk/mcp/README.md).
 
-### Pre-built recipes
+### Framework integration recipes (host-side, no rootfs build)
+
+Drop-in patterns for the four agent frameworks most often used with
+forkd. Each is ~150-250 lines of Python with a `--dry-run` mode that
+exercises the forkd plumbing without an LLM key:
+
+| Recipe | Driver | Forkd-specific move |
+|---|---|---|
+| [`mcp-agent/`](./recipes/mcp-agent/) | Claude Desktop / Cursor / Cline (MCP) | End-to-end MCP protocol verification |
+| [`crewai-fanout/`](./recipes/crewai-fanout/) | CrewAI | N agents on N microVMs from one parent — per-agent isolation, ~24ms per child |
+| [`autogen-branch/`](./recipes/autogen-branch/) | AutoGen | Forkd-backed `CodeExecutor` + mid-conversation BRANCH that fans out N alternatives |
+| [`openai-swarm/`](./recipes/openai-swarm/) | OpenAI Swarm / Agents SDK | Handoff = BRANCH: agent B inherits agent A's full VM state |
+
+### Pre-built rootfs recipes
 
 Skip the rootfs design step — pick one of the [`recipes/`](./recipes/)
 and run its `build.sh`:
@@ -510,7 +523,9 @@ sdk/mcp/                MCP server (`forkd-mcp`) — drive forkd from
 scripts/                Host-side helpers (KVM, Firecracker, netns, rootfs)
 packaging/systemd/      systemd unit for the controller
 packaging/k8s/          Starter Kubernetes manifest for forkd-controller
-recipes/                Pre-built parent-rootfs recipes (python-numpy,
+recipes/                Framework integration recipes (mcp-agent,
+                        crewai-fanout, autogen-branch, openai-swarm)
+                        + parent-rootfs recipes (python-numpy,
                         e2b-codeinterpreter, jupyter-kernel, coding-agent,
                         nodejs, playwright-browser, agent-workbench,
                         postgres-fixture). See recipes/README.md.

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,5 +1,31 @@
 # Recipes
 
+Two flavors:
+
+1. **Integration recipes** (host-side, no rootfs build) — Python scripts
+   that drive forkd from an agent framework, demonstrating the
+   BRANCH + fanout pattern with that framework's idioms. Start here if
+   you want to plug forkd into CrewAI / AutoGen / Swarm / Claude
+   Desktop in five minutes.
+2. **Rootfs recipes** (parent images) — `build.sh` scripts that turn
+   public OCI images into forkd parent snapshots. Start here if you
+   want a custom warmed image to fork from.
+
+## Integration recipes (host-side)
+
+Read the script, copy the helper, drop it into your project. Each is
+~150-250 lines of Python with a `--dry-run` mode so you can verify
+the forkd plumbing without an LLM key.
+
+| Recipe | Framework | Forkd-specific value |
+|---|---|---|
+| [`mcp-agent/`](./mcp-agent/) | Claude Desktop / Cursor / Cline (via MCP) | End-to-end MCP protocol verification — same JSON-RPC framing a real LLM client uses |
+| [`crewai-fanout/`](./crewai-fanout/) | CrewAI | N agents on N microVMs from one warmed parent — per-agent isolation without Docker cold-start |
+| [`autogen-branch/`](./autogen-branch/) | AutoGen | Forkd-backed `CodeExecutor` + mid-conversation BRANCH that fans out N alternatives from the same warmed state |
+| [`openai-swarm/`](./openai-swarm/) | OpenAI Swarm / Agents SDK | Handoff = BRANCH: agent B inherits agent A's full VM state (filesystem, imports, env) on handoff |
+
+## Rootfs recipes
+
 Ready-made parent-rootfs recipes for common workbench images.
 Each recipe takes a public Docker / OCI image and turns it into a
 forkd parent snapshot, so you can fork N warmed children from it
@@ -21,7 +47,7 @@ sudo forkd snapshot --tag <name> \
 sudo -E forkd fork --tag <name> -n 100 --per-child-netns
 ```
 
-## Available recipes
+### Available rootfs recipes
 
 | Recipe | Parent image | Size | Audience |
 |---|---|---|---|
@@ -36,6 +62,13 @@ sudo -E forkd fork --tag <name> -n 100 --per-child-netns
 
 ## Choosing a recipe
 
+**By framework / driver (integration recipes):**
+- **Claude Desktop / Cursor / Cline** → `mcp-agent/`
+- **CrewAI multi-agent crew** → `crewai-fanout/`
+- **AutoGen ConversableAgent / GroupChat** → `autogen-branch/`
+- **OpenAI Swarm / Agents SDK** → `openai-swarm/`
+
+**By workload (rootfs recipes):**
 - **You're benchmarking** → `python-numpy/`
 - **You're running an AI code interpreter** → `e2b-codeinterpreter/`
 - **You need the full SciPy / notebook stack** → `jupyter-kernel/`


### PR DESCRIPTION
## Summary
Before this PR, the four host-side integration recipes shipped yesterday (mcp-agent, crewai-fanout, autogen-branch, openai-swarm) were nowhere in the main README or in `recipes/README.md` — anyone landing on the repo from a Twitter link or blog post couldn't find them.

This PR is **README polish only, no code changes**. It splits `recipes/README.md` into two sections (integration vs rootfs) and adds a "Framework integration recipes" table to the main README right above the existing rootfs table.

## What changes
- `recipes/README.md`: top section now explains the two flavors; new "Integration recipes" table; existing rootfs content reframed as "Rootfs recipes" subsection; "Choosing a recipe" grouped by driver vs workload.
- `README.md`: new `### Framework integration recipes` table (driver / forkd-specific move); existing rootfs table retitled `### Pre-built rootfs recipes`; one-line note added to the source-tree.
- 51 insertions, 3 deletions, no code touched.

## Why now
Distribution push starts soon. The 4 recipes shipped 2026-05-20 are the strongest concrete artifacts of forkd's BRANCH+fanout story; the README needs to surface them to convert curious readers.

## Test plan
- [x] Render-check both READMEs locally — markdown valid
- [ ] (post-merge) Verify GitHub rendering on https://github.com/deeplethe/forkd

🤖 Generated with [Claude Code](https://claude.com/claude-code)