### PR TITLE
fix(docs): clear all rustdoc errors under -D warnings

### DIFF
--- a/crates/forkd-cli/src/hub.rs
+++ b/crates/forkd-cli/src/hub.rs
@@ -44,7 +44,7 @@ pub struct Manifest {
     pub created_at: String,
     /// forkd version that wrote this pack.
     pub forkd_version: String,
-    /// If set, this is a diff snapshot rooted at <parent_tag>. Reserved for M2.1.
+    /// If set, this is a diff snapshot rooted at `<parent_tag>`. Reserved for M2.1.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_tag: Option<String>,
     /// Per-file metadata (path inside the pack, size, sha256).

--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -1,14 +1,17 @@
 //! `forkd` — CLI entrypoint.
 //!
 //! Subcommands:
+//!
+//! ```text
 //!   forkd snapshot --tag <name> --kernel <path> --rootfs <path>
 //!   forkd fork --tag <name> --n <N>
 //!   forkd pack --tag <name> [--out <file>]    (Snapshot Hub)
 //!   forkd unpack <file> [--tag <name>]        (Snapshot Hub)
 //!   forkd pull <url> [--tag <name>]           (Snapshot Hub)
 //!   forkd images                              (Snapshot Hub)
+//! ```
 //!
-//! Snapshots live under $XDG_DATA_HOME/forkd/snapshots/<tag>/.
+//! Snapshots live under `$XDG_DATA_HOME/forkd/snapshots/<tag>/`.
 
 mod bench;
 mod doctor;
@@ -43,7 +46,7 @@ enum Cmd {
     /// `--from-sandbox`, snapshot a running child sandbox into a new
     /// tag via the controller daemon (sandbox branching).
     Snapshot {
-        /// Name of the snapshot. Becomes ~/.local/share/forkd/snapshots/<tag>/.
+        /// Name of the snapshot. Becomes `~/.local/share/forkd/snapshots/<tag>/`.
         /// With `--from-sandbox`, leave unset to let the daemon generate
         /// `branch-<sandbox-id>-<unix-ts>`.
         #[arg(long)]
@@ -97,7 +100,7 @@ enum Cmd {
         #[arg(long)]
         keep_workdir: bool,
         /// Persistent volume to attach to every child of this snapshot.
-        /// Format: HOST_FILE:GUEST_PATH[:ro]. Repeatable for up to 24
+        /// Format: `HOST_FILE:GUEST_PATH[:ro]`. Repeatable for up to 24
         /// volumes (vdb..vdy). The host file must be an existing ext4
         /// image (create one with `mkfs.ext4 /var/lib/forkd/vol/<tag>.img`).
         /// Use volumes for pip caches, model weights, agent scratch space —
@@ -305,7 +308,7 @@ enum Cmd {
         /// Tag of the local snapshot to pack.
         #[arg(long)]
         tag: String,
-        /// Output file. Default: ./<sanitized-tag>.forkd-snapshot.tar.zst
+        /// Output file. Default: `./<sanitized-tag>.forkd-snapshot.tar.zst`
         #[arg(long, short)]
         out: Option<PathBuf>,
         /// Human description recorded in the manifest. Optional.
@@ -343,8 +346,8 @@ enum Cmd {
         /// Overwrite an existing local snapshot of the same tag.
         #[arg(long)]
         force: bool,
-        /// Hub base URL for short-form targets. Default: env FORKD_HUB_URL
-        /// or https://forkd-hub.deeplethe.com.
+        /// Hub base URL for short-form targets. Default: env `FORKD_HUB_URL`
+        /// or <https://forkd-hub.deeplethe.com>.
         #[arg(long, env = "FORKD_HUB_URL")]
         hub: Option<String>,
     },
@@ -522,7 +525,7 @@ enum ParentAction {
     Build {
         /// Docker image (e.g. `python:3.12-slim`, `ubuntu:24.04`).
         image: String,
-        /// Output ext4 file (default: ./<image-slug>.ext4).
+        /// Output ext4 file (default: `./<image-slug>.ext4`).
         #[arg(long, short)]
         output: Option<PathBuf>,
         /// Image size in MiB (default 1536).

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -953,9 +953,9 @@ impl Vm {
     /// (forkd does this via the `WpBranch` async-copy path on memfd +
     /// MAP_SHARED). `memory` and `volumes` are NOT written by this call
     /// — they're attached to the returned [`Snapshot`] so the caller
-    /// gets the same record shape it would from [`snapshot_to`] /
-    /// [`snapshot_diff_to`] and can hand it off to the post-pause copy
-    /// pipeline without reconstructing it.
+    /// gets the same record shape it would from [`Self::snapshot_to`] /
+    /// [`Self::snapshot_diff_to`] and can hand it off to the post-pause
+    /// copy pipeline without reconstructing it.
     ///
     /// Requires the vendored Firecracker fork
     /// (`deeplethe/firecracker:forkd-v0.4-mem-backend-shared-v1.12`); stock

--- a/experiments/v0.4-kvm-uffd-wp-poc/src/main.rs
+++ b/experiments/v0.4-kvm-uffd-wp-poc/src/main.rs
@@ -1,6 +1,6 @@
 //! v0.4 Phase 2 PoC — does UFFD_WP catch KVM guest writes through EPT?
 //!
-//! Answers open question #1 in [`DESIGN-v0.4.md`]: when a guest accesses
+//! Answers open question #1 in `DESIGN-v0.4.md` (at the repo root): when a guest accesses
 //! memory via `KVM_RUN` (and therefore through EPT/NPT, not the host MMU),
 //! does write-protection armed on the host VMA still produce a userspace
 //! fault?


### PR DESCRIPTION
## Summary

Full-workspace audit (\`cargo doc --document-private-items\` + \`RUSTDOCFLAGS=-D warnings\`) turned up **16+ errors**. None are runtime bugs but they break the published rustdoc — clicking any of the broken intra-doc links gives a 404, and the angle-bracketed CLI placeholders render as raw \`<name>\` text.

Categories fixed:

- **2 new errors** from PR #190's \`snapshot_vmstate_only\` doc: \`[snapshot_to]\` / \`[snapshot_diff_to]\` intra-doc links need the \`Self::\` prefix.
- **11+ pre-existing** angle-bracket-as-HTML errors across \`crates/forkd-cli/src/main.rs\` and \`crates/forkd-cli/src/hub.rs\`: wrap the subcommand listing in a \`text\` code fence; backtick individual placeholders in arg-help strings.
- **1 unresolved-link** \`[:ro]\` after \`HOST_FILE:GUEST_PATH\` — wrap whole format string in backticks.
- **1 'this URL is not a hyperlink'** — convert bare \`https://forkd-hub.deeplethe.com\` to an autolink with \`<...>\`.
- **1 dangling intra-doc link** \`[\\`DESIGN-v0.4.md\\`]\` in v0.4 PoC — switch to plain prose.

## Test plan

- [x] \`cargo doc --workspace --no-deps --document-private-items\` with \`RUSTDOCFLAGS='-D warnings'\` — exit 0
- [x] \`cargo fmt --all --check\` — exit 0
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — exit 0
- [x] \`cargo test --workspace --all-features\` — 85 passed, 0 failed