### PR TITLE
security: fix bearer-token length oracle in constant_time_eq (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ Notable changes per release. forkd follows [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 1.0; until then, the minor version can break compatibility.
 
+## Unreleased
+
+### Security — bearer-token comparison was a length oracle (closes #162)
+
+`crates/forkd-controller/src/auth.rs::constant_time_eq` was advertised
+as constant-time but leaked the presented token's length via two
+distinct paths:
+
+1. The length-mismatch branch's "fake work" loop used
+   `x.wrapping_mul(0)` — the compiler is allowed to (and LLVM does)
+   delete the loop as dead code, so response time was monotonic in
+   the longer slice's length.
+2. Even if the loop had been preserved, taking different branches
+   for length-equal vs length-mismatch was itself a timing oracle.
+
+For a deployment with a fixed-length token (e.g. 32-byte hex from
+`forkd doctor`), the length oracle collapses security to a single
+attempted length, after which the equal-length branch is real
+constant-time.
+
+**Fix.** Replaced with a `subtle::ConstantTimeEq` call against a
+zero-padded copy of the presented token. Same code path regardless
+of input length; length difference is folded into the result via a
+non-short-circuiting bitwise AND. `subtle` was already an indirect
+dep via the rustls / aws-lc-rs subtree, so the patch adds no new
+crate to the lockfile.
+
+Thanks to @m-dmupba for the report and the precise repro.
+
 ## 0.3.4 — 2026-05-23
 
 ### Multi-BRANCH pause anomaly fixed (closes #146)

--- a/crates/forkd-controller/Cargo.toml
+++ b/crates/forkd-controller/Cargo.toml
@@ -31,6 +31,12 @@ parking_lot.workspace = true
 # 1970-01-01 via unwrap_or(0), and the i64→i32 year cast overflowed for
 # corrupted state files. `time` is ~30 KiB, already in axum's tree.
 time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
+# Constant-time bearer-token comparison (issue #162). The previous
+# hand-rolled `constant_time_eq` had two flaws: the "fake work" loop
+# on length-mismatch was dead code LLVM would optimize away, and the
+# length-difference path was distinguishable from the length-equal
+# path by timing. `subtle` is the standard crate, no_std, no deps.
+subtle = { version = "2", default-features = false }
 
 # posix_fallocate for the memory.bin pre-allocation in BRANCH path
 # (issue #146). Avoids ext4 mballoc cost on writeback.

--- a/crates/forkd-controller/src/auth.rs
+++ b/crates/forkd-controller/src/auth.rs
@@ -73,26 +73,49 @@ fn reject(status: StatusCode, msg: &str) -> Response {
         .into_response()
 }
 
-/// Length-aware byte comparison that always reads both slices fully.
-/// Prevents an attacker from inferring the token length or matched
-/// prefix by timing the response.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        // Still iterate over the longer slice so the early-return path
-        // doesn't leak length information by being conspicuously fast.
-        let mut diff: u8 = 1;
-        let longer = if a.len() > b.len() { a } else { b };
-        for &x in longer {
-            diff = diff.wrapping_add(x.wrapping_mul(0));
-        }
-        let _ = diff;
-        return false;
-    }
-    let mut diff: u8 = 0;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
+/// Constant-time byte comparison of a presented bearer token against
+/// the daemon's expected token.
+///
+/// Backed by `subtle::ConstantTimeEq`, which compiles to a length-
+/// equal `ct_eq` and is the standard answer for this problem in Rust
+/// crypto code. We pad the presented token (in a fresh allocation) so
+/// the comparison path is the same regardless of input length — this
+/// closes the length-oracle vector reported in issue #162.
+///
+/// History: the previous hand-rolled implementation had two flaws —
+///
+/// 1. On length mismatch it executed a "fake work" loop using
+///    `wrapping_mul(0)`, which the compiler is allowed to (and does)
+///    erase as dead code, leaving response time monotonic in the
+///    longer slice's length.
+/// 2. Even if the loop had been preserved, taking different branches
+///    for length-mismatch vs length-equal is itself a timing oracle:
+///    the length-equal branch contains a real XOR loop, the mismatch
+///    branch a constant-bytes loop.
+///
+/// The fix here uses one code path regardless of input length and
+/// defers timing-resistance to `subtle`.
+fn constant_time_eq(presented: &[u8], expected: &[u8]) -> bool {
+    use subtle::ConstantTimeEq;
+    // Build a length-`expected.len()` view of the presented token so
+    // the comparison always runs on equal-length buffers. Bytes past
+    // `presented.len()` are zero-filled; any difference (extra bytes,
+    // missing bytes, wrong bytes) shows up as a non-zero XOR in the
+    // ct_eq result.
+    let n = expected.len();
+    let mut padded = vec![0u8; n];
+    let take = presented.len().min(n);
+    padded[..take].copy_from_slice(&presented[..take]);
+    // Combine the ct_eq result with a length-equality bit so a
+    // presented token that is a strict prefix of `expected` (padded
+    // would equal `expected` on the first n bytes but presented is
+    // shorter) is still rejected. Both branches reduce to the same
+    // arithmetic.
+    let bytes_match: bool = padded.ct_eq(expected).into();
+    // Length comparison is already constant-time at the CPU level.
+    // Non-short-circuiting bitwise AND keeps both sides evaluated so
+    // the function's total time doesn't depend on bytes_match's value.
+    bytes_match & (presented.len() == n)
 }
 
 #[cfg(test)]
@@ -110,5 +133,31 @@ mod tests {
         assert!(!constant_time_eq(b"abc", b"abd"));
         assert!(!constant_time_eq(b"abc", b"abcd"));
         assert!(!constant_time_eq(b"abcd", b"abc"));
+    }
+
+    #[test]
+    fn presented_prefix_of_expected_rejected() {
+        // Regression for #162: an attacker who guesses a prefix of the
+        // real token would have been distinguishable from a totally
+        // wrong guess in the old implementation. Now both reject.
+        assert!(!constant_time_eq(b"abc", b"abcdef"));
+        assert!(!constant_time_eq(b"", b"x"));
+    }
+
+    #[test]
+    fn presented_longer_than_expected_rejected() {
+        // Symmetric case: padded view truncates to expected's length,
+        // so an attacker can't bypass by appending garbage.
+        assert!(!constant_time_eq(b"abcdef", b"abc"));
+        assert!(!constant_time_eq(b"x", b""));
+    }
+
+    #[test]
+    fn all_zero_padding_doesnt_accidentally_match() {
+        // If `presented` is shorter than `expected`, the unfilled
+        // tail of `padded` is 0x00. Make sure that doesn't accidentally
+        // match an expected token whose tail also happens to be 0x00.
+        assert!(!constant_time_eq(b"ab", b"ab\x00\x00"));
+        assert!(!constant_time_eq(b"", b"\x00\x00"));
     }
 }


