### PR TITLE
hub: add deeplethe/playwright-browser v1 (M1.1 headliner)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -76,6 +76,31 @@
           "release_tag": "hub-python-numpy-v1"
         }
       }
+    },
+    "deeplethe/playwright-browser": {
+      "description": "Node.js + Playwright 1.50 + Chromium pre-warmed with one about:blank tab. JSON-RPC command loop ready on stdin; sandbox.eval(<js>) reuses the warmed Chromium across all children. Per-child fork ~56 ms vs ~2-3 s cold-starting a headless Chromium container.",
+      "versions": {
+        "latest": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-playwright-browser-v1/playwright-browser.forkd-snapshot.tar.zst",
+          "sha256": "811db4deddfdc4b07931e353b20370f7270946456ba8722d372ba239dbba3f86",
+          "size_bytes": 110596798,
+          "memory_mib": 2048,
+          "base_image": "mcr.microsoft.com/playwright:v1.50.0-jammy",
+          "recipe_path": "recipes/playwright-browser",
+          "created_at": "2026-05-27T04:46:00Z",
+          "release_tag": "hub-playwright-browser-v1"
+        },
+        "v1": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-playwright-browser-v1/playwright-browser.forkd-snapshot.tar.zst",
+          "sha256": "811db4deddfdc4b07931e353b20370f7270946456ba8722d372ba239dbba3f86",
+          "size_bytes": 110596798,
+          "memory_mib": 2048,
+          "base_image": "mcr.microsoft.com/playwright:v1.50.0-jammy",
+          "recipe_path": "recipes/playwright-browser",
+          "created_at": "2026-05-27T04:46:00Z",
+          "release_tag": "hub-playwright-browser-v1"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Adds `deeplethe/playwright-browser` to `registry.json`, closing the M1.1 ROADMAP item "Hub-published playwright-browser pack". This is the recipe the README headlines for browser fan-out: per-child Chromium fork in ~56 ms vs ~2-3 s cold-starting a headless Chromium container.

## Pack details

| field | value |
|---|---|
| description | Node.js + Playwright 1.50 + Chromium pre-warmed with one about:blank tab. JSON-RPC command loop ready on stdin; sandbox.eval(<js>) reuses the warmed Chromium across all children. |
| base image | `mcr.microsoft.com/playwright:v1.50.0-jammy` |
| memory_mib | 2048 (Chromium OOMs on the 512 MiB default) |
| compressed | **105.5 MiB** (2.00 GiB uncompressed, 19.4× zstd — Chromium memory has more entropy than pure Python; cf. python-numpy at 97× on the same setup) |
| sha256 | `811db4deddfdc4b07931e353b20370f7270946456ba8722d372ba239dbba3f86` |
| recipe path | `recipes/playwright-browser` |
| release tag | `hub-playwright-browser-v1` |

## End-to-end verification

```
$ forkd pull https://github.com/deeplethe/forkd/releases/download/hub-playwright-browser-v1/playwright-browser.forkd-snapshot.tar.zst --tag test-pull-playwright --force
==> GET .../playwright-browser.forkd-snapshot.tar.zst
       105.5 / 105.5 MiB (100.0% · 1.2 MiB/s)
✓ downloaded 105.5 MiB
✓ sha256 verified
✓ unpacked tag 'test-pull-playwright'
```

(Verified on the dev box. ~95 s download on a residential link; ~5 s on github.com to github.com runners.)

## Why now

After #166 (python-numpy), this is the second-most-headlined recipe in the README — the "100-300× win on browser fan-out" claim is now backed by a single `forkd pull` instead of a 2-3 minute build.

## Follow-up

`coding-agent`, `e2b-codeinterpreter`, `postgres-fixture`, `nodejs`, `jupyter-kernel`, `agent-workbench` remain — same per-recipe PR pattern.