### PR TITLE
fix(controller): retry restore_many on tap/cgroup busy with backoff

### DIFF
--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -439,9 +439,46 @@ async fn create_sandbox(
     // restore_many_with is sync + blocking (spawns N firecracker procs,
     // waits on their unix sockets, fires N parallel restore PUTs). Run it
     // off the async runtime so we don't starve other requests.
+    //
+    // Retry-on-busy: when a sandbox is killed and another spawn fires
+    // immediately, the kernel's tap-device / cgroup teardown can race
+    // with the new firecracker process trying to claim them, producing:
+    //   - "Open tap device failed: Resource busy (os error 16)" — fc
+    //     can't open forkd-tap0 because the previous owner's fd hasn't
+    //     been released
+    //   - "Device or resource busy" on cgroup leaf creation
+    // The kernel usually clears state within tens of milliseconds. Retry
+    // up to 3 times with 50/200/800 ms backoff. ForkOpts and Snapshot are
+    // Clone so we can hand a fresh copy to each attempt.
     let prewarm_requested = req.prewarm;
     let fork_result = match tokio::task::spawn_blocking(move || {
-        snapshot.restore_many_with(opts, &work_dir)
+        let mut last_err: Option<anyhow::Error> = None;
+        let backoffs_ms = [50u64, 200, 800];
+        for attempt in 0..=backoffs_ms.len() {
+            if attempt > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(backoffs_ms[attempt - 1]));
+            }
+            match snapshot.restore_many_with(opts.clone(), &work_dir) {
+                Ok(r) => return Ok(r),
+                Err(e) => {
+                    let msg = format!("{e:#}");
+                    let is_busy = msg.contains("Resource busy")
+                        || msg.contains("Device or resource busy")
+                        || msg.contains("os error 16");
+                    if !is_busy || attempt == backoffs_ms.len() {
+                        return Err(e);
+                    }
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        next_backoff_ms = backoffs_ms[attempt],
+                        error = %e,
+                        "restore_many: tap/cgroup busy, retrying"
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.expect("loop must produce an error on exit"))
     })
     .await
     {


### PR DESCRIPTION
## Summary
Daemon log shows recurring 400s from firecracker's \`/snapshot/load\` when a sandbox is killed and another spawn fires before the kernel finishes tearing down the tap device / cgroup leaf:

\`\`\`
ERROR forkd_controller::http: internal error: restore_many: firecracker API PUT /snapshot/load
  returned 400: ...Open tap device failed: Resource busy (os error 16).
WARN  forkd_vmm::cgroup: cgroup cleanup failed path=/sys/fs/cgroup/forkd/child-1
  error=Device or resource busy (os error 16)
\`\`\`

User-visible behavior: 500 errors on spawn-after-kill. Workarounds today: add a sleep between calls, or use \`per_child_netns=true\` (which dodges the shared forkd-tap0 entirely). Both are paper-cuts.

## Fix
Wrap \`restore_many_with\` in a 3-attempt retry inside the existing \`spawn_blocking\` closure. Backoffs 50 / 200 / 800 ms (~1 s worst case, ~50 ms typical). Only retries when the error message matches one of:
- \`Resource busy\`
- \`Device or resource busy\`
- \`os error 16\`

Other errors propagate as before. Each retry logs at WARN level.

\`Snapshot\` and \`ForkOpts\` are both \`Clone\`, so each attempt gets a fresh \`opts\`; \`snapshot.restore_many_with\` takes \`&self\` so the snapshot is borrowed each call.

## Smoke test on dev box
- Built + restarted controller with new binary
- Ran 5 back-to-back spawn-then-kill cycles (no \`per_child_netns\`) → all succeeded, no retry warnings emitted (kernel didn't race in this run — retry path is a defensive backstop)
- Compiles clean, no clippy noise

## Files
- \`crates/forkd-controller/src/http.rs\` — 40 inserted, 1 deleted in the spawn_blocking closure

## Closes
The "tap/cgroup busy race on spawn-after-kill" item from yesterday's bug audit (bug #2 in the list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)