### PR TITLE
chore(sdk/typescript): align @deeplethe/forkd to 0.3.3

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deeplethe/forkd",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deeplethe/forkd",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deeplethe/forkd",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "TypeScript client for forkd — open-source fork-on-write microVM primitive for AI agents",
   "license": "Apache-2.0",
   "author": "Deeplethe <info@deeplethe.com>",


### PR DESCRIPTION
## Summary
Bumps \`sdk/typescript/package.json\` + \`package-lock.json\` from 0.3.1 to 0.3.3. No code changes — purely version-number alignment with the rest of the workspace (Cargo + Python SDK both at 0.3.3). After merge, tag \`ts-v0.3.3\` to trigger \`publish-npm.yml\`.

## Closes
Last item from yesterday's bug audit: \"TS SDK npm version drift\" — was at 0.3.1 on npm while everything else moved to 0.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)