### PR TITLE
feat(uffd,vmm): Phase 6.3a — WpBranch::begin_with_external_uffd + PauseGuard

### DIFF
--- a/crates/forkd-uffd/src/wp_snapshot.rs
+++ b/crates/forkd-uffd/src/wp_snapshot.rs
@@ -164,6 +164,94 @@ impl WpBranch {
         })
     }
 
+    /// Like [`begin`](Self::begin) but takes an already-registered uffd
+    /// instead of creating one. The v0.4 controller path uses this:
+    /// Firecracker creates the uffd inside its own process (because
+    /// `UFFDIO_REGISTER` is per-process and KVM runs in FC) and ships
+    /// the fd to the controller via SCM_RIGHTS — see
+    /// `Vm::request_wp_uffd` in `forkd-vmm`. The controller then
+    /// arms WP from this side without needing the register ioctl.
+    ///
+    /// `memfd` is the controller's own clone of FC's backing memfd, used
+    /// by [`bulk_copy_clean`](Self::bulk_copy_clean) to read clean pages
+    /// through the controller's mmap. `region` and `region_size` describe
+    /// the controller-side mmap of that memfd.
+    ///
+    /// # Safety
+    ///
+    /// `region` must point to a valid `region_size`-byte mmap of `memfd`
+    /// in this process. The mmap must remain alive for the lifetime of
+    /// the returned `WpBranch`. `uffd` must already be registered (WP
+    /// mode) against the same memory range *as observed in the registering
+    /// process* — for the forkd v0.4 path that's FC's process, which has
+    /// its own mmap of the same memfd inode at a different VA. The
+    /// kernel's UFFD_WP plumbing tracks pages at the page-table level,
+    /// so arming + faults work as long as both processes ultimately
+    /// touch the same backing pages.
+    pub unsafe fn begin_with_external_uffd(
+        uffd: OwnedFd,
+        memfd: OwnedFd,
+        region: *mut libc::c_void,
+        region_size: usize,
+        snapshot_path: &Path,
+    ) -> Result<Self> {
+        if region.is_null() {
+            bail!("WpBranch::begin_with_external_uffd: region pointer is null");
+        }
+        if region_size == 0 || !region_size.is_multiple_of(PAGE_SIZE) {
+            bail!(
+                "WpBranch::begin_with_external_uffd: region_size {region_size} must be a positive multiple of {PAGE_SIZE}"
+            );
+        }
+        let region_addr = region as usize;
+        let num_pages = region_size / PAGE_SIZE;
+
+        // No UFFDIO_REGISTER — FC already did it. Just arm WP. This is
+        // still the timed critical section for the live BRANCH pause.
+        let arm_start = Instant::now();
+        raw::writeprotect(&uffd, region, region_size, true)
+            .context("UFFDIO_WRITEPROTECT arm (external uffd)")?;
+        let arm_duration = arm_start.elapsed();
+
+        let snapshot = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(snapshot_path)
+            .with_context(|| format!("open snapshot file {}", snapshot_path.display()))?;
+        snapshot
+            .set_len(region_size as u64)
+            .context("set_len snapshot file")?;
+
+        let captured: Vec<AtomicBool> = (0..num_pages).map(|_| AtomicBool::new(false)).collect();
+
+        let state = Arc::new(SharedState {
+            snapshot: Mutex::new(snapshot),
+            captured,
+            dirty_faults: AtomicU64::new(0),
+            uffd,
+        });
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let handler_state = Arc::clone(&state);
+        let handler_stop = Arc::clone(&stop);
+        let handler = thread::spawn(move || -> Result<()> {
+            run_handler(handler_state, handler_stop, region_addr)
+        });
+
+        let _ = memfd; // keepalive only — handler reads through the existing mmap.
+
+        Ok(WpBranch {
+            region_addr,
+            region_size,
+            arm_duration,
+            state,
+            handler: Some(handler),
+            stop,
+        })
+    }
+
     /// The time `UFFDIO_WRITEPROTECT` held the critical section.
     pub fn arm_duration(&self) -> Duration {
         self.arm_duration

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -970,6 +970,73 @@ impl Vm {
         api_call(&self.sock, "PATCH", "/vm", r#"{"state":"Resumed"}"#)
     }
 
+    /// Acquire a [`PauseGuard`] that holds the VM paused until dropped.
+    /// `?`-friendly alternative to manual `pause()` + `resume()` —
+    /// resumes even on early return / panic. Best-effort: drop swallows
+    /// the resume error to avoid masking the panic that triggered the
+    /// drop; for explicit error handling, use [`PauseGuard::commit`].
+    pub fn pause_guard(&self) -> Result<PauseGuard<'_>> {
+        PauseGuard::pause(self)
+    }
+}
+
+/// RAII guard that holds a VM paused. Drop calls `vm.resume()` unless
+/// the guard was [`commit`](Self::commit)ted (used when the caller has
+/// already explicitly resumed and doesn't want the implicit retry).
+///
+/// Phase 6.3 uses this around the brief `pause -> snapshot_vmstate_only
+/// -> resume` critical section: if `snapshot_vmstate_only` errors, the
+/// guard drops on the early return and the source VM doesn't get
+/// stuck paused.
+pub struct PauseGuard<'a> {
+    vm: &'a Vm,
+    committed: bool,
+}
+
+impl<'a> PauseGuard<'a> {
+    /// Pause the VM and return a guard that will resume on drop.
+    pub fn pause(vm: &'a Vm) -> Result<Self> {
+        vm.pause()?;
+        Ok(Self {
+            vm,
+            committed: false,
+        })
+    }
+
+    /// Explicitly resume now and consume the guard, returning the
+    /// resume result so the caller can handle it. Use this instead of
+    /// `drop()` when you want the resume to be a checked failure point.
+    pub fn resume(mut self) -> Result<()> {
+        self.committed = true;
+        self.vm.resume()
+    }
+
+    /// Mark the guard as resumed-elsewhere so Drop won't retry. Use
+    /// this if the caller resumed via some other path and just needs
+    /// the guard to stop being responsible.
+    pub fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for PauseGuard<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            // Best-effort. If this errors during a panic unwind, the
+            // panic message is what callers want to see — swallowing
+            // the resume error preserves that signal. Operators see
+            // the still-paused VM and can re-resume manually if needed.
+            if let Err(e) = self.vm.resume() {
+                tracing::warn!(
+                    error = %e,
+                    "PauseGuard drop: vm.resume() failed; VM may be stuck paused",
+                );
+            }
+        }
+    }
+}
+
+impl Vm {
     /// Write a Full snapshot to disk. VM must be paused first. `volumes` is
     /// the list of volumes that were attached at boot — the snapshot stores
     /// them so subsequent restores reattach the same host files at the same


### PR DESCRIPTION
Phase 6.3 split into two PRs so the controller integration stays focused. This PR adds the two utilities; #TBD-6.3b will wire them into \`branch_sandbox\`.

## What's in this PR

### \`WpBranch::begin_with_external_uffd\` (forkd-uffd)

A new constructor that takes an already-registered uffd instead of creating one. Phase 6.1.5 / 6.2's protocol is:

1. controller asks FC for a WP-uffd via \`PUT /uffd/wp\`,
2. FC creates the uffd in *its own* process (UFFDIO_REGISTER is per-process and KVM runs in FC), registers WP mode against the guest memory VMA, ships the fd back via SCM_RIGHTS,
3. controller receives the fd through \`Vm::request_wp_uffd\` and now needs to drive WPing + bulk-copy from this side.

The existing \`WpBranch::begin\` (which both creates and registers the uffd in the same process) stays available for the standalone PoC and tests; the new constructor handles the cross-process case by skipping the register step and going straight to \`UFFDIO_WRITEPROTECT\` for the arm.

### \`PauseGuard\` (forkd-vmm)

RAII over \`Vm::pause\` / \`Vm::resume\`. Drop resumes unless the guard was \`.commit()\`ted (caller resumed via another path) or \`.resume()\`d (consume + return the resume \`Result\` for checked error handling).

Drop-side resume errors are \`tracing::warn!\`'d, not panicked — when this fires inside a panic unwind we want the original panic message to be what callers see, not a double-panic from the resume retry.

Phase 6.3b will use this around the \`pause -> snapshot_vmstate_only -> resume\` critical section so an error from \`snapshot_vmstate_only\` between pause and resume doesn't leave the source VM stuck paused.

## Test plan

- [x] \`cargo check --workspace\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check --all\` — clean
- [x] \`cargo test --workspace --lib\` — all passing (42 controller / 5 uffd / 24 vmm + the rest)
- [ ] End-to-end integration test for both utilities lands with Phase 6.3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)