### PR TITLE
fix: address external issues #158 + #159

### DIFF
--- a/crates/forkd-controller/Cargo.toml
+++ b/crates/forkd-controller/Cargo.toml
@@ -30,7 +30,7 @@ parking_lot.workspace = true
 # but had two latent bugs (issue #158): pre-epoch clocks collapsed to
 # 1970-01-01 via unwrap_or(0), and the i64→i32 year cast overflowed for
 # corrupted state files. `time` is ~30 KiB, already in axum's tree.
-time = { version = "0.3", default-features = false, features = ["formatting"] }
+time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
 
 # posix_fallocate for the memory.bin pre-allocation in BRANCH path
 # (issue #146). Avoids ext4 mballoc cost on writeback.

--- a/crates/forkd-controller/Cargo.toml
+++ b/crates/forkd-controller/Cargo.toml
@@ -26,6 +26,11 @@ axum.workspace = true
 axum-server.workspace = true
 rustls.workspace = true
 parking_lot.workspace = true
+# Audit log RFC3339 timestamps. Was hand-rolled (Howard Hinnant's algorithm)
+# but had two latent bugs (issue #158): pre-epoch clocks collapsed to
+# 1970-01-01 via unwrap_or(0), and the i64→i32 year cast overflowed for
+# corrupted state files. `time` is ~30 KiB, already in axum's tree.
+time = { version = "0.3", default-features = false, features = ["formatting"] }
 
 # posix_fallocate for the memory.bin pre-allocation in BRANCH path
 # (issue #146). Avoids ext4 mballoc cost on writeback.

--- a/crates/forkd-controller/src/audit.rs
+++ b/crates/forkd-controller/src/audit.rs
@@ -108,9 +108,8 @@ fn format_unix_seconds_as_rfc3339(secs: i64) -> String {
     // pre-epoch collapse that the previous hand-rolled formatter had
     // (issue #158). `time` is a small, no-default-features dep already
     // in axum's transitive tree.
-    let format = time::macros::format_description!(
-        "[year]-[month]-[day]T[hour]:[minute]:[second]Z"
-    );
+    let format =
+        time::macros::format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]Z");
     match time::OffsetDateTime::from_unix_timestamp(secs) {
         Ok(dt) => dt
             .format(&format)
@@ -151,10 +150,7 @@ mod tests {
         // "1970-01-01T00:00:00Z" silently. Now the negative i64 just
         // produces the actual prior date instead of a misleading zero.
         // -1 second == 1969-12-31T23:59:59Z.
-        assert_eq!(
-            format_unix_seconds_as_rfc3339(-1),
-            "1969-12-31T23:59:59Z"
-        );
+        assert_eq!(format_unix_seconds_as_rfc3339(-1), "1969-12-31T23:59:59Z");
     }
 
     #[test]

--- a/crates/forkd-controller/src/audit.rs
+++ b/crates/forkd-controller/src/audit.rs
@@ -96,39 +96,33 @@ pub async fn audit_layer(sink: AuditSink, req: Request, next: Next) -> Response 
 }
 
 fn now_rfc3339() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    // Minimal RFC3339-ish without pulling in chrono. Seconds-precision
-    // is plenty for audit purposes; the latency_us field captures the
-    // sub-second cost of each handler.
-    format_unix_seconds_as_rfc3339(secs)
+    // We log audits with seconds precision; sub-second latency goes in
+    // the `latency_us` field. `time::OffsetDateTime::now_utc()` reads the
+    // system clock and can never silently collapse a pre-epoch clock to
+    // 1970 (the previous hand-rolled formatter did, see #158).
+    format_unix_seconds_as_rfc3339(time::OffsetDateTime::now_utc().unix_timestamp())
 }
 
