### PR TITLE
feat(controller): branch_count + warning when source over-branched (#146)

### DIFF
--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -1879,6 +1879,9 @@ fn branch_snapshot_via_daemon(
     println!("tag:           {new_tag}");
     println!("dir:           {dir}");
     println!("branched_from: {branched_from}");
+    if let Some(w) = info.get("warning").and_then(|v| v.as_str()) {
+        eprintln!("\x1b[33m⚠ warning:\x1b[0m {w}");
+    }
     Ok(())
 }
 

--- a/crates/forkd-cli/src/sandbox.rs
+++ b/crates/forkd-cli/src/sandbox.rs
@@ -30,11 +30,12 @@ pub fn ls(daemon_url: &str, token: Option<String>) -> Result<()> {
         .unwrap_or(8)
         .max(8);
     println!(
-        "  {:<id_w$}  {:<tag_w$}  {:<8}  {:<14}  GUEST_ADDR",
+        "  {:<id_w$}  {:<tag_w$}  {:<8}  {:<14}  {:<8}  GUEST_ADDR",
         "ID",
         "SNAPSHOT",
         "PID",
         "NETNS",
+        "BRANCHES",
         id_w = id_w,
         tag_w = tag_w,
     );
@@ -51,12 +52,20 @@ pub fn ls(daemon_url: &str, token: Option<String>) -> Result<()> {
             .unwrap_or_else(|| "—".to_string());
         let netns = s.get("netns").and_then(|v| v.as_str()).unwrap_or("—");
         let guest = s.get("guest_addr").and_then(|v| v.as_str()).unwrap_or("—");
+        // branch_count: emphasize when >=3 (slow regime per issue #146)
+        let bc_n = s.get("branch_count").and_then(|v| v.as_u64()).unwrap_or(0);
+        let bc = if bc_n >= 3 {
+            format!("\x1b[33m{bc_n}⚠\x1b[0m")
+        } else {
+            bc_n.to_string()
+        };
         println!(
-            "  {:<id_w$}  {:<tag_w$}  {:<8}  {:<14}  {}",
+            "  {:<id_w$}  {:<tag_w$}  {:<8}  {:<14}  {:<8}  {}",
             id,
             tag,
             pid,
             netns,
+            bc,
             guest,
             id_w = id_w,
             tag_w = tag_w,

--- a/crates/forkd-controller/src/api.rs
+++ b/crates/forkd-controller/src/api.rs
@@ -57,6 +57,12 @@ pub struct SnapshotInfo {
     /// snapshot file. Equals the source's full guest-RAM size.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub diff_logical_bytes: Option<u64>,
+    /// Human-readable advisory included on BRANCH responses when the
+    /// source sandbox has been BRANCHed 3+ times. Issue #146 documents
+    /// a ~5× pause_ms jump in that regime. None for non-BRANCH
+    /// snapshots and for the first 2 BRANCHes on any source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
 }
 
 /// `POST /v1/sandboxes/:id/branch` — pause a running sandbox, snapshot
@@ -177,6 +183,14 @@ pub struct SandboxInfo {
     /// via Registry::update_last_branch_memory_path.
     #[serde(default)]
     pub last_branch_memory_path: Option<std::path::PathBuf>,
+    /// Total number of BRANCHes taken on this sandbox (Full + Diff).
+    /// Incremented in `mark_branched`. Used to emit a warning on the
+    /// BRANCH response when the count crosses a threshold — issue
+    /// [#146](https://github.com/deeplethe/forkd/issues/146) documents
+    /// a ~5× pause_ms jump on BRANCH 3+. Users hitting the warning
+    /// should either cap N or kill+respawn from the latest BRANCH.
+    #[serde(default)]
+    pub branch_count: u32,
 }
 
 /// State of a stateful workspace (#116). Tracks whether the workspace

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -285,6 +285,7 @@ async fn create_snapshot(
         diff_ms: None,
         diff_physical_bytes: None,
         diff_logical_bytes: None,
+        warning: None,
     };
     if let Err(e) = s.registry.insert_snapshot(info.clone()) {
         return server_error(&format!("persist snapshot: {e:#}"));
@@ -516,6 +517,7 @@ async fn create_sandbox(
                 memory_limit_mib: req.memory_limit_mib,
                 has_branched: false,
                 last_branch_memory_path: None,
+                branch_count: 0,
             };
             if let Err(e) = s.registry.insert_sandbox(info.clone()) {
                 tracing::error!(error=%e, "persist sandbox failed");
@@ -856,6 +858,7 @@ async fn branch_sandbox(
     // Re-insert the source sandbox into live_vms. If a DELETE happened during
     // the branching window, the entry is gone from the registry; we drop the
     // returned `vm` (its Drop kills firecracker + cleans cgroup).
+    let mut new_branch_count: Option<u32> = None;
     if s.registry.get_sandbox(&id).is_some() {
         s.live_vms.lock().insert(id.clone(), vm_back);
         // Phase 1d: record this BRANCH's memory.bin as the chain head
@@ -863,8 +866,11 @@ async fn branch_sandbox(
         // dirty bitmap, so EITHER mode's output is the correct base for
         // the next diff regardless of which mode produced it.
         let new_chain_head = snap_dir.join("memory.bin");
-        if let Err(e) = s.registry.mark_branched(&id, new_chain_head) {
-            tracing::warn!(sandbox = %id, error = %e, "failed to persist last_branch_memory_path");
+        match s.registry.mark_branched(&id, new_chain_head) {
+            Ok(count) => new_branch_count = count,
+            Err(e) => {
+                tracing::warn!(sandbox = %id, error = %e, "failed to persist last_branch_memory_path");
+            }
         }
     } else {
         drop(vm_back);
@@ -896,6 +902,15 @@ async fn branch_sandbox(
         Some((ms, phys, log)) => (Some(ms), Some(phys), Some(log)),
         None => (None, None, None),
     };
+    // Advisory when the source's branch_count crosses into the slow
+    // regime documented in issue #146. Threshold = 3 (BRANCH 1-2 are
+    // typically fast; BRANCH 3+ shows the ~5× pause_ms jump).
+    let warning = new_branch_count.filter(|&n| n >= 3).map(|n| {
+        format!(
+            "branch #{n} on this source — pause_ms typically grows 5× from BRANCH 3 (issue #146). \
+             Consider spawning a fresh source from this BRANCH and continuing the chain there."
+        )
+    });
     let info = SnapshotInfo {
         tag: tag.clone(),
         dir: snap_dir.display().to_string(),
@@ -905,6 +920,7 @@ async fn branch_sandbox(
         diff_ms,
         diff_physical_bytes,
         diff_logical_bytes,
+        warning,
     };
     if let Err(e) = s.registry.insert_snapshot(info.clone()) {
         return server_error(&format!("persist snapshot: {e:#}"));
@@ -1182,6 +1198,7 @@ fn spawn_one_for_workspace(
         memory_limit_mib,
         has_branched: false,
         last_branch_memory_path: None,
+        branch_count: 0,
     };
     Ok((vm, info))
 }
@@ -1433,6 +1450,7 @@ async fn suspend_workspace(
         diff_ms: None,
         diff_physical_bytes: None,
         diff_logical_bytes: None,
+        warning: None,
     };
     if let Err(e) = s.registry.insert_snapshot(snapshot_info) {
         return server_error(&format!("persist suspend snapshot: {e:#}"));
@@ -1874,6 +1892,7 @@ mod tests {
                 memory_limit_mib: None,
                 has_branched: false,
                 last_branch_memory_path: None,
+                branch_count: 0,
             })
             .unwrap();
         let app = router(s);

--- a/crates/forkd-controller/src/state.rs
+++ b/crates/forkd-controller/src/state.rs
@@ -98,25 +98,28 @@ impl Registry {
     /// record its most recent BRANCH output's memory.bin path so
     /// subsequent diff BRANCHes can chain off it (phase 1d).
     ///
-    /// Returns Ok(false) if the sandbox is no longer registered (it
-    /// got DELETE'd during the BRANCH window — best-effort, the
-    /// updated state is silently dropped).
-    pub fn mark_branched(&self, id: &str, last_memory_bin: PathBuf) -> Result<bool> {
-        let updated = {
+    /// Returns Ok(Some(new_branch_count)) on success, where the count is
+    /// the post-increment value (so the first BRANCH on a sandbox
+    /// returns 1). Returns Ok(None) if the sandbox is no longer
+    /// registered (it got DELETE'd during the BRANCH window —
+    /// best-effort, the updated state is silently dropped).
+    pub fn mark_branched(&self, id: &str, last_memory_bin: PathBuf) -> Result<Option<u32>> {
+        let new_count = {
             let mut g = self.inner.lock();
             match g.sandboxes.get_mut(id) {
                 Some(sb) => {
                     sb.has_branched = true;
                     sb.last_branch_memory_path = Some(last_memory_bin);
-                    true
+                    sb.branch_count = sb.branch_count.saturating_add(1);
+                    Some(sb.branch_count)
                 }
-                None => false,
+                None => None,
             }
         };
-        if updated {
+        if new_count.is_some() {
             self.flush()?;
         }
-        Ok(updated)
+        Ok(new_count)
     }
 
     pub fn remove_sandbox(&self, id: &str) -> Result<Option<SandboxInfo>> {
@@ -296,6 +299,7 @@ mod tests {
             memory_limit_mib: None,
             has_branched: false,
             last_branch_memory_path: None,
+            branch_count: 0,
         })
         .unwrap();
 


### PR DESCRIPTION
## Summary
Surfaces the multi-BRANCH anomaly (#146) directly to users via three coordinated surfaces, so anyone fanning out repeatedly from one source gets a clear pointer to the workaround before they wonder why their 4th BRANCH took 1.5 s.

## E2E test on dev box
\`\`\`
BRANCH 1: pause_ms=455, warning=null
BRANCH 2: pause_ms=221, warning=null
BRANCH 3: pause_ms=232, warning="branch #3 on this source — pause_ms typically grows 5× from BRANCH 3 (issue #146). Consider spawning a fresh source from this BRANCH and continuing the chain there."
BRANCH 4: pause_ms=380, warning="branch #4 on this source — ..."

$ forkd ls
  ID                SNAPSHOT                      PID       NETNS           BRANCHES  GUEST_ADDR
  sb-6a11229e-0000  coding-agent-fork-prewarm-v1  2708931   forkd-child-1   4⚠        10.42.0.2:8888

$ forkd snapshot --from-sandbox sb-... --diff --tag bc-cli-test
✓ branch ready
tag:           bc-cli-test
dir:           ...
branched_from: sb-6a11229e-0000
⚠ warning: branch #5 on this source — ...
\`\`\`

(BRANCHES column shows yellow ⚠ on counts ≥3 in real terminals.)

## API changes
- \`SandboxInfo.branch_count: u32\` — \`#[serde(default)]\` for backward compat (older state files load as 0)
- \`SnapshotInfo.warning: Option<String>\` — \`#[skip_serializing_if = Option::is_none]\`, only populated on BRANCH responses when count ≥3
- \`Registry::mark_branched\` return type \`Result<bool>\` → \`Result<Option<u32>>\` (the new count). One call site updated.

## CLI changes
- \`forkd ls\` — new BRANCHES column, yellow when count ≥3
- \`forkd snapshot --from-sandbox\` — echoes the daemon \`warning\` field to stderr

## Refs
Implements the user-facing surface advisory called out in [#146](https://github.com/deeplethe/forkd/issues/146). Doesn't fix the underlying anomaly — that still needs the DWARF-FC + perf flamegraph path documented in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)