### PR TITLE
feat(vmm): v0.4 Phase 5b — MemoryBackend::MemfdShared via restore_many_with

### DIFF
--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -228,6 +228,12 @@ pub struct Vm {
     /// cgroup v2 directory this VM's Firecracker process was placed in,
     /// if `ForkOpts::memory_limit_mib` was set. Removed on Drop.
     pub cgroup: Option<PathBuf>,
+    /// memfd holding this VM's restored guest RAM, when spawned under
+    /// `MemoryBackend::MemfdShared`. Held for the VM's lifetime so the
+    /// kernel keeps the backing pages alive; closed automatically on
+    /// Drop. Phase 6's UFFD_WP arming will dup this fd to register a
+    /// `userfaultfd` against the same VMA.
+    pub memfd: Option<memfd::MemfdRegion>,
 }
 
 impl Vm {
@@ -304,6 +310,20 @@ pub enum MemoryBackend {
     Userfault {
         handler_sock: PathBuf,
     },
+    /// v0.4 live-fork backing. Each restored child gets its own memfd
+    /// populated from the snapshot's memory.bin; the patched
+    /// Firecracker (deeplethe/firecracker:forkd-v0.4-mem-backend-shared,
+    /// see `docs/VENDORED-FIRECRACKER.md`) mmaps the memfd with
+    /// `MAP_SHARED` so the controller can later arm
+    /// `UFFDIO_WRITEPROTECT` on the same backing and capture dirty
+    /// pages asynchronously — the actual live-fork primitive lands in
+    /// Phase 6.
+    ///
+    /// Requires the patched FC binary at runtime; an unpatched FC
+    /// silently falls back to `MAP_PRIVATE`, breaking the WP-capture
+    /// invariant. `forkd doctor` (Phase 8) will check for the patched
+    /// binary at daemon start.
+    MemfdShared,
 }
 
 /// Options controlling a fork-many operation.
@@ -1044,16 +1064,15 @@ impl Snapshot {
 
     /// Same as `restore_many` but with explicit options.
     pub fn restore_many_with(&self, opts: ForkOpts, work_dir: &Path) -> Result<ForkResult> {
-        // v0.3 scaffolding: the Userfault arm is reserved for the live-fork
-        // design in docs/design/userfaultfd.md but isn't wired up yet. Fail
-        // loudly so callers know not to rely on it; falling back to File
-        // would silently give them v0.2 semantics with the wrong perf
-        // expectations.
-        if !matches!(opts.memory_backend, MemoryBackend::File) {
-            bail!(
+        // v0.3 Userfault scaffolding is intentionally not wired up yet.
+        // v0.4 MemfdShared (Phase 5b) IS wired below. Anything else
+        // fails loudly so callers don't silently get File semantics.
+        match opts.memory_backend {
+            MemoryBackend::File | MemoryBackend::MemfdShared => {}
+            MemoryBackend::Userfault { .. } => bail!(
                 "MemoryBackend::Userfault is v0.3 scaffolding and not yet \
                  implemented — see docs/design/userfaultfd.md for status"
-            );
+            ),
         }
         let n = opts.n;
         std::fs::create_dir_all(work_dir).context("create fork work_dir")?;
@@ -1094,6 +1113,7 @@ impl Snapshot {
                 console,
                 netns,
                 cgroup: None,
+                memfd: None,
             });
         }
         for c in &children {
@@ -1126,21 +1146,63 @@ impl Snapshot {
             }
         }
 
+        // Phase 1.5 (v0.4 MemfdShared): create one memfd per child,
+        // populated from the snapshot's memory.bin, before any restore
+        // request goes out. The memfd holds the FC-visible RAM pages;
+        // forkd-controller keeps an mmap on the same memfd so Phase 6
+        // can arm UFFDIO_WRITEPROTECT on the shared VMA.
+        if matches!(opts.memory_backend, MemoryBackend::MemfdShared) {
+            for (i, child) in children.iter_mut().enumerate() {
+                let region = memfd::create_and_populate(
+                    &self.memory,
+                    &format!("forkd-source-mem-{}", opts.netns_offset + i + 1),
+                )
+                .with_context(|| {
+                    format!(
+                        "create_and_populate memfd from {} for child #{}",
+                        self.memory.display(),
+                        i + 1
+                    )
+                })?;
+                child.memfd = Some(region);
+            }
+        }
+
         // Phase 2: parallel restore via threads. Each thread issues one
-        // /snapshot/load PUT to its child's API socket.
+        // /snapshot/load PUT to its child's API socket. Body varies per
+        // child only under MemfdShared (each child has its own memfd
+        // path); for the File path, all children share the same JSON.
         let restore_start = Instant::now();
-        let body = serde_json::json!({
-            "snapshot_path": &self.vmstate,
-            "mem_backend": {"backend_path": &self.memory, "backend_type": "File"},
-            "enable_diff_snapshots": opts.enable_diff_snapshots,
-            "resume_vm": true,
-        })
-        .to_string();
+        let bodies: Vec<String> = children
+            .iter()
+            .map(|c| match &c.memfd {
+                Some(region) => serde_json::json!({
+                    "snapshot_path": &self.vmstate,
+                    "mem_backend": {
+                        "backend_path": region.backend_path(),
+                        "backend_type": "File",
+                        "shared": true,
+                    },
+                    "enable_diff_snapshots": opts.enable_diff_snapshots,
+                    "resume_vm": true,
+                })
+                .to_string(),
+                None => serde_json::json!({
+                    "snapshot_path": &self.vmstate,
+                    "mem_backend": {
+                        "backend_path": &self.memory,
+                        "backend_type": "File",
+                    },
+                    "enable_diff_snapshots": opts.enable_diff_snapshots,
+                    "resume_vm": true,
+                })
+                .to_string(),
+            })
+            .collect();
 
         let mut handles = Vec::with_capacity(n);
-        for c in &children {
+        for (c, body) in children.iter().zip(bodies.into_iter()) {
             let sock = c.sock.clone();
-            let body = body.clone();
             handles.push(thread::spawn(move || -> Result<()> {
                 api_call(&sock, "PUT", "/snapshot/load", &body)
             }));

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -841,6 +841,7 @@ impl Vm {
             console,
             netns: None,
             cgroup: None,
+            memfd: None,
         })
     }
 

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -1202,7 +1202,7 @@ impl Snapshot {
             .collect();
 
         let mut handles = Vec::with_capacity(n);
-        for (c, body) in children.iter().zip(bodies.into_iter()) {
+        for (c, body) in children.iter().zip(bodies) {
             let sock = c.sock.clone();
             handles.push(thread::spawn(move || -> Result<()> {
                 api_call(&sock, "PUT", "/snapshot/load", &body)


### PR DESCRIPTION
Builds on the Phase 5a helper ([#186](https://github.com/deeplethe/forkd/pull/186)) by wiring memfd-backed restore into the existing parallel-restore path. When \`ForkOpts::memory_backend == MemoryBackend::MemfdShared\`, each restored child gets its own memfd populated from the snapshot's \`memory.bin\`, and the JSON PUT to \`/snapshot/load\` carries \`mem_backend.shared: true\` against \`/proc/self/fd/<N>\`.

The patched Firecracker at [\`deeplethe/firecracker:forkd-v0.4-mem-backend-shared\`](https://github.com/deeplethe/firecracker/tree/forkd-v0.4-mem-backend-shared) honours the new \`shared\` flag and mmaps with \`MAP_SHARED\`; forkd-controller can then arm \`UFFDIO_WRITEPROTECT\` on the same backing in **Phase 6** to capture dirty pages asynchronously.

## What changed in \`crates/forkd-vmm/src/lib.rs\`

| Surface | Before | After |
|---|---|---|
| \`MemoryBackend\` enum | \`File\` (default), \`Userfault\` (todo) | + \`MemfdShared\` |
| \`Vm\` struct | proc/pid/sock/console/netns/cgroup | + public \`memfd: Option<MemfdRegion>\` |
| \`restore_many_with\` pre-flight | rejects everything except \`File\` | allows \`File\` and \`MemfdShared\`; still bails on \`Userfault\` |
| Restore-path JSON body | single shared \`String\` cloned to every thread | per-child \`Vec<String>\`; each MemfdShared child stamps its own \`/proc/self/fd/<N>\` + \`shared: true\` |

A new \"Phase 1.5\" loop sits between spawn and restore: when \`MemfdShared\`, it calls \`memfd::create_and_populate(self.memory, \"forkd-source-mem-<N>\")\` per child and attaches the region to \`child.memfd\`. Error chain includes the child index and source path.

## Local verification on dev box

\`\`\`
$ cargo fmt --all -- --check        # clean
$ cargo check --all-targets          # ok (26.9 s)
$ cargo test -p forkd-vmm --lib
  test result: ok. 21 passed; 0 failed
\`\`\`

End-to-end against the patched FC binary is deferred to Phase 5c (real-VM smoke test on the dev box, using the just-built FC at \`~/firecracker-fork/build/cargo_target/release/firecracker\`). This PR is the code-side wiring; the next step is a single \"happy path\" smoke that boots one MemfdShared child and asserts \`/proc/<fc_pid>/maps\` shows the memory.bin region as \`rw-s\`.

## Side fix in the upstream FC fork

While wiring this up I discovered the original \`mem_backend.shared\` patch in [\`deeplethe/firecracker\`](https://github.com/deeplethe/firecracker) only added the **field** to \`MemBackendConfig\` but left six \`MemBackendConfig { ... }\` struct literals (1 production site + 5 tests in \`api_server/request/snapshot.rs\`) unupdated — the compiler rightly rejected the partial change with E0063. Fixed in [\`deeplethe/firecracker@ca090c9\`](https://github.com/deeplethe/firecracker/commit/ca090c9) by adding \`shared: false\` to each literal. Behavior unchanged for those sites — \`false\` matches the existing MAP_PRIVATE default.

The corresponding update to \`0001-feat-mem-backend-shared-option-for-MAP-SHARED.patch\` in this repo will land in a follow-up housekeeping PR so the patch file accurately reflects the now-buildable fork. Filed mentally; not blocking 5b review.

Refs #101.