### PR TITLE
feat(controller): expose live_fork on CreateSandboxRequest

### DIFF
--- a/crates/forkd-controller/src/api.rs
+++ b/crates/forkd-controller/src/api.rs
@@ -208,6 +208,19 @@ pub struct CreateSandboxRequest {
     /// consistent BRANCH latency from the first call.
     #[serde(default)]
     pub prewarm: bool,
+    /// **Phase 6 unstable / internal.** Spawn the sandbox with
+    /// `MemoryBackend::MemfdShared` instead of `File`. Required for
+    /// the v0.4 live BRANCH path (`live: true` on
+    /// `POST /v1/sandboxes/:id/branch`) — UFFD_WP only works on
+    /// shmem/memfd-backed VMAs, not ext4. File-backed sandboxes can
+    /// still take Full or Diff BRANCHes; they just can't take Live.
+    ///
+    /// **Phase 7 will replace this with an auto-detect mechanism**
+    /// driven by `forkd doctor`'s kernel-version check. For now it's
+    /// here so the controller bench can stand up a live-capable
+    /// sandbox without going through the CLI's surface.
+    #[serde(default)]
+    pub live_fork: bool,
 }
 
 fn default_one() -> usize {

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -532,9 +532,14 @@ async fn create_sandbox(
         } else {
             None
         },
-        // v0.2 ships only File. Userfault (live branching) lands in v0.3
-        // — see docs/design/userfaultfd.md.
-        memory_backend: forkd_vmm::MemoryBackend::File,
+        // Phase 6 unstable: live_fork=true opts the sandbox into
+        // memfd-backed RAM so the Phase 6 mode=live BRANCH path can
+        // arm UFFD_WP on it. Default stays File for backward compat.
+        memory_backend: if req.live_fork {
+            forkd_vmm::MemoryBackend::MemfdShared
+        } else {
+            forkd_vmm::MemoryBackend::File
+        },
         // Daemon-spawned sources are the targets of BRANCH; enabling
         // dirty-page tracking lets later BRANCHes opt into Diff
         // snapshots (see docs/design/diff-snapshots.md). The cost is


### PR DESCRIPTION
Phase 6's \`mode=live\` BRANCH path needs the source sandbox to have been spawned with \`MemoryBackend::MemfdShared\` (Phase 5b backend variant — UFFD_WP only works on shmem/memfd VMAs, not ext4). The controller's spawn path was hard-coded to \`File\`, so nothing currently exercises the Phase 6.1/6.1.5/6.2/6.3/6.4 plumbing end-to-end.

This adds \`live_fork: bool\` (default \`false\`) to \`CreateSandboxRequest\`. When \`true\`, the sandbox is restored with \`MemfdShared\`. Documented as Phase 6 unstable / internal — Phase 7's \`forkd doctor\` auto-detect will replace this with a kernel-version-driven default.

File-backed sandboxes still take Full / Diff BRANCHes as before; they just can't take Live (\`run_live_branch_setup\` returns a clear error if \`memfd_handle()\` is None).

## Test plan

- [x] \`cargo check --workspace\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check --all\` — clean
- [ ] E2E smoke against the patched FC (next step after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)