### PR TITLE
docs: close M1.2 — 9 recipes in Hub, hosting decision, README done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,14 +59,24 @@ Done when:
 - ✓ CLI ships `forkd pack`, `forkd unpack`, `forkd pull`, `forkd push`,
   `forkd images`. Pack format v1 documented inline in `hub.rs`
   (tar.zst + manifest.toml + per-file sha256). ([#29](https://github.com/deeplethe/forkd/issues/29))
-- ☐ R2 / S3 bucket provisioned at `forkd-hub.deeplethe.com` and
-  default CLI hub URL pointed at it.
-- ☐ All 7 existing recipes (incl. playwright-browser) pushed to the
-  bucket; on a clean Ubuntu host, `forkd pull deeplethe/python-numpy
-  && forkd fork --tag python-numpy -n 100` works end-to-end without
-  running any recipe build script.
-- ☐ README quickstart rewritten to lead with `forkd pull` (currently
-  just mentions it as a section, not as the default path).
+- ✓ Hosting decided: **GitHub Releases** instead of an R2/S3 bucket —
+  free, free egress, stable URLs, no infra to operate. Registry
+  index served from
+  `raw.githubusercontent.com/deeplethe/forkd/main/registry.json`
+  (default `--hub` URL). The original `forkd-hub.deeplethe.com`
+  custom-domain plan is dropped as unnecessary.
+- ✓ **9 snapshot-producing recipes published**: `python-numpy`,
+  `playwright-browser`, `postgres-fixture`, `coding-agent`, `nodejs`,
+  `e2b-codeinterpreter`, `jupyter-kernel`, `langgraph-react`,
+  `coding-agent-fork`. `forkd pull deeplethe/python-numpy && forkd
+  fork --tag python-numpy -n 100` works end-to-end from a clean
+  Ubuntu host without running any recipe build script.
+  (`agent-workbench` is the one remaining recipe with a `build.sh`;
+  its base image pull from `ghcr.io/agent-infra/sandbox:latest` is
+  rate-limit-sensitive and will land in a follow-up.)
+- ✓ README quickstart leads with `forkd pull` — both `README.md`
+  and `README-zh.md`. `from-image` and `from-source` are reframed
+  as "Alternative:" sections. ([#165](https://github.com/deeplethe/forkd/pull/165))
 
 Risk: base-image redistribution licensing per recipe. Triaged 1-time
 at start; expected clear since all our base images are Apache / BSD /

--- a/docs/HUB.md
+++ b/docs/HUB.md
@@ -30,12 +30,15 @@ you run your own (e.g., internal mirror, or your own fork's recipes).
 
 | Name | Description | Memory | Pack size |
 |---|---|---:|---:|
-| `deeplethe/langgraph-react` | ReAct agent for the branch-and-fan-out demo (Python 3.12 + requests) | 513 MiB | 14.5 MiB |
-| `deeplethe/coding-agent-fork` | Pre-warmed snapshot: `/tmp/workspace` already has the buggy mathy package, 50 MiB synthetic vendored.bin, `__pycache__` populated. Children boot 'ready to BRANCH'. | 513 MiB | 67.6 MiB |
-
-More recipes (`postgres-fixture`, `python-numpy`, `agent-workbench`)
-will land here as `recipes/<name>/build.sh` matures and we automate
-the publishing pipeline.
+| `deeplethe/python-numpy` | Python 3.12 + numpy preinstalled. Default fork-target for the README quickstart and bench scripts. | 1536 MiB | 15.8 MiB |
+| `deeplethe/playwright-browser` | Node.js + Playwright 1.50 + Chromium pre-warmed with one `about:blank` tab. ~56 ms fork vs ~2-3 s cold container. | 2048 MiB | 105.5 MiB |
+| `deeplethe/postgres-fixture` | PostgreSQL 16 with `initdb` done + postmaster pre-launched. ~10 ms fork-per-test vs ~2 s fresh container start. | 1024 MiB | 38.0 MiB |
+| `deeplethe/coding-agent` | Python 3.12 + git + `gh` CLI + pytest. SWE-bench-style parallel evals — each child gets an isolated `git clone + pip install + pytest`. | 1024 MiB | 15.2 MiB |
+| `deeplethe/nodejs` | Node.js 22 slim runtime preloaded. Generic JS workload base. | 512 MiB | 10.5 MiB |
+| `deeplethe/e2b-codeinterpreter` | E2B code-interpreter image preloaded (Python + Node + Jupyter + ML libs). Drop-in for the E2B sandbox API via forkd's Python SDK. | 2048 MiB | 21.6 MiB |
+| `deeplethe/jupyter-kernel` | Jupyter scipy-notebook with IPython + numpy + scipy + pandas + matplotlib pre-imported. | 2048 MiB | 15.5 MiB |
+| `deeplethe/langgraph-react` | ReAct agent for the branch-and-fan-out demo (Python 3.12 + requests). | 513 MiB | 14.5 MiB |
+| `deeplethe/coding-agent-fork` | Pre-warmed: `/tmp/workspace` with the buggy mathy package, 50 MiB synthetic `vendored.bin`, populated `__pycache__/`. Children boot 'ready to BRANCH'. | 513 MiB | 67.6 MiB |
 
 The `coding-agent-fork` pack is intentionally larger than
 `langgraph-react`: it carries a 50 MiB synthetic `vendored.bin` of


### PR DESCRIPTION
Closes the M1.2 Snapshot Hub MVP milestone in ROADMAP.md and brings docs/HUB.md in line with reality.

## ROADMAP.md M1.2

All four done-when items flipped to ✓:

| Done when | Status |
|---|---|
| CLI ships pack/unpack/pull/push/images | ✓ (was already) |
| Hosting decided | ✓ (GitHub Releases instead of R2/S3 — see new explainer in the file) |
| All recipes published | ✓ (9 shipped: python-numpy, playwright-browser, postgres-fixture, coding-agent, nodejs, e2b-codeinterpreter, jupyter-kernel, langgraph-react, coding-agent-fork; agent-workbench deferred) |
| README quickstart leads with `forkd pull` | ✓ (#165) |

## docs/HUB.md

"What's currently published" table grown from 2 to 9 entries. The "more recipes will land here as `recipes/<name>/build.sh` matures" disclaimer removed — most recipes have matured.

Order in the table: the 7 new recipes first (since they're the result of this week's M1.2 push), then the 2 pre-existing.

## Out of scope

- `agent-workbench` — `ghcr.io/agent-infra/sandbox:latest` pulls are rate-limit-sensitive from our dev box; will land in a follow-up PR once we either pre-pull the image or switch sources.