### PR TITLE
hub: add deeplethe/python-numpy v1

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -51,6 +51,31 @@
           "release_tag": "hub-coding-agent-fork-v1"
         }
       }
+    },
+    "deeplethe/python-numpy": {
+      "description": "Python 3.12 + numpy preinstalled. Default fork-target for the README quickstart and bench scripts.",
+      "versions": {
+        "latest": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-python-numpy-v1/python-numpy.forkd-snapshot.tar.zst",
+          "sha256": "811c2f6d9e0efbfd811c3f9da4e60722db26dc535e217761ebaa8a53acf33163",
+          "size_bytes": 16597810,
+          "memory_mib": 1536,
+          "base_image": "python:3.12-slim",
+          "recipe_path": "recipes/python-numpy",
+          "created_at": "2026-05-27T04:36:00Z",
+          "release_tag": "hub-python-numpy-v1"
+        },
+        "v1": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-python-numpy-v1/python-numpy.forkd-snapshot.tar.zst",
+          "sha256": "811c2f6d9e0efbfd811c3f9da4e60722db26dc535e217761ebaa8a53acf33163",
+          "size_bytes": 16597810,
+          "memory_mib": 1536,
+          "base_image": "python:3.12-slim",
+          "recipe_path": "recipes/python-numpy",
+          "created_at": "2026-05-27T04:36:00Z",
+          "release_tag": "hub-python-numpy-v1"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Adds the `deeplethe/python-numpy` entry to `registry.json`, wiring `forkd pull deeplethe/python-numpy` to the new release [`hub-python-numpy-v1`](https://github.com/deeplethe/forkd/releases/tag/hub-python-numpy-v1).

## Pack details

| field | value |
|---|---|
| description | Python 3.12 + numpy preinstalled. Default fork-target for the README quickstart and bench scripts. |
| base image | `python:3.12-slim` |
| memory_mib | 1536 |
| compressed | **15.8 MiB** (1.50 GiB uncompressed, 97× zstd) |
| sha256 | `811c2f6d9e0efbfd811c3f9da4e60722db26dc535e217761ebaa8a53acf33163` |
| recipe path | `recipes/python-numpy` |
| release tag | `hub-python-numpy-v1` |

## End-to-end verification

```
$ forkd pull https://github.com/deeplethe/forkd/releases/download/hub-python-numpy-v1/python-numpy.forkd-snapshot.tar.zst --tag test-pull-python-numpy
==> GET .../python-numpy.forkd-snapshot.tar.zst
       15.8 / 15.8 MiB (100.0% · 1.2 MiB/s)
✓ downloaded 15.8 MiB
✓ sha256 verified
✓ unpacked tag 'test-pull-python-numpy'
```

(Verified on the dev box, against the live GitHub Release.)

Once this merges, `forkd pull deeplethe/python-numpy` resolves through `registry.json` on `main`.

## Follow-up

The 6 other snapshot-producing recipes (`playwright-browser`, `e2b-codeinterpreter`, `postgres-fixture`, `coding-agent`, `nodejs`, `jupyter-kernel`, `agent-workbench`) are out of scope for this PR — they'll land in follow-ups, one per recipe to keep the diffs reviewable.