### PR TITLE
feat(controller): Phase 7.1 — canonical `mode` field on BRANCH

### DIFF
--- a/crates/forkd-controller/src/api.rs
+++ b/crates/forkd-controller/src/api.rs
@@ -153,13 +153,18 @@ pub struct BranchSandboxRequest {
     /// sandboxes don't support UFFD_WP and the request fails 400.
     /// Mutually exclusive with `diff` and `measure_diff`.
     ///
-    /// **The wire-level name and shape will change in Phase 7** when
-    /// the public surface lands as `mode: "live" / "diff" / "full"`.
-    /// Don't rely on `live: true` from external clients yet — it's
-    /// here so the controller smoke test and the dev-box benchmark
-    /// can exercise the path before Phase 7 rewrites it.
+    /// Phase 7 legacy field. Set the canonical [`Self::mode`] to
+    /// [`BranchMode::Live`] instead; if both `mode` and this field
+    /// are set, the daemon errors with 400.
     #[serde(default)]
     pub live: bool,
+    /// Phase 7 canonical surface: `"full"` | `"diff"` | `"live"`.
+    /// Takes precedence over the legacy `diff` / `live` booleans
+    /// when set. Defaults to None (falls back to legacy booleans).
+    ///
+    /// See [`DESIGN-v0.4-USER-API.md`](https://github.com/deeplethe/forkd/blob/main/DESIGN-v0.4-USER-API.md).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<BranchMode>,
     /// Phase 6.4: when `false`, the live-BRANCH response returns as
     /// soon as the source resumes (~10 ms), and the bulk copy from
     /// memfd into `memory.bin` continues in the background. The
@@ -178,6 +183,27 @@ pub struct BranchSandboxRequest {
 
 fn default_wait() -> bool {
     true
+}
+
+/// Phase 7: canonical BRANCH mode. Replaces the legacy `diff` /
+/// `live` boolean pair on [`BranchSandboxRequest`]. Defaults aren't
+/// derived because there is no "default mode" at the type level —
+/// absence of the field means "fall back to legacy bools".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BranchMode {
+    /// Full memory dump inside the pause window. Highest pause cost,
+    /// simplest restore. ~150–500 ms for 512 MiB on ext4 SSDs.
+    Full,
+    /// Dirty-page diff snapshot during pause; full memory.bin
+    /// reconstructed asynchronously around it. Pause ≈ diff size,
+    /// total wall-clock ≈ Full's. Default for v0.3.x callers.
+    Diff,
+    /// v0.4 UFFD_WP-based path: WP-arm during pause, vmstate-only
+    /// dump, resume; memory streamed async out of the memfd. Sub-50
+    /// ms pause on the prototype. Requires a `live_fork=true`
+    /// sandbox (memfd-backed RAM).
+    Live,
 }
 
 /// `POST /v1/sandboxes` — fork a sandbox (child VM) from a snapshot tag.

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -707,12 +707,28 @@ async fn branch_sandbox(
         }
     };
 