-fn format_unix_seconds_as_rfc3339(secs: u64) -> String {
-    // 1970-01-01T00:00:00Z + secs. Algorithm from Howard Hinnant's
-    // "civil from days" (public domain). Avoids the chrono dependency.
-    let z = secs as i64;
-    let days = z.div_euclid(86_400);
-    let sec_of_day = z.rem_euclid(86_400);
-    let hour = (sec_of_day / 3600) as u32;
-    let minute = ((sec_of_day % 3600) / 60) as u32;
-    let second = (sec_of_day % 60) as u32;
-
-    let z2 = days + 719_468;
-    let era = z2.div_euclid(146_097);
-    let doe = z2.rem_euclid(146_097);
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
-    let y = (y + if m <= 2 { 1 } else { 0 }) as i32;
-
-    format!("{y:04}-{m:02}-{d:02}T{hour:02}:{minute:02}:{second:02}Z")
+fn format_unix_seconds_as_rfc3339(secs: i64) -> String {
+    // Use `time` to avoid the y2262 i64→i32 overflow and the silent
+    // pre-epoch collapse that the previous hand-rolled formatter had
+    // (issue #158). `time` is a small, no-default-features dep already
+    // in axum's transitive tree.
+    let format = time::macros::format_description!(
+        "[year]-[month]-[day]T[hour]:[minute]:[second]Z"
+    );
+    match time::OffsetDateTime::from_unix_timestamp(secs) {
+        Ok(dt) => dt
+            .format(&format)
+            .unwrap_or_else(|_| "0000-00-00T00:00:00Z".to_string()),
+        Err(_) => {
+            // Out-of-range: timestamp falls outside what `time` can
+            // represent (~year ±9999). Emit a sentinel rather than
+            // pretending the value was 0. The audit-log consumer can
+            // grep for "outside-time-range" to find these.
+            "outside-time-range".to_string()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -146,6 +140,41 @@ mod tests {
         assert_eq!(
             format_unix_seconds_as_rfc3339(1_704_067_200),
             "2024-01-01T00:00:00Z"
+        );
+    }
+
+    // Regression tests for issue #158.
+
+    #[test]
+    fn rfc3339_format_negative_pre_epoch() {
+        // Previously the unwrap_or(0) path collapsed pre-epoch clocks to
+        // "1970-01-01T00:00:00Z" silently. Now the negative i64 just
+        // produces the actual prior date instead of a misleading zero.
+        // -1 second == 1969-12-31T23:59:59Z.
+        assert_eq!(
+            format_unix_seconds_as_rfc3339(-1),
+            "1969-12-31T23:59:59Z"
+        );
+    }
+
+    #[test]
+    fn rfc3339_format_far_future_does_not_overflow() {
+        // Year 9999 fits in time::OffsetDateTime's range.
+        // 253_402_300_799 == 9999-12-31T23:59:59Z.
+        assert_eq!(
+            format_unix_seconds_as_rfc3339(253_402_300_799),
+            "9999-12-31T23:59:59Z"
+        );
+    }
+
+    #[test]
+    fn rfc3339_format_out_of_range_returns_sentinel() {
+        // Beyond year ±9999 — `time` rejects the construction. We don't
+        // silently overflow into a wrong-year string; we emit a sentinel
+        // the operator can grep for.
+        assert_eq!(
+            format_unix_seconds_as_rfc3339(1_000_000_000_000_000_000),
+            "outside-time-range"
         );
     }
 

--- a/crates/forkd-vmm/src/cgroup.rs
+++ b/crates/forkd-vmm/src/cgroup.rs
@@ -12,8 +12,10 @@
 //! single place to set workload-wide caps later (cpu.max, io.max, pids.max).
 //!
 //! Requires cgroup v2 unified hierarchy (kernel 4.5+, default since Ubuntu 22.04).
-//! The memory controller must be enabled at the parent's subtree_control — we
-//! handle that automatically on first use.
+//! The memory / cpu / io / pids controllers are enabled at the parent's
+//! subtree_control on first use; only `memory.max` is actually written today
+//! (in `place_child`), but enabling the rest up front lets later PRs add
+//! `cpu.max` etc. without re-touching this file.
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
@@ -57,12 +59,35 @@ pub fn ensure_parent() -> Result<PathBuf> {
             .with_context(|| format!("mkdir {} (need root or delegation?)", parent.display()))?;
     }
 
+    // Enable every controller the project is *likely* to want, not just the
+    // one place_child writes today (memory.max). Adding cpu.max / io.max /
+    // pids.max in a future PR otherwise silently fails because the child
+    // cgroup won't expose those files — see #159. The kernel ignores
+    // unknown controllers in subtree_control (they just aren't listed in
+    // /sys/fs/cgroup/cgroup.controllers), so writes for controllers that
+    // aren't compiled in are no-ops, not errors.
+    const WANT_CONTROLLERS: &[&str] = &["memory", "cpu", "io", "pids"];
+
     let parent_subtree = parent.join("cgroup.subtree_control");
     let cur = std::fs::read_to_string(&parent_subtree).unwrap_or_default();
-    if !cur.split_whitespace().any(|c| c == "memory") {
-        std::fs::write(&parent_subtree, "+memory").with_context(|| {
+    let enabled: std::collections::HashSet<&str> = cur.split_whitespace().collect();
+    let missing: Vec<&&str> = WANT_CONTROLLERS
+        .iter()
+        .filter(|c| !enabled.contains(**c))
+        .collect();
+    if !missing.is_empty() {
+        // subtree_control accepts multiple "+ctrl" tokens space-separated in
+        // a single write. One syscall is cheaper and atomic relative to
+        // concurrent readers.
+        let plus = missing
+            .iter()
+            .map(|c| format!("+{c}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        std::fs::write(&parent_subtree, &plus).with_context(|| {
             format!(
-                "enable memory controller on {} subtree_control",
+                "enable controllers ({}) on {} subtree_control",
+                plus,
                 parent.display()
             )
         })?;


### PR DESCRIPTION
Two community-reported quality bugs in one PR. Both reporters left concrete patches in their issues; I followed both closely with small tweaks for safety/testability.

## #159 — \`cgroup::ensure_parent\` only enabled \`memory\`

Reporter: [@mxz2007](https://github.com/mxz2007).

The module doc-comment promises future cpu/io/pids support, but the enable code only set \`+memory\` in subtree_control. A future PR adding \`cpu.max\` would silently fail because the child cgroup wouldn't expose the file — silent regression bait.

Fix (as reporter suggested): enable \`{memory, cpu, io, pids}\` on first use. Single-write of all "+ctrl" tokens. The kernel ignores subtree_control tokens for controllers not compiled in, so no error.

Also tightened the module doc-comment to match the new behavior.

## #158 — Audit RFC3339 formatter had two latent bugs

Reporter: [@pardcomper](https://github.com/pardcomper) (Ziyu Wang).

The hand-rolled formatter avoided pulling in chrono, but:

1. \`SystemTime::duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)\` silently collapsed pre-epoch clocks (dead CMOS battery boot) to \`1970-01-01T00:00:00Z\`. Two audit records back-to-back in this state would have identical timestamps, with no signal anywhere.

2. \`(y + ...) as i32\` overflowed for \`secs > ~4×10^17\`. A corrupted \`state.json\` with a bogus future \`created_at_unix\` would silently render a wrong year.

Fix: replaced the hand-rolled formatter with the \`time\` crate (\`default-features = false\`, features = \`["formatting", "macros"]\`). For in-range timestamps, output is bit-identical to the old formatter. Out-of-range now returns a \`"outside-time-range"\` sentinel rather than overflowing.

Added three regression tests:

- \`rfc3339_format_negative_pre_epoch\`: \`-1 → "1969-12-31T23:59:59Z"\` (the actual prior date, not a misleading zero)
- \`rfc3339_format_far_future_does_not_overflow\`: year 9999 renders correctly
- \`rfc3339_format_out_of_range_returns_sentinel\`: \`1e18 → "outside-time-range"\`

## Test results (dev box, kernel 6.14)

\`\`\`
test audit::tests::rfc3339_format_epoch_zero ... ok
test audit::tests::rfc3339_format_far_future_does_not_overflow ... ok
test audit::tests::rfc3339_format_known_timestamp ... ok
test audit::tests::audit_sink_writes_and_persists ... ok
test audit::tests::rfc3339_format_negative_pre_epoch ... ok
test audit::tests::rfc3339_format_out_of_range_returns_sentinel ... ok
test result: ok. 6 passed; 0 failed
\`\`\`

Closes #158. Closes #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)