### PR DESCRIPTION
Closes #162.

The hand-rolled `constant_time_eq` in `crates/forkd-controller/src/auth.rs` was advertised as constant-time but leaked the presented token's length via two distinct paths, both reported precisely by @m-dmupba:

1. **Dead-code optimization**: the length-mismatch branch's "fake work" loop used `x.wrapping_mul(0) == 0`, which the compiler is allowed to (and LLVM does) eliminate. Response time was therefore monotonic in `max(len(presented), len(expected))`.

2. **Branch-shape oracle**: even if the loop had been preserved, taking different branches for length-equal vs length-mismatch is itself a timing oracle — equal-length ran a real XOR loop, mismatch ran a constant-byte loop.

For a deployment with a fixed-length token (e.g. 32-byte hex from `forkd doctor`), the length oracle collapses security to a single attempted length, after which the equal-length branch is genuinely constant-time.

## Fix

Replaced with `subtle::ConstantTimeEq` against a zero-padded copy of the presented token. Same code path regardless of input length; length difference is folded into the result via a non-short-circuiting bitwise AND so the function's total time doesn't depend on `bytes_match` either.

`subtle` was already an indirect dep via the rustls / aws-lc-rs subtree — confirmed by inspecting `Cargo.lock` (no new transitive entry added).

## Tests

Three regression tests added in addition to the original two:

- `presented_prefix_of_expected_rejected` — strict prefix attack
- `presented_longer_than_expected_rejected` — truncating attack
- `all_zero_padding_doesnt_accidentally_match` — zero-tail collision

```
cargo test -p forkd-controller --lib auth::
test auth::tests::all_zero_padding_doesnt_accidentally_match ... ok
test auth::tests::matching_tokens_eq ... ok
test auth::tests::presented_longer_than_expected_rejected ... ok
test auth::tests::presented_prefix_of_expected_rejected ... ok
test auth::tests::different_tokens_not_eq ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 34 filtered out
```

Built + tested on dev box (Ubuntu 24.04 / Linux 6.14 / rust stable).

## Test plan

- [x] `cargo check -p forkd-controller` passes
- [x] `cargo test -p forkd-controller --lib auth::` — 5 passed
- [x] `Cargo.lock` unchanged (subtle already transitive)
- [x] CHANGELOG.md entry under "Unreleased"

🤖 Generated with [Claude Code](https://claude.com/claude-code)