-    // Phase 6.3: mode selection. Reject combinations that don't make
-    // sense before we touch any state.
-    let mode_count = req.measure_diff as u8 + req.diff as u8 + req.live as u8;
+    // Phase 7: canonical `mode` takes precedence over the legacy
+    // `diff` / `live` bools. Allowing both opens an ambiguity
+    // window — reject up front.
+    if req.mode.is_some() && (req.diff || req.live) {
+        return bad_request(
+            "set either `mode` (canonical) OR the legacy `diff` / `live` booleans, not both",
+        );
+    }
+    let (effective_diff, effective_live) = match req.mode {
+        Some(crate::api::BranchMode::Full) => (false, false),
+        Some(crate::api::BranchMode::Diff) => (true, false),
+        Some(crate::api::BranchMode::Live) => (false, true),
+        None => (req.diff, req.live),
+    };
+    // Phase 6.3: mode selection — legacy bools still mutually
+    // exclusive with `measure_diff`. (When `mode` is set, the legacy
+    // bools are forced to `false` above, so the check still applies
+    // via `effective_*`.)
+    let mode_count = req.measure_diff as u8 + effective_diff as u8 + effective_live as u8;
     if mode_count > 1 {
         return bad_request(
-            "set at most one of `measure_diff` / `diff` / `live`: \
+            "set at most one of `measure_diff` / `diff` / `live` (or use `mode`): \
              measure_diff is the pure measurement hook (Full path + Diff sidecar timing); \
              diff is the real diff-based BRANCH path; \
              live is the v0.4 UFFD_WP-based path",
@@ -720,8 +736,8 @@ async fn branch_sandbox(
     }
     // Phase 6.4: wait=false is the async live path; meaningless for
     // Full/Diff (they're already synchronous by construction).
-    if !req.wait && !req.live {
-        return bad_request("`wait: false` requires `live: true`");
+    if !req.wait && !effective_live {
+        return bad_request("`wait: false` requires `live: true` (or `mode: \"live\"`)");
     }
 
     let snap_dir = s.snapshot_root.join(&tag);
@@ -770,8 +786,8 @@ async fn branch_sandbox(
     let snap_dir_for_task = snap_dir.clone();
     let id_for_log = id.clone();
     let measure_diff = req.measure_diff;
-    let diff_mode = req.diff;
-    let live_mode = req.live;
+    let diff_mode = effective_diff;
+    let live_mode = effective_live;
     let source_tag_memory_path = s
         .snapshot_root
         .join(&source_snapshot_tag)
@@ -2517,6 +2533,130 @@ mod tests {
                     .uri("/v1/sandboxes/anything/branch")
                     .header("Content-Type", "application/json")
                     .body(Body::from(r#"{"tag":"../etc/passwd"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn branch_rejects_mode_plus_legacy_bools() {
+        // Phase 7: `mode` is canonical; can't combine it with legacy
+        // `diff` / `live` even if the resolved mode would match
+        // (preserves a single source of truth).
+        for body in [
+            r#"{"mode":"live","live":true}"#,
+            r#"{"mode":"diff","diff":true}"#,
+            r#"{"mode":"full","diff":false,"live":true}"#,
+            r#"{"mode":"diff","live":true}"#,
+        ] {
+            let app = router(test_state());
+            let resp = app
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/v1/sandboxes/anything/branch")
+                        .header("Content-Type", "application/json")
+                        .body(Body::from(body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::BAD_REQUEST,
+                "expected 400 for body: {body}",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn branch_mode_full_for_missing_sandbox_returns_404_not_400() {
+        // `mode: "full"` alone with no legacy bools should validate
+        // and proceed past the request-validation phase; the next
+        // failure point (missing sandbox) returns 404. If we
+        // accidentally regressed and the mode resolution rejected
+        // valid input, we'd see 400 here instead.
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sandboxes/nope/branch")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"mode":"full"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn branch_mode_diff_alone_validates() {
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sandboxes/nope/branch")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"mode":"diff"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn branch_mode_live_validates() {
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sandboxes/nope/branch")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"mode":"live"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn branch_mode_live_with_wait_false_validates() {
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sandboxes/nope/branch")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"mode":"live","wait":false}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Not 400 — `wait:false` is valid when `mode:live`. Falls
+        // through to 404 since the sandbox doesn't exist.
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn branch_rejects_mode_full_with_wait_false() {
+        // wait:false only makes sense for the live path.
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sandboxes/anything/branch")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"mode":"full","wait":false}"#))
                     .unwrap(),
             )
             .await


### PR DESCRIPTION
Land the public-surface \`mode\` field from \`DESIGN-v0.4-USER-API.md\`. Internal request path is unchanged; this is the wire-level layer that lets external callers stop touching the unstable \`live: true\` / \`diff: true\` booleans.

## Changes

- **\`api.rs\`**: add \`BranchMode { Full, Diff, Live }\` (lowercase serde) and an optional \`mode\` field on \`BranchSandboxRequest\`.
- **\`http.rs\`**: at the top of \`branch_sandbox\`, resolve \`mode\` → \`effective_diff\` / \`effective_live\`. Reject any request that sets both \`mode\` and either legacy bool (single source of truth). Downstream code unchanged — it still reads the boolean pair.

The legacy bools are still accepted for v0.3.x clients and for the existing diff/measure_diff bench harness. Doc-comments now point at \`mode\` as canonical.

## What's out of scope (follow-up PRs)

- CLI (\`forkd snapshot --live\`)
- Python + TS SDK (\`mode=\"live\"\`)
- \`mode: \"live-async\"\` enum variant alternative to \`wait: false\` (USER-API doc open Q #2)
- \`forkd doctor\` checks 15-16 (Phase 8)

## Test plan

- [x] \`cargo check --workspace\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check --all\` — clean
- [x] \`cargo test -p forkd-controller --lib\` — **50 passed, 0 failed** (44 pre-existing + 6 new)

New tests:
- \`branch_rejects_mode_plus_legacy_bools\` — every combo of \`mode\` + (\`diff\` or \`live\`) returns 400 (4 combos)
- \`branch_mode_full_for_missing_sandbox_returns_404_not_400\` — \`mode: \"full\"\` passes resolution
- \`branch_mode_diff_alone_validates\`
- \`branch_mode_live_validates\`
- \`branch_mode_live_with_wait_false_validates\` — legit combo
- \`branch_rejects_mode_full_with_wait_false\` — wait=false needs live

🤖 Generated with [Claude Code](https://claude.com/claude-code)