### PR TITLE
fix(vmm): apply_diff rejects diff/base size mismatch (closes #180)

### DIFF
--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -1265,14 +1265,8 @@ pub fn apply_diff(diff: &Path, base: &Path) -> Result<u64> {
     // past `base_len` to silently extend the base file (Linux semantics
     // for writes to O_RDWR files past EOF), corrupting the snapshot for
     // any subsequent mmap-based restore. See #180.
-    let diff_len_u = diff_f
-        .metadata()
-        .context("stat diff")?
-        .len();
-    let base_len_u = base_f
-        .metadata()
-        .context("stat base")?
-        .len();
+    let diff_len_u = diff_f.metadata().context("stat diff")?.len();
+    let base_len_u = base_f.metadata().context("stat base")?.len();
     if diff_len_u != base_len_u {
         bail!(
             "apply_diff: size mismatch (diff={diff_len_u} B vs base={base_len_u} B); \

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -1234,9 +1234,13 @@ impl Snapshot {
 /// Safety / correctness:
 /// - Both files must already exist; `base` is opened O_RDWR, `diff`
 ///   O_RDONLY.
-/// - The diff's logical size must equal base's. We don't enforce this
-///   beyond `pwrite` bounds; mismatch leaves base in an undefined state.
-///   (The caller is `forkd-controller`, which controls both files.)
+/// - The diff's logical size **must equal** base's. Enforced at the top
+///   of the function — mismatch returns an error rather than extending
+///   the base file (which would silently corrupt the snapshot; the next
+///   restore via `mmap` would see a larger memory image than the guest
+///   was built with). The check exists for callers outside the daemon
+///   path and for upgrade scenarios where a stale `last_branch_memory_path`
+///   survives a format change.
 /// - No fsync — the merge is allowed to be in page cache until the
 ///   children's restore mmaps it. If the host crashes mid-merge,
 ///   subsequent restore reads garbage; durability of the shadow file
@@ -1256,7 +1260,26 @@ pub fn apply_diff(diff: &Path, base: &Path) -> Result<u64> {
         .open(base)
         .with_context(|| format!("open base {}", base.display()))?;
 
-    let diff_len = diff_f.metadata()?.len() as i64;
+    // Size-invariant check: the diff and base must be the same logical
+    // size. Without this, a larger diff would cause `base_f.write_all`
+    // past `base_len` to silently extend the base file (Linux semantics
+    // for writes to O_RDWR files past EOF), corrupting the snapshot for
+    // any subsequent mmap-based restore. See #180.
+    let diff_len_u = diff_f
+        .metadata()
+        .context("stat diff")?
+        .len();
+    let base_len_u = base_f
+        .metadata()
+        .context("stat base")?
+        .len();
+    if diff_len_u != base_len_u {
+        bail!(
+            "apply_diff: size mismatch (diff={diff_len_u} B vs base={base_len_u} B); \
+             refusing to corrupt base — diff and base must have identical logical size"
+        );
+    }
+    let diff_len = diff_len_u as i64;
     let mut copied: u64 = 0;
     let mut cursor: i64 = 0;
     // Cap buffer at 1 MiB so we don't allocate the whole guest RAM on a
@@ -1589,6 +1612,46 @@ mod tests {
         assert!(
             result.iter().all(|&b| b == 0xAA),
             "base should be untouched"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn apply_diff_rejects_size_mismatch() {
+        // Regression for #180: a diff that's larger than its base must
+        // not silently extend the base file. Without the size-equality
+        // check at the top of apply_diff, base_f.write_all past the
+        // base's original length would grow the file and corrupt the
+        // snapshot for any subsequent mmap-based restore.
+        let tmp =
+            std::env::temp_dir().join(format!("apply-diff-mismatch-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let base = tmp.join("base.bin");
+        let diff = tmp.join("diff.bin");
+
+        // Base = 8 KiB, diff = 16 KiB (mismatch).
+        std::fs::write(&base, vec![0xAAu8; 8 * 1024]).unwrap();
+        std::fs::write(&diff, vec![0xBBu8; 16 * 1024]).unwrap();
+
+        let err = apply_diff(&diff, &base).expect_err("size mismatch should error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("size mismatch"),
+            "expected 'size mismatch' in error, got: {msg}"
+        );
+        // Base must be untouched — no silent extension.
+        let result = std::fs::read(&base).unwrap();
+        assert_eq!(
+            result.len(),
+            8 * 1024,
+            "base must not have been extended; got len {}",
+            result.len()
+        );
+        assert!(
+            result.iter().all(|&b| b == 0xAA),
+            "base bytes must be untouched"
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -1625,8 +1625,7 @@ mod tests {
         // check at the top of apply_diff, base_f.write_all past the
         // base's original length would grow the file and corrupt the
         // snapshot for any subsequent mmap-based restore.
-        let tmp =
-            std::env::temp_dir().join(format!("apply-diff-mismatch-{}", std::process::id()));
+        let tmp = std::env::temp_dir().join(format!("apply-diff-mismatch-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
         let base = tmp.join("base.bin");
         let diff = tmp.join("diff.bin");


### PR DESCRIPTION
Closes #180. Thanks to @okturro for the precise diagnosis (and the 5-line suggested fix — basically lifted verbatim).

## Root cause

\`apply_diff\` only read \`diff_len\` and used it to drive the SEEK_DATA loop. \`base_len\` was never checked. If a caller passed a diff larger than the base, the inner \`base_f.write_all\` past the base's original length would silently extend the base file (standard Linux O_RDWR semantics) — corrupting the snapshot, because the next mmap-based restore would see a larger memory image than the guest was originally built with.

The docstring at \`lib.rs:1237-1238\` even acknowledged the gap (\"we don't enforce this beyond \`pwrite\` bounds\") — exactly the kind of "footgun documented in the comment" that breaks for a future caller or upgrade path. Latent for now because the sole in-tree caller is \`forkd-controller\` which controls both files.

## Fix

- Read \`diff_len\` and \`base_len\` at the top of the function and \`bail!\` if they differ, with both sizes in the error message.
- Update the docstring's safety/correctness bullet from "We don't enforce this" → documents the enforcement and explains the silent-extension failure mode it prevents.
- Add \`apply_diff_rejects_size_mismatch\` regression test:
  - Constructs an 8 KiB base + 16 KiB diff (mismatch).
  - Asserts \`apply_diff\` returns an error containing "size mismatch".
  - Asserts the base bytes AND length are untouched (i.e., no silent extension).

## Local verification on the dev box

\`\`\`
$ cargo fmt --all -- --check                # clean
$ cargo check --all-targets                 # ok (lesson from #179 — don't skip --all-targets)
$ cargo test -p forkd-vmm --lib apply_diff
  running 3 tests
  test tests::apply_diff_rejects_size_mismatch ... ok
  test tests::apply_diff_handles_empty_diff ... ok
  test tests::apply_diff_copies_only_data_regions ... ok

  test result: ok. 3 passed; 0 failed
\`\`\`