### PR TITLE
packaging(systemd): add cgroup to RestrictNamespaces (closes #163)

### DIFF
--- a/packaging/systemd/forkd-controller.service
+++ b/packaging/systemd/forkd-controller.service
@@ -36,7 +36,19 @@ ProtectKernelModules=true
 LockPersonality=true
 MemoryDenyWriteExecute=false
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
-RestrictNamespaces=net mnt user pid
+# Allowed namespaces (RestrictNamespaces is an allowlist; everything else
+# returns EPERM on unshare/clone). Document the reason for each so a
+# well-intentioned trim doesn't silently break a feature:
+#   net    — per-child network namespace (one tap + one bridge endpoint
+#            per fork)
+#   mnt    — per-VM mount namespace (rootfs, virtio-fs, scratch)
+#   user   — unprivileged subprocess isolation
+#   pid    — Firecracker per-VM PID namespace (so PID 1 in the guest
+#            doesn't collide with host PIDs in logs and signals)
+#   cgroup — required for per-child cgroup-v2 namespace under the
+#            delegated subtree (without this, `unshare(CLONE_NEWCGROUP)`
+#            returns EPERM — see #163)
+RestrictNamespaces=net mnt user pid cgroup
 RestrictRealtime=true
 SystemCallArchitectures=native
 SystemCallFilter=@system-service


### PR DESCRIPTION
Closes #163. Thanks @mrvellang for catching the latent trap.

\`RestrictNamespaces\` is an allowlist — anything not enumerated returns \`EPERM\` on \`unshare\`/\`clone\`. Two changes to \`packaging/systemd/forkd-controller.service\`:

1. **Add \`cgroup\` to the allowlist.** Without it, the moment we wire up per-child cgroup-v2 namespaces (the natural next step for fork-out isolation, and one we're sketching for v0.4 — see [\`DESIGN-v0.4-USER-API.md\`](https://github.com/deeplethe/forkd/blob/main/DESIGN-v0.4-USER-API.md)), \`unshare(CLONE_NEWCGROUP)\` silently returns \`EPERM\` from inside the service. The kind of trap that costs an afternoon to debug, exactly as #163 warned.

2. **Inline-comment each token** (net / mnt / user / pid / cgroup) explaining why it's there. The previous one-line directive made each token equally easy to remove on a future hardening pass; now a reviewer can see what gates what.

No behaviour change today — the controller doesn't yet \`unshare(CLONE_NEWCGROUP)\`. This unblocks future per-child cgroup namespacing without surfacing the EPERM at the worst moment.