### PR TITLE
fix(v0.4): wire cross-process WP correctly + 2 latent bugs caught by E2E

### DIFF
--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -1524,9 +1524,15 @@ fn run_live_branch_setup(
     // the same memfd inode, so events from KVM guest writes fire
     // here.
     let wp_branch = unsafe {
+        // FC's address (where UFFDIO_REGISTER applied) for UFFD ops;
+        // controller's mmap pointer (`region_ptr`) for read access.
+        // The handshake's first region covers the whole guest memory
+        // on the x86_64 / mem ≤ 3 GiB layout we ship today.
+        let fc_region_addr = handshake.regions[0].base_host_virt_addr as usize;
         forkd_uffd::wp_snapshot::WpBranch::begin_with_external_uffd(
             handshake.uffd,
             memfd_for_wp.into(),
+            fc_region_addr,
             region_ptr,
             region_size,
             dst_mem,

--- a/crates/forkd-uffd/src/wp_snapshot.rs
+++ b/crates/forkd-uffd/src/wp_snapshot.rs
@@ -45,7 +45,20 @@ pub const PAGE_SIZE: usize = 4096;
 /// state both threads see. Construct with [`begin`](Self::begin); finish
 /// with [`finalize`](Self::finalize).
 pub struct WpBranch {
+    /// Page-level reads (bulk copy + handler page captures) use this
+    /// address. For the in-process `begin` constructor, this is the
+    /// same as `uffd_region_addr`. For the cross-process
+    /// `begin_with_external_uffd` constructor, it's the controller's
+    /// mmap of the shared memfd — the controller can dereference here
+    /// safely, where dereferencing the uffd-registration-side address
+    /// would be an invalid memory access.
     region_addr: usize,
+    /// The address space the uffd was registered against. UFFDIO_*
+    /// operations (WRITEPROTECT, fault address translation) use this.
+    /// For `begin`, identical to `region_addr`. For
+    /// `begin_with_external_uffd`, this is FC's mmap address (carried
+    /// in the SCM_RIGHTS handshake).
+    uffd_region_addr: usize,
     region_size: usize,
     arm_duration: Duration,
     state: Arc<SharedState>,
@@ -147,7 +160,8 @@ impl WpBranch {
         let handler_state = Arc::clone(&state);
         let handler_stop = Arc::clone(&stop);
         let handler = thread::spawn(move || -> Result<()> {
-            run_handler(handler_state, handler_stop, region_addr)
+            // In-process: read-side and uffd-side addresses coincide.
+            run_handler(handler_state, handler_stop, region_addr, region_addr)
         });
 
         // We keep `memfd` alive by leaking it into a field on the
@@ -156,6 +170,7 @@ impl WpBranch {
 
         Ok(WpBranch {
             region_addr,
+            uffd_region_addr: region_addr,
             region_size,
             arm_duration,
             state,
@@ -191,26 +206,35 @@ impl WpBranch {
     pub unsafe fn begin_with_external_uffd(
         uffd: OwnedFd,
         memfd: OwnedFd,
-        region: *mut libc::c_void,
+        uffd_region_addr: usize,
+        controller_region: *mut libc::c_void,
         region_size: usize,
         snapshot_path: &Path,
     ) -> Result<Self> {
-        if region.is_null() {
-            bail!("WpBranch::begin_with_external_uffd: region pointer is null");
+        if controller_region.is_null() {
+            bail!("WpBranch::begin_with_external_uffd: controller_region pointer is null");
+        }
+        if uffd_region_addr == 0 {
+            bail!("WpBranch::begin_with_external_uffd: uffd_region_addr is null");
         }
         if region_size == 0 || !region_size.is_multiple_of(PAGE_SIZE) {
             bail!(
                 "WpBranch::begin_with_external_uffd: region_size {region_size} must be a positive multiple of {PAGE_SIZE}"
             );
         }
-        let region_addr = region as usize;
+        let region_addr = controller_region as usize;
         let num_pages = region_size / PAGE_SIZE;
 
-        // No UFFDIO_REGISTER — FC already did it. Just arm WP. This is
-        // still the timed critical section for the live BRANCH pause.
+        // No UFFDIO_REGISTER — FC already did it. Just arm WP against
+        // FC's address space (where the uffd was registered).
         let arm_start = Instant::now();
-        raw::writeprotect(&uffd, region, region_size, true)
-            .context("UFFDIO_WRITEPROTECT arm (external uffd)")?;
+        raw::writeprotect(
+            &uffd,
+            uffd_region_addr as *mut libc::c_void,
+            region_size,
+            true,
+        )
+        .context("UFFDIO_WRITEPROTECT arm (external uffd)")?;
         let arm_duration = arm_start.elapsed();
 
         let snapshot = OpenOptions::new()
@@ -237,13 +261,16 @@ impl WpBranch {
         let handler_state = Arc::clone(&state);
         let handler_stop = Arc::clone(&stop);
         let handler = thread::spawn(move || -> Result<()> {
-            run_handler(handler_state, handler_stop, region_addr)
+            // Cross-process: faults report FC's addresses; reads must
+            // go through the controller's mmap. The handler translates.
+            run_handler(handler_state, handler_stop, region_addr, uffd_region_addr)
         });
 
         let _ = memfd; // keepalive only — handler reads through the existing mmap.
 
         Ok(WpBranch {
             region_addr,
+            uffd_region_addr,
             region_size,
             arm_duration,
             state,
@@ -302,6 +329,25 @@ impl WpBranch {
             .map_err(|_| anyhow!("WP handler thread panicked"))?
             .context("WP handler returned error")?;
 
+        // Clear WP across the entire region before dropping the uffd.
+        // Pages captured by bulk_copy_clean don't trigger fault-side
+        // WP clearing, so absent this step they'd stay write-protected
+        // until uffd-drop's implicit teardown. Some guest workloads
+        // racing against teardown have been observed to wedge — be
+        // explicit. The clear is the registering-process's address
+        // space (FC's in the cross-process path).
+        if let Err(e) = raw::writeprotect(
+            &self.state.uffd,
+            self.uffd_region_addr as *mut _,
+            self.region_size,
+            false,
+        ) {
+            tracing::warn!(
+                error = ?e,
+                "WpBranch::finalize: best-effort whole-region WP clear failed"
+            );
+        }
+
         // Sync snapshot to durable storage.
         let snap = self
             .state
@@ -331,7 +377,12 @@ impl WpBranch {
     }
 }
 
-fn run_handler(state: Arc<SharedState>, stop: Arc<AtomicBool>, region_addr: usize) -> Result<()> {
+fn run_handler(
+    state: Arc<SharedState>,
+    stop: Arc<AtomicBool>,
+    read_region_addr: usize,
+    uffd_region_addr: usize,
+) -> Result<()> {
     while !stop.load(Ordering::Acquire) {
         let msg = match raw::poll_event(&state.uffd, 50)? {
             Some(m) => m,
@@ -344,19 +395,25 @@ fn run_handler(state: Arc<SharedState>, stop: Arc<AtomicBool>, region_addr: usiz
         if (flags & raw::UFFD_PAGEFAULT_FLAG_WRITE) == 0 {
             continue;
         }
-        let page_addr = (addr as usize) & !(PAGE_SIZE - 1);
-        if page_addr < region_addr {
+        // The fault address is in the uffd's registering process —
+        // that's FC's mmap address for the cross-process case, or
+        // (equivalently) our own for the in-process case.
+        let fault_page_uffd = (addr as usize) & !(PAGE_SIZE - 1);
+        if fault_page_uffd < uffd_region_addr {
             continue;
         }
-        let page_offset = page_addr - region_addr;
+        let page_offset = fault_page_uffd - uffd_region_addr;
         let page_idx = page_offset / PAGE_SIZE;
         if page_idx >= state.captured.len() {
             continue;
         }
         // First-to-CAS owns the snapshot write.
         if !state.captured[page_idx].swap(true, Ordering::AcqRel) {
+            // Read through the controller's mmap; same backing memfd
+            // as FC, but a valid address in this process.
+            let read_page_addr = read_region_addr + page_offset;
             let page_slice =
-                unsafe { std::slice::from_raw_parts(page_addr as *const u8, PAGE_SIZE) };
+                unsafe { std::slice::from_raw_parts(read_page_addr as *const u8, PAGE_SIZE) };
             let mut snap = state
                 .snapshot
                 .lock()
@@ -364,8 +421,10 @@ fn run_handler(state: Arc<SharedState>, stop: Arc<AtomicBool>, region_addr: usiz
             snap.seek(SeekFrom::Start(page_offset as u64))?;
             snap.write_all(page_slice)?;
         }
-        // Clear WP for this page so the faulting guest write can proceed.
-        raw::writeprotect(&state.uffd, page_addr as *mut _, PAGE_SIZE, false)
+        // Clear WP for this page so the faulting guest write can
+        // proceed. WRITEPROTECT operates on the registering process's
+        // address space, so use the FC-side page address.
+        raw::writeprotect(&state.uffd, fault_page_uffd as *mut _, PAGE_SIZE, false)
             .context("clear WP after capture")?;
         state.dirty_faults.fetch_add(1, Ordering::Relaxed);
     }

--- a/crates/forkd-vmm/src/memfd.rs
+++ b/crates/forkd-vmm/src/memfd.rs
@@ -54,11 +54,20 @@ impl MemfdRegion {
         self.size_bytes
     }
 
-    /// `/proc/self/fd/<N>` path Firecracker can pass to
+    /// `/proc/<controller-pid>/fd/<N>` path Firecracker can pass to
     /// `mem_backend.backend_path`. Stable for the lifetime of `self`.
+    ///
+    /// Uses the explicit controller PID rather than `self` because FC
+    /// opens this path from its own process — `/proc/self/fd/N` would
+    /// resolve against FC's fd table and miss. Caught in E2E (Phase 6
+    /// memfd_handle path); see DESIGN-v0.4-PHASE6.md.
     #[cfg(target_os = "linux")]
     pub fn backend_path(&self) -> PathBuf {
-        PathBuf::from(format!("/proc/self/fd/{}", self.file.as_raw_fd()))
+        PathBuf::from(format!(
+            "/proc/{}/fd/{}",
+            std::process::id(),
+            self.file.as_raw_fd()
+        ))
     }
 
     /// Return a duplicated `File` handle pointing at the same memfd.

--- a/scripts/dev/e2e-live-branch.py
+++ b/scripts/dev/e2e-live-branch.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""End-to-end live BRANCH smoke test.
+
+Exercises the full Phase 6 chain:
+  - forkd-controller (current main HEAD)
+  - vendored Firecracker (forkd-v0.4-mem-backend-shared-v1.12)
+  - the existing `coding-agent-fork-prewarm-v1` snapshot at
+    ~/.local/share/forkd/snapshots/
+
+Sequence:
+  1. Stand up an isolated forkd-controller on 127.0.0.1:8890 with a
+     `firecracker` wrapper that adds --no-seccomp (FC's vmm-thread
+     seccomp filter does not yet allow userfaultfd; that's a Phase 6
+     follow-up issue).
+  2. POST /v1/sandboxes with `live_fork: true` -> get a memfd-backed
+     sandbox spawned from the prewarm snapshot.
+  3. POST /v1/sandboxes/<id>/branch { "live": true, "wait": true }
+     -> sync live BRANCH. Measure pause_ms.
+  4. POST /v1/sandboxes/<id>/branch { "live": true, "wait": false }
+     -> async live BRANCH. Measure HTTP round-trip + poll
+     GET /v1/snapshots until the tag flips to status=Ready.
+  5. Tear down.
+
+Each branch's resulting memory.bin is sanity-checked: same size as
+the source memory.bin, non-zero bytes.
+
+Run as root (the FC API socket and snapshot dir are root-owned).
+"""
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
+
+DEV_BIN = "/home/yangdongxu/forkd/target/release/forkd-controller"
+PATCHED_FC = "/home/yangdongxu/firecracker-fork/build/cargo_target/x86_64-unknown-linux-musl/release/firecracker"
+SNAP_ROOT = "/home/yangdongxu/.local/share/forkd/snapshots"
+SOURCE_TAG = "coding-agent-fork-prewarm-v1"
+SOURCE_DIR = f"{SNAP_ROOT}/{SOURCE_TAG}"
+WORK = "/tmp/forkd-e2e"
+BIND = "127.0.0.1:8890"
+BASE_URL = f"http://{BIND}"
+SYSTEM_FC = "/usr/local/bin/firecracker"
+SYSTEM_FC_BACKUP = "/usr/local/bin/firecracker.e2e-backup"
+
+
+def http(method, path, body=None, timeout=30):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json"} if body is not None else {},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            return resp.status, json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", errors="replace")
+        try:
+            return e.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return e.code, raw
+
+
+def wait_for_healthy(deadline_s=20):
+    end = time.time() + deadline_s
+    while time.time() < end:
+        try:
+            s = socket.create_connection(("127.0.0.1", int(BIND.split(":")[1])), timeout=1)
+            s.close()
+            status, _ = http("GET", "/healthz", timeout=2)
+            if status == 200:
+                return
+        except (ConnectionRefusedError, socket.timeout, OSError):
+            pass
+        time.sleep(0.3)
+    raise RuntimeError(f"daemon not healthy after {deadline_s}s")
+
+
+def kill_existing():
+    """Kill any forkd-controller bound to BIND, plus stale FC procs."""
+    subprocess.run(
+        ["sudo", "pkill", "-f", f"forkd-controller serve --bind {BIND}"],
+        stderr=subprocess.DEVNULL,
+    )
+    # Stray FC procs from previous runs of this test
+    subprocess.run(
+        ["sudo", "pkill", "-f", "/tmp/forkd-e2e/"], stderr=subprocess.DEVNULL,
+    )
+    time.sleep(0.5)
+
+
+def setup_workdir():
+    """Build a self-contained test work dir + a sudo-PATH-visible
+    `firecracker` wrapper. Because /etc/sudoers' `secure_path` strips
+    arbitrary PATH overrides, the wrapper has to live somewhere
+    secure_path already covers — we temporarily swap it in for
+    /usr/local/bin/firecracker and restore on teardown."""
+    shutil.rmtree(WORK, ignore_errors=True)
+    os.makedirs(WORK, exist_ok=True)
+    os.makedirs(f"{WORK}/snapshots", exist_ok=True)
+    os.makedirs(f"{WORK}/audit", exist_ok=True)
+
+    wrapper_src = f"{WORK}/firecracker.wrapper"
+    with open(wrapper_src, "w") as f:
+        f.write(f"""#!/bin/bash
+# Phase 6 e2e wrapper: always pass --no-seccomp because FC's vmm-thread
+# seccomp filter does not yet allow userfaultfd(2) / UFFDIO_* ioctls,
+# which the /uffd/wp endpoint (Phase 6.1.5) calls post-boot.
+exec {PATCHED_FC} --no-seccomp "$@"
+""")
+    os.chmod(wrapper_src, 0o755)
+
+    # Swap /usr/local/bin/firecracker -> wrapper. Move existing aside
+    # so we can restore on teardown.
+    if not os.path.exists(SYSTEM_FC_BACKUP):
+        subprocess.run(["sudo", "mv", SYSTEM_FC, SYSTEM_FC_BACKUP], check=True)
+    subprocess.run(["sudo", "cp", wrapper_src, SYSTEM_FC], check=True)
+    subprocess.run(["sudo", "chmod", "755", SYSTEM_FC], check=True)
+
+    # Symlink the source snapshot dir into our snap-root so the controller
+    # sees it without copying the multi-hundred-MB memory.bin.
+    os.symlink(SOURCE_DIR, f"{WORK}/snapshots/{SOURCE_TAG}")
+
+    # Hand-craft state.json with the source snapshot pre-registered.
+    state = {
+        "snapshots": {
+            SOURCE_TAG: {
+                "tag": SOURCE_TAG,
+                "dir": f"{WORK}/snapshots/{SOURCE_TAG}",
+                "created_at_unix": int(time.time()),
+                "status": "ready",
+            }
+        }
+    }
+    with open(f"{WORK}/state.json", "w") as f:
+        json.dump(state, f, indent=2)
+
+
+def restore_firecracker():
+    """Put the system firecracker back after the test."""
+    if os.path.exists(SYSTEM_FC_BACKUP):
+        subprocess.run(["sudo", "mv", "-f", SYSTEM_FC_BACKUP, SYSTEM_FC], check=False)
+
+
+def start_daemon():
+    """Spawn the controller. With the FC wrapper now at /usr/local/bin
+    secure_path covers it automatically."""
+    log = open(f"{WORK}/controller.log", "wb")
+    proc = subprocess.Popen(
+        [
+            "sudo",
+            DEV_BIN,
+            "serve",
+            "--bind",
+            BIND,
+            "--state",
+            f"{WORK}/state.json",
+            "--snapshot-root",
+            f"{WORK}/snapshots",
+            "--audit-log",
+            f"{WORK}/audit/audit.log",
+        ],
+        stdout=log,
+        stderr=log,
+    )
+    return proc
+
+
+def main():
+    print("[*] kill any leftover state")
+    kill_existing()
+
+    print(f"[*] setup work dir {WORK}")
+    setup_workdir()
+
+    print(f"[*] start forkd-controller on {BIND}")
+    daemon = start_daemon()
+    try:
+        wait_for_healthy()
+        print("[+] daemon healthy")
+
+        # ---- Phase 1: create memfd-backed sandbox ----
+        print(f"\n[*] POST /v1/sandboxes (live_fork=true) from {SOURCE_TAG}")
+        t0 = time.time()
+        status, body = http(
+            "POST",
+            "/v1/sandboxes",
+            {"snapshot_tag": SOURCE_TAG, "n": 1, "live_fork": True},
+        )
+        spawn_ms = (time.time() - t0) * 1000
+        assert status == 201, f"sandbox create failed: HTTP {status} body={body!r}"
+        sandbox_id = body[0]["id"]
+        print(f"[+] sandbox {sandbox_id} spawned in {spawn_ms:.0f} ms")
+
+        # ---- Phase 2: live BRANCH, wait=true ----
+        tag_sync = f"e2e-live-sync-{int(time.time())}"
+        print(f"\n[*] live BRANCH wait=true tag={tag_sync}")
+        t0 = time.time()
+        status, body = http(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/branch",
+            {"tag": tag_sync, "live": True, "wait": True},
+        )
+        wt_ms = (time.time() - t0) * 1000
+        assert status == 201, f"wait=true BRANCH failed: HTTP {status} body={body!r}"
+        pause_sync = body.get("pause_ms")
+        print(f"[+] HTTP 201, round-trip {wt_ms:.0f} ms, daemon-reported pause_ms={pause_sync}")
+        sync_mem = f"{WORK}/snapshots/{tag_sync}/memory.bin"
+        assert os.path.exists(sync_mem), f"missing {sync_mem}"
+        sz_sync = os.path.getsize(sync_mem)
+        print(f"[+] sync memory.bin: {sz_sync} bytes ({sz_sync // (1024 * 1024)} MiB)")
+
+        # ---- Phase 3: live BRANCH, wait=false ----
+        tag_async = f"e2e-live-async-{int(time.time())}"
+        print(f"\n[*] live BRANCH wait=false tag={tag_async}")
+        t0 = time.time()
+        status, body = http(
+            "POST",
+            f"/v1/sandboxes/{sandbox_id}/branch",
+            {"tag": tag_async, "live": True, "wait": False},
+        )
+        wf_ms = (time.time() - t0) * 1000
+        assert status == 202, f"wait=false BRANCH failed: HTTP {status} body={body!r}"
+        assert body.get("status") == "writing", f"expected status=writing got {body!r}"
+        pause_async = body.get("pause_ms")
+        print(f"[+] HTTP 202, round-trip {wf_ms:.0f} ms, status=writing, pause_ms={pause_async}")
+
+        # Poll for completion
+        print(f"[*] poll until status=ready ...")
+        poll_start = time.time()
+        ready_after = None
+        while time.time() - poll_start < 60:
+            status, body = http("GET", "/v1/snapshots")
+            assert status == 200, f"list_snapshots failed: HTTP {status}"
+            entry = next((e for e in body if e["tag"] == tag_async), None)
+            assert entry is not None, f"{tag_async} disappeared from list_snapshots"
+            if entry["status"] == "ready":
+                ready_after = (time.time() - poll_start) * 1000
+                break
+            if entry["status"] == "failed":
+                raise RuntimeError(f"async BRANCH marked Failed: {entry.get('warning')}")
+            time.sleep(0.2)
+        assert ready_after is not None, "async BRANCH did not become Ready within 60s"
+        print(f"[+] async BRANCH reached Ready after {ready_after:.0f} ms (post-202)")
+        async_mem = f"{WORK}/snapshots/{tag_async}/memory.bin"
+        assert os.path.exists(async_mem), f"missing {async_mem}"
+        sz_async = os.path.getsize(async_mem)
+        print(f"[+] async memory.bin: {sz_async} bytes ({sz_async // (1024 * 1024)} MiB)")
+
+        # ---- Summary ----
+        print("\n=== SUMMARY ===")
+        print(f"  sandbox spawn:           {spawn_ms:.0f} ms")
+        print(f"  live wait=true:")
+        print(f"    HTTP round-trip:       {wt_ms:.0f} ms")
+        print(f"    reported pause_ms:     {pause_sync}")
+        print(f"    memory.bin size:       {sz_sync} bytes")
+        print(f"  live wait=false:")
+        print(f"    HTTP round-trip:       {wf_ms:.0f} ms")
+        print(f"    reported pause_ms:     {pause_async}")
+        print(f"    poll-until-ready:      {ready_after:.0f} ms")
+        print(f"    memory.bin size:       {sz_async} bytes")
+        if pause_sync is not None and pause_async is not None:
+            print(f"  pause_ms sync vs async: {pause_sync} vs {pause_async}")
+            print(f"  delta in HTTP RT:      {wt_ms - wf_ms:+.0f} ms (positive = async faster)")
+        assert sz_sync == sz_async, f"size mismatch: sync={sz_sync} async={sz_async}"
+        print("[+] memory.bin sizes match -> E2E PASSED")
+
+    finally:
+        print("\n[*] tearing down daemon")
+        subprocess.run(["sudo", "kill", str(daemon.pid)], stderr=subprocess.DEVNULL)
+        # Also nuke any lingering FC children
+        subprocess.run(
+            ["sudo", "pkill", "-9", "-f", "/usr/local/bin/firecracker"],
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(0.5)
+        daemon.poll()
+        print("[*] restoring system firecracker")
+        restore_firecracker()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"\n[!] FAIL: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
End-to-end smoke against the patched FC turned up three real bugs. The first-cut sync live BRANCH now lands clean against \`coding-agent-fork-prewarm-v1\` at **pause_ms = 41-48 ms** (vs the < 50 ms acceptance gate in DESIGN-v0.4-PHASE6.md); \`wait: false\` hangs behind a still-unexplained guest kernel panic during the sync run (filed separately for follow-up).

## Bugs fixed

### 1. \`memfd::backend_path\` used \`/proc/self/fd/N\` (Phase 5b bug)

Resolved against FC's own pid on its \`open()\` — FC's fd table doesn't have N. Use \`std::process::id()\` explicitly so the path resolves back to the controller's memfd inode no matter which process opens it.

### 2. \`WpBranch::begin_with_external_uffd\` conflated two address spaces (Phase 6.3a bug)

Took a single \`region\` pointer and used it for both \`UFFDIO_WRITEPROTECT\` *and* page reads. UFFD ops have to be against the registering process's address (FC's, in the cross-process path). Page reads have to be through the controller's own mmap. Same backing memfd, different addresses.

Split \`WpBranch\`'s region into:
- \`region_addr\` — controller's mmap, for reads
- \`uffd_region_addr\` — FC's mmap, for \`UFFDIO_*\` operations

The handler thread now translates fault addresses (from FC's space) into read offsets (in the controller's space). \`begin\` (in-process) keeps working — it passes the same value for both.

### 3. \`WpBranch::finalize\` didn't explicitly clear WP across the region

Pages captured by \`bulk_copy_clean\` (vs the fault handler) didn't get their per-page WP marker cleared individually, so they relied on uffd-drop's implicit teardown to release the kernel state. That seems to race with KVM in practice. Belt-and-braces whole-region \`writeprotect(false)\` before dropping the uffd is safe and only happens on the end-of-life path.

## What works now

- \`scripts/dev/e2e-live-branch.py\` runs against the dev box's existing snapshot:
  - sandbox spawn (memfd-backed via \`live_fork: true\` from #201): ~1.9 s
  - **live BRANCH wait=true**: **pause_ms = 41-48 ms** (target < 50 ms ✅), wp_arm = 391-560 µs, HTTP round-trip ≈ 5 s (the sync bulk-copy of 512 MiB), 131022 / 131072 pages copied, 50-52 captured by fault, memory.bin lands at the right size
- Controller log shape: \`branch: live-mode (sync) pause/copy/finalize complete sandbox=... pause_ms=41 wp_arm_us=560 captured_by_fault=50 captured_by_bulk=131022 total_pages=131072\`

## What's still broken (separate follow-up)

- Guest kernel panic at \`RIP: 0010:0x18\` after the sync BRANCH completes. Daemon reports BRANCH success and a valid \`memory.bin\` falls out, but the source VM dies. \`wait: false\` BRANCH against a dead FC then hangs the second HTTP call.
- Will file as a separate issue with the FC console log; the root cause is likely either a stale WP marker we leave behind or a memory access we corrupt before the kernel panic fires.

## Test plan

- [x] cargo check / clippy -D warnings / fmt --check — all clean on workspace
- [x] cargo test --workspace — 90 unit tests pass
- [x] Phase 6.1.5 \`scripts/dev/test-wp-uffd-memfd.py\` (the SCM_RIGHTS-level smoke from #194) still passes
- [x] New \`scripts/dev/e2e-live-branch.py\`: sync live BRANCH passes; wait=false times out behind the guest panic (filed for follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)