### PR TITLE
hub: add deeplethe/postgres-fixture v1 (fork-per-test DB)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -101,6 +101,31 @@
           "release_tag": "hub-playwright-browser-v1"
         }
       }
+    },
+    "deeplethe/postgres-fixture": {
+      "description": "PostgreSQL 16 with initdb complete + postmaster pre-launched. Children fork ready-to-query at user=forkd, db=forkd_test, listening on guest 10.42.0.2:5432. ~10 ms per child vs ~2 s for a fresh container start + initdb — the fork-per-test isolated-database pattern from the README's production case shapes.",
+      "versions": {
+        "latest": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-postgres-fixture-v1/postgres-fixture.forkd-snapshot.tar.zst",
+          "sha256": "bba5e79aaab01830519b925a8ac9eebd0d21ecbecd9687408b18a0473324d27f",
+          "size_bytes": 39852722,
+          "memory_mib": 1024,
+          "base_image": "postgres:16",
+          "recipe_path": "recipes/postgres-fixture",
+          "created_at": "2026-05-27T04:57:00Z",
+          "release_tag": "hub-postgres-fixture-v1"
+        },
+        "v1": {
+          "url": "https://github.com/deeplethe/forkd/releases/download/hub-postgres-fixture-v1/postgres-fixture.forkd-snapshot.tar.zst",
+          "sha256": "bba5e79aaab01830519b925a8ac9eebd0d21ecbecd9687408b18a0473324d27f",
+          "size_bytes": 39852722,
+          "memory_mib": 1024,
+          "base_image": "postgres:16",
+          "recipe_path": "recipes/postgres-fixture",
+          "created_at": "2026-05-27T04:57:00Z",
+          "release_tag": "hub-postgres-fixture-v1"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Adds `deeplethe/postgres-fixture` to `registry.json` — the isolated-DB-per-test shape from the README's production case shapes.

## Pack details

| field | value |
|---|---|
| description | PostgreSQL 16 with initdb complete + postmaster pre-launched. Children fork ready-to-query at user=forkd, db=forkd_test, listening on guest 10.42.0.2:5432. |
| base image | `postgres:16` |
| memory_mib | 1024 |
| compressed | **38.0 MiB** (1.00 GiB uncompressed, 26.9× zstd) |
| sha256 | `bba5e79aaab01830519b925a8ac9eebd0d21ecbecd9687408b18a0473324d27f` |
| recipe path | `recipes/postgres-fixture` |
| release tag | `hub-postgres-fixture-v1` |

## Headline numbers

- **Per-child fork-per-test**: ~10 ms (vs ~2 s for a fresh container start + initdb)
- Every child gets an identical, isolated, ready-to-query DB; tests that mutate diverge only on the pages they touch

## End-to-end verification

```
$ forkd pull https://github.com/deeplethe/forkd/releases/download/hub-postgres-fixture-v1/postgres-fixture.forkd-snapshot.tar.zst --tag test-pull-postgres --force
✓ downloaded 38.0 MiB
✓ sha256 verified
✓ unpacked tag 'test-pull-postgres'
```

## Follow-up

`coding-agent`, `e2b-codeinterpreter`, `nodejs`, `jupyter-kernel`, `agent-workbench` remain.