### PR TITLE
feat(metrics): expose forkd_branches_in_flight + cap (follow-up to #177)

### DIFF
--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -60,6 +60,10 @@ pub struct AppState {
     /// of memory.bin; without a cap, an attacker can fill the disk by
     /// firing many BRANCHes in parallel.
     pub branch_sem: Arc<Semaphore>,
+    /// The configured maximum the `branch_sem` was constructed with.
+    /// Tracked separately for `/metrics` (`forkd_branch_concurrency_cap`)
+    /// because `Semaphore` doesn't expose its initial permit count.
+    pub branch_concurrency_cap: usize,
     /// Scratch directory used for prewarm throwaway snapshots when
     /// `CreateSandboxRequest::prewarm` is set. Mirror of
     /// `DaemonConfig::prewarm_scratch_dir`.
@@ -178,6 +182,8 @@ async fn version() -> impl IntoResponse {
 
 async fn metrics(State(s): State<SharedState>) -> impl IntoResponse {
     let (snap_count, sb_count) = s.registry.counts();
+    let branches_in_flight = s.branch_in_flight.lock().len();
+    let branch_cap = s.branch_concurrency_cap;
     // Prometheus text format. Keep names stable — exporters depend on them.
     let body = format!(
         "# HELP forkd_snapshots_total Number of snapshots known to the controller.\n\
@@ -186,6 +192,12 @@ async fn metrics(State(s): State<SharedState>) -> impl IntoResponse {
          # HELP forkd_sandboxes_active Number of active sandboxes (child VMs).\n\
          # TYPE forkd_sandboxes_active gauge\n\
          forkd_sandboxes_active {sb_count}\n\
+         # HELP forkd_branches_in_flight Number of BRANCH operations currently writing memory.bin.\n\
+         # TYPE forkd_branches_in_flight gauge\n\
+         forkd_branches_in_flight {branches_in_flight}\n\
+         # HELP forkd_branch_concurrency_cap Configured maximum concurrent BRANCH operations.\n\
+         # TYPE forkd_branch_concurrency_cap gauge\n\
+         forkd_branch_concurrency_cap {branch_cap}\n\
          # HELP forkd_build_info Build version of the controller binary.\n\
          # TYPE forkd_build_info gauge\n\
          forkd_build_info{{version=\"{BUILD_VERSION}\"}} 1\n"
@@ -1609,6 +1621,7 @@ mod tests {
             snapshot_root,
             branch_in_flight: Mutex::new(HashSet::new()),
             branch_sem: Arc::new(Semaphore::new(DEFAULT_BRANCH_CONCURRENCY)),
+            branch_concurrency_cap: DEFAULT_BRANCH_CONCURRENCY,
             prewarm_scratch_dir: std::env::temp_dir().join("forkd-test-prewarm"),
         })
     }
@@ -1663,6 +1676,61 @@ mod tests {
         let s = std::str::from_utf8(&body).unwrap();
         assert!(s.contains("forkd_sandboxes_active 0"));
         assert!(s.contains("forkd_build_info"));
+        // BRANCH concurrency observability (see #177 / #179 follow-up).
+        assert!(s.contains("forkd_branches_in_flight 0"));
+        assert!(
+            s.contains(&format!(
+                "forkd_branch_concurrency_cap {DEFAULT_BRANCH_CONCURRENCY}"
+            )),
+            "expected cap to surface as the test_state default; got body:\n{s}"
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_branches_in_flight_tracks_slot_acquisitions() {
+        // Regression for the #179 follow-up: forkd_branches_in_flight
+        // must increment while a BranchSlot is held and decrement when
+        // it's dropped. Without this guarantee, operators can't size
+        // FORKD_BRANCH_CONCURRENCY empirically — which is the whole
+        // point of exposing it as a CLI flag.
+        let state = test_state();
+        let slot_a = state.try_acquire_branch_slot("t1").unwrap();
+        let slot_b = state.try_acquire_branch_slot("t2").unwrap();
+        let app = router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(resp.into_body(), 4096).await.unwrap();
+        let s = std::str::from_utf8(&body).unwrap();
+        assert!(
+            s.contains("forkd_branches_in_flight 2"),
+            "expected 2 in-flight branches while two slots are held; got:\n{s}"
+        );
+        // Drop both — the gauge must come back to 0.
+        drop(slot_a);
+        drop(slot_b);
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(resp.into_body(), 4096).await.unwrap();
+        let s = std::str::from_utf8(&body).unwrap();
+        assert!(
+            s.contains("forkd_branches_in_flight 0"),
+            "expected gauge to return to 0 after slot drops; got:\n{s}"
+        );
     }
 
     #[tokio::test]
@@ -1757,6 +1825,7 @@ mod tests {
             snapshot_root,
             branch_in_flight: Mutex::new(HashSet::new()),
             branch_sem: Arc::new(Semaphore::new(2)),
+            branch_concurrency_cap: 2,
             prewarm_scratch_dir: std::env::temp_dir().join("forkd-test-prewarm"),
         });
         let _a = s.try_acquire_branch_slot("t1").unwrap();
@@ -1779,6 +1848,7 @@ mod tests {
             snapshot_root,
             branch_in_flight: Mutex::new(HashSet::new()),
             branch_sem: Arc::new(Semaphore::new(1)),
+            branch_concurrency_cap: 1,
             prewarm_scratch_dir: std::env::temp_dir().join("forkd-test-prewarm"),
         });
         let a = s.try_acquire_branch_slot("t1").unwrap();

--- a/crates/forkd-controller/src/lib.rs
+++ b/crates/forkd-controller/src/lib.rs
@@ -132,6 +132,7 @@ pub async fn run_daemon(cfg: DaemonConfig) -> Result<()> {
         snapshot_root: cfg.snapshot_root.clone(),
         branch_in_flight: Mutex::new(std::collections::HashSet::new()),
         branch_sem: std::sync::Arc::new(tokio::sync::Semaphore::new(branch_concurrency)),
+        branch_concurrency_cap: branch_concurrency,
         prewarm_scratch_dir: cfg.prewarm_scratch_dir.clone(),
     });
 


### PR DESCRIPTION
Follow-up to #179, fulfilling the metrics suggestion @cortsdine raised in #177:

> While in there: it'd be worth surfacing the *current* in-flight count via \`/metrics\` (\`forkd_branches_in_flight\`) so operators can size the cap empirically.

Adding both the in-flight count and the configured cap, so a Grafana panel can render \"5 / 16 in-flight\" without external knowledge of \`FORKD_BRANCH_CONCURRENCY\`.

## New gauges on \`/metrics\`

| Gauge | Value |
|---|---|
| \`forkd_branches_in_flight\` | \`branch_in_flight.lock().len()\` — number of BRANCHes currently writing \`memory.bin\` |
| \`forkd_branch_concurrency_cap\` | The value the \`branch_sem\` Semaphore was constructed with (defaults to \`DEFAULT_BRANCH_CONCURRENCY = 4\`, configurable via \`--branch-concurrency\` / \`FORKD_BRANCH_CONCURRENCY\` from #179) |

\`tokio::Semaphore\` doesn't expose its initial permit count, so the cap is cached on \`AppState\` in a new \`branch_concurrency_cap: usize\` field that mirrors the value from \`DaemonConfig::branch_concurrency\`. Threading change touches only the constructor — the rest of \`AppState\` is unchanged.

## Tests

- \`metrics_emits_prometheus_text\` extended to assert both new gauges appear with the \`test_state\` default cap (\`DEFAULT_BRANCH_CONCURRENCY\`).
- New \`metrics_branches_in_flight_tracks_slot_acquisitions\` — acquires two \`BranchSlot\`s, asserts \`forkd_branches_in_flight 2\`, drops both, asserts the gauge returns to \`0\`. This is the same Drop-recovery invariant @henliveira singled out in #178; now externally observable.

Local on the dev box:

\`\`\`
$ cargo fmt --all -- --check        # clean
$ cargo check --all-targets          # ok (12.4s)
$ cargo test -p forkd-controller --lib metrics
  test http::tests::metrics_emits_prometheus_text ... ok
  test http::tests::metrics_branches_in_flight_tracks_slot_acquisitions ... ok
  test result: ok. 2 passed; 0 failed
\`\`\`

## Out of scope

The CHANGELOG is left to the maintainer (per the project convention). No CLI flag added — the cap is already configurable from #179.