### PR TITLE
docs: align README + API.md + CHANGELOG with shipped v0.4 live-fork surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 
 ## Unreleased
 
+### v0.4 live-fork: user-facing surface complete
+
+The v0.4 live-fork path — BRANCH that pauses the source for sub-50 ms
+instead of the 150-300 ms a Diff BRANCH costs — is now reachable from
+every supported entry point. The underlying mechanism (UFFD_WP to
+capture dirty pages out-of-band, memfd-backed RAM so Firecracker and
+the controller share the same page cache) was prototyped in Phase 6
+(PRs #194-#202). This release wires it through the public surface:
+
+- **REST** (PR #204) — `POST /v1/sandboxes/:id/branch` accepts a
+  canonical `mode: "full" | "diff" | "live"` field. The legacy `diff:
+  true` boolean still works; setting both yields HTTP 400. New
+  `wait: false` toggles fire-and-forget (return after the source
+  resumes, ~10 ms; snapshot reaches `status: "ready"` asynchronously).
+  `POST /v1/sandboxes` accepts `live_fork: true` so the spawned
+  sandbox boots with memfd-backed RAM — a prerequisite for later
+  `mode: "live"` BRANCHes from it.
+- **CLI** (PR #205) — `forkd snapshot --from-sandbox <id> --live`
+  and `--live --no-wait`. Clap enforces `--diff` / `--live` mutex
+  and `--no-wait` requires `--live`. **Gap**: `forkd fork
+  --live-fork` (spawn-time opt-in) isn't surfaced on the CLI yet —
+  use the SDK or `POST /v1/sandboxes` directly to spawn a live-fork
+  parent. Tracking as a follow-up.
+- **SDKs** (PR #206) — Python (`Controller.branch_sandbox(mode=,
+  wait=)`, `Controller.spawn_sandboxes(live_fork=)`), TypeScript
+  (`branchSandbox({ mode, wait })`, `spawnSandboxes({ liveFork })`,
+  `BranchMode` type re-exported), MCP (`branch_sandbox` /
+  `spawn_sandboxes` tools). All backwards-compatible: existing
+  `diff=True` callers keep working and still drive v0.3.x daemons
+  unchanged.
+- **Doctor** (PR #207) — two new checks (`uffd_wp (v0.4 live BRANCH)`
+  and `memfd_create (v0.4 live BRANCH)`) probe the kernel
+  prerequisites. WARN-not-FAIL: v0.3 Diff/Full still work without
+  these. Smart hints — EPERM maps to `sysctl
+  vm.unprivileged_userfaultfd=1`, ENOSYS to "kernel < 5.7, Diff
+  still works".
+
+**Prereqs for `mode: "live"`**: Linux ≥ 5.7 (UFFD_WP),
+`unprivileged_userfaultfd=1` or `CAP_SYS_PTRACE`, the vendored
+Firecracker fork from
+[deeplethe/firecracker:forkd-v0.4-mem-backend-shared-v1.12](https://github.com/deeplethe/firecracker/tree/forkd-v0.4-mem-backend-shared-v1.12)
+— upstream FC doesn't yet ship `mem_backend.shared = true`. See
+[`docs/VENDORED-FIRECRACKER.md`](./docs/VENDORED-FIRECRACKER.md).
+
+**Stability**: the user surface is stable; numbers across realistic
+workloads (`bench/live-fork-pause-window.md`) are in progress against
+a freshly-rebuilt clean snapshot — the previous
+`coding-agent-fork-prewarm-v1` parent had 17 pre-baked guest Oopses
+that contaminate Live BRANCH timing.
+
 ### Security — bearer-token comparison was a length oracle (closes #162)
 
 `crates/forkd-controller/src/auth.rs::constant_time_eq` was advertised

--- a/DESIGN-v0.4.md
+++ b/DESIGN-v0.4.md
@@ -1,9 +1,20 @@
 # v0.4: live-fork via userfaultfd write-protect
 
-**Status:** DRAFT — sketching the implementation. Comments and prior-art
-pointers welcome via [#101](https://github.com/deeplethe/forkd/issues/101)
-or PR comments.
-**Target:** v0.4, ~8 weeks.
+**Status:** IMPLEMENTED — the design described below is wired up end-to-end
+on the user surface (Phases 6 + 7, May 2026). REST `mode: "live"`, CLI
+`--live`, Python / TypeScript / MCP SDKs, and `forkd doctor` capability
+checks all shipped via PRs
+[#194](https://github.com/deeplethe/forkd/pull/194)–[#207](https://github.com/deeplethe/forkd/pull/207).
+The vendored Firecracker dependency lives at
+[deeplethe/firecracker:forkd-v0.4-mem-backend-shared-v1.12](https://github.com/deeplethe/firecracker/tree/forkd-v0.4-mem-backend-shared-v1.12);
+upstream proposal is open
+([`FIRECRACKER-UPSTREAM-PROPOSAL.md`](./FIRECRACKER-UPSTREAM-PROPOSAL.md)).
+Clean-parent bench (`bench/live-fork-pause-window.md`) still pending —
+Phase 6 E2E saw pause_ms = 41-48 ms, but on a parent with pre-baked
+guest Oopses contaminating the measurement.
+
+The original DRAFT below is preserved verbatim as the architecture
+record; the implementation tracks it closely.
 **Tracking issue:** [#101](https://github.com/deeplethe/forkd/issues/101)
 
 ## Motivation

--- a/README-zh.md
+++ b/README-zh.md
@@ -44,14 +44,38 @@ pause 时间会从 150 ms 涨到 2.7 s
 ([#146](https://github.com/deeplethe/forkd/issues/146));修复后
 连续 BRANCH 保持平直(第 6 次 BRANCH 快了 17.6×)。
 
-**v0.4 预览**:实验性的 live-fork 路径把 BRANCH 卡顿窗口从 ~150 ms
-降到每 GiB ~3 ms ——做法是把内存写出从临界区移出。可用 `forkd wp-bench`
-试 library API:
+**v0.4 live BRANCH** 把源 VM 的卡顿窗口从 ~150 ms(Diff)降到
+sub-50 ms:vCPU 状态 dump 完源 VM 立刻恢复,脏页通过 UFFD_WP
+异步抓取。端到端路径已经全部接入:CLI 用 `--live`、REST 用
+`mode: "live"`、Python / TypeScript / MCP SDK 同名。再加 `--no-wait`
+(CLI)或 `wait: false`(REST/SDK)就立刻返回(~10 ms),不等
+背景拷贝完成。
 
-![forkd wp-bench v0.4 demo](./docs/assets/wp-bench-demo-zh.webp)
+```python
+from forkd import Controller
+c = Controller()
+# 源 VM 必须用 live_fork=True 启动(memfd 后端 RAM,UFFD_WP 看到
+# 运行中父 VM 写的前提条件)。
+parent = c.spawn_sandboxes("pyagent", n=1, live_fork=True)[0]
+# ... 驱动 parent ... 然后 live BRANCH + fire-and-forget:
+branch = c.branch_sandbox(parent["id"], mode="live", wait=False)
+# ~10 ms 返回,status="writing";poll list_snapshots 等到
+# status="ready" 即背景拷贝完成。
+```
 
-完整设计:[`DESIGN-v0.4.md`](./DESIGN-v0.4.md)。4 个 PoC 实证数据
-全部通过:[`experiments/v0.4-*-poc/`](./experiments/)。跟踪 issue
+```bash
+# Live BRANCH 已经在 CLI 上(Phase 7.2):
+sudo -E forkd snapshot --from-sandbox <sb-id> --live --no-wait
+# 启动时带 live_fork 目前只走 REST/SDK ——`forkd fork --live-fork`
+# 在后续 phase 里加;现在用 SDK 或直接 POST /v1/sandboxes 启动。
+```
+
+需要 Linux ≥ 5.7、`vm.unprivileged_userfaultfd=1`(或
+`CAP_SYS_PTRACE`),以及 vendored Firecracker 分支
+[deeplethe/firecracker:forkd-v0.4-mem-backend-shared-v1.12](https://github.com/deeplethe/firecracker/tree/forkd-v0.4-mem-backend-shared-v1.12)
+——`forkd doctor` 会探测这两项。完整设计:
+[`DESIGN-v0.4.md`](./DESIGN-v0.4.md)。PoC 实证数据:
+[`experiments/v0.4-*-poc/`](./experiments/)。跟踪 issue
 [#101](https://github.com/deeplethe/forkd/issues/101)。
 
 <br/>
@@ -358,10 +382,11 @@ pip install forkd                         # Python SDK —— 通过 HTTP 调守
 npm install @deeplethe/forkd              # TypeScript SDK
 ```
 
-`forkd doctor` 跑 14 项检查(KVM、硬件虚拟化、cgroup v2、IP 转发、
+`forkd doctor` 跑 16 项检查(KVM、硬件虚拟化、cgroup v2、IP 转发、
 tap、netns、Firecracker 二进制 + 版本、Docker daemon、快照目录 +
-磁盘空间、内核镜像、controller 可达性、平台),每一项不通过都附带
-具体修复提示。任何东西觉得不对就先跑它。
+磁盘空间、内核镜像、controller 可达性、平台,以及 v0.4 live-fork
+所需的 `uffd_wp` 和 `memfd_create`),每一项不通过都附带具体修复
+提示。任何东西觉得不对就先跑它。
 
 ![forkd doctor —— 配置好的宿主机 14 项全过](./docs/assets/doctor-14pass.webp)
 
@@ -470,15 +495,21 @@ npm install @deeplethe/forkd
 import { Controller } from '@deeplethe/forkd';
 
 const ctrl = new Controller();   // 从 env 读 FORKD_URL、FORKD_TOKEN
-const [parent] = await ctrl.spawnSandboxes({ snapshotTag: 'pyagent', n: 1, perChildNetns: true });
+const [parent] = await ctrl.spawnSandboxes({
+  snapshotTag: 'pyagent', n: 1, perChildNetns: true,
+  liveFork: true,             // v0.4:打开后,后续 BRANCH 可以用 mode: 'live'
+});
 
 // ... 驱动 parent ...
-const branch = await ctrl.branchSandbox(parent.id, { diff: true });    // ~200 ms
+// `mode: 'live'` + `wait: false` 让源 VM 卡顿 sub-50 ms,~10 ms 返回。
+// 背景内存拷贝异步完成,完成后快照 status 从 "writing" 变 "ready"。
+const branch = await ctrl.branchSandbox(parent.id, { mode: 'live', wait: false });
 const kids = await ctrl.spawnSandboxes({ snapshotTag: branch.tag, n: 5, perChildNetns: true });
 ```
 
 Surface 与 Python SDK 对齐:`spawnSandboxes` / `branchSandbox` 都接受
-`prewarm` / `diff` / `measure_diff`。详见 [`sdk/typescript/`](./sdk/typescript/)。
+`prewarm` / `liveFork` / `mode` / `wait` / `measure_diff`。详见
+[`sdk/typescript/`](./sdk/typescript/)。
 
 ### MCP server
 
@@ -633,13 +664,23 @@ chain 检测到文件缺失自动 fall back 到 source-tag (带 warning)。
 完整设计:
 [`docs/design/diff-snapshots.md`](./docs/design/diff-snapshots.md)。
 
-更大的 v0.4+ 候选——基于 memfd + uffd_wp 的 live-fork——还在
-[issue #101](https://github.com/deeplethe/forkd/issues/101)。
-Scaffolding (`crates/forkd-uffd/`、`MemoryBackend::Userfault` enum、
-设计文档) 留作起点。**明确决定不 fork Firecracker** —— phase 1
-的 143× 已经在 upstream 上完成了原目标 85% 的空间,而 memfd
-唯一价值(让 uffd_wp 干净追踪源 VM 的写)并不增加 forkd 已经
-靠 `mmap MAP_PRIVATE` 拿到的 share 能力。
+**v0.4 live BRANCH** 已经把用户接口全部接通(REST `mode: "live"`、
+CLI `--live`、Python / TypeScript / MCP SDK;PR
+[#204](https://github.com/deeplethe/forkd/pull/204)–[#207](https://github.com/deeplethe/forkd/pull/207))。
+机制:spawn 时带 `live_fork: true`,guest RAM 用 memfd 后端(被
+Firecracker 和 controller 共享),BRANCH 时用 UFFD_WP 异步抓脏页,
+源 VM 在 vCPU 状态 dump 完立刻恢复(sub-50 ms),内存拷贝异步
+完成。原本想留在 vanilla FC,但 `mem_backend.backend_type:
+"Shared"` 配 `shared: true`(`mmap MAP_SHARED`)是绕不开的
+upstream gap,因此 fork 了:
+[deeplethe/firecracker:forkd-v0.4-mem-backend-shared-v1.12](https://github.com/deeplethe/firecracker/tree/forkd-v0.4-mem-backend-shared-v1.12)。
+我们已经向 upstream 提了
+[`FIRECRACKER-UPSTREAM-PROPOSAL.md`](./FIRECRACKER-UPSTREAM-PROPOSAL.md),
+合并后 vendor 要求即可去掉。跟踪:
+[issue #101](https://github.com/deeplethe/forkd/issues/101)。在
+干净父快照上的 bench 数字(`bench/live-fork-pause-window.md`)
+正在跑——Phase 6 E2E 早期数据是 pause_ms = 41-48 ms,但那个
+parent 带着 17 个已经 baked-in 的 guest Oopses,会污染测量。
 
 > **0.1.4 包含 daemon 侧安全修复**。`POST /v1/sandboxes` 的
 > `snapshot_tag` 校验缺失(任意路径 → 控制 grandchild VM

--- a/README.md
+++ b/README.md
@@ -45,16 +45,43 @@ where repeated BRANCHes on the same parent ballooned from 150 ms to
 2.7 s ([#146](https://github.com/deeplethe/forkd/issues/146)); the
 chain now stays flat (17.6× faster on the 6th consecutive BRANCH).
 
-**v0.4 preview**: an experimental live-fork path drops the BRANCH
-pause window from ~150 ms to ~3 ms per GiB by moving the memory
-write out of the critical section. Try the library API with
-`forkd wp-bench`:
+**v0.4 live BRANCH** drops the source-pause window from ~150 ms
+(Diff) to sub-50 ms by moving the memory copy out of the critical
+section: the source resumes as soon as Firecracker dumps vCPU state,
+and dirty pages get captured asynchronously via UFFD_WP. The full
+end-to-end path is wired up — pass `--live` on the CLI, `mode:
+"live"` on REST, or `mode="live"` / `mode: "live"` on the Python /
+TypeScript / MCP SDKs. Add `--no-wait` (CLI) or `wait: false` (REST /
+SDKs) to return as soon as the source resumes (~10 ms) rather than
+waiting on the background copy.
 
-![forkd wp-bench v0.4 demo](./docs/assets/wp-bench-demo.webp)
+```python
+from forkd import Controller
+c = Controller()
+# Source must boot with live_fork=True (memfd-backed RAM, the prereq
+# for UFFD_WP to see writes from the running parent).
+parent = c.spawn_sandboxes("pyagent", n=1, live_fork=True)[0]
+# ... drive parent ... then BRANCH live + fire-and-forget:
+branch = c.branch_sandbox(parent["id"], mode="live", wait=False)
+# Returns after ~10 ms with status="writing"; poll list_snapshots
+# until status="ready" for the background copy to finish.
+```
 
-Full design: [`DESIGN-v0.4.md`](./DESIGN-v0.4.md). Empirical PoC data
-(4 PoCs, all passing): [`experiments/v0.4-*-poc/`](./experiments/).
-Tracking issue [#101](https://github.com/deeplethe/forkd/issues/101).
+```bash
+# Live BRANCH itself is exposed on the CLI (Phase 7.2):
+sudo -E forkd snapshot --from-sandbox <sb-id> --live --no-wait
+# Spawning with live_fork is REST/SDK-only today — `forkd fork
+# --live-fork` is a follow-up; for now drive spawning via the SDK
+# or POST /v1/sandboxes directly.
+```
+
+Requires Linux ≥ 5.7, `vm.unprivileged_userfaultfd=1` (or
+`CAP_SYS_PTRACE`), and the vendored Firecracker fork from
+[deeplethe/firecracker:forkd-v0.4-mem-backend-shared-v1.12](https://github.com/deeplethe/firecracker/tree/forkd-v0.4-mem-backend-shared-v1.12)
+— `forkd doctor` probes both. Full design:
+[`DESIGN-v0.4.md`](./DESIGN-v0.4.md). Empirical PoC data:
+[`experiments/v0.4-*-poc/`](./experiments/). Tracking issue
+[#101](https://github.com/deeplethe/forkd/issues/101).
 
 <br/>
 
@@ -356,9 +383,10 @@ pip install forkd                         # Python SDK — calls the daemon over
 npm install @deeplethe/forkd              # TypeScript SDK
 ```
 
-`forkd doctor` runs 14 checks (KVM, hardware virt, cgroup v2, IP forward,
+`forkd doctor` runs 16 checks (KVM, hardware virt, cgroup v2, IP forward,
 tap, netns, Firecracker binary + version, Docker daemon, snapshot dir +
-disk space, kernel image, controller reachability, platform) and emits
+disk space, kernel image, controller reachability, platform, plus
+`uffd_wp` + `memfd_create` for the v0.4 live-fork path) and emits
 specific fix hints for each non-pass. Run this first whenever something
 feels off.
 
@@ -467,11 +495,15 @@ Controller daemon (lifecycle + branching):
 from forkd import Controller
 
 c = Controller()                                  # http://127.0.0.1:8889
-children = c.spawn_sandboxes("pyagent", n=1, per_child_netns=True)
+children = c.spawn_sandboxes("pyagent", n=1, per_child_netns=True,
+                             live_fork=True)      # v0.4: enables `mode="live"` later
 sb_id = children[0]["id"]
 
-# … drive sb_id via in-guest Sandbox, then branch before a risky step:
-branch = c.branch_sandbox(sb_id, tag="checkpoint-1")
+# … drive sb_id via in-guest Sandbox, then branch before a risky step.
+# `mode="live"` collapses source pause to sub-50 ms (vs ~200 ms for diff);
+# `wait=False` returns after the source resumes (~10 ms), background
+# copy finishes asynchronously — poll list_snapshots for status="ready".
+branch = c.branch_sandbox(sb_id, tag="checkpoint-1", mode="live", wait=False)
 grandchildren = c.spawn_sandboxes(branch["tag"], n=5)  # speculative fan-out
 ```
 
@@ -490,15 +522,22 @@ npm install @deeplethe/forkd
 import { Controller } from '@deeplethe/forkd';
 
 const ctrl = new Controller();   // reads FORKD_URL, FORKD_TOKEN from env
-const [parent] = await ctrl.spawnSandboxes({ snapshotTag: 'pyagent', n: 1, perChildNetns: true });
+const [parent] = await ctrl.spawnSandboxes({
+  snapshotTag: 'pyagent', n: 1, perChildNetns: true,
+  liveFork: true,             // v0.4: enables { mode: 'live' } later
+});
 
 // ... drive parent via REST/HTTP ...
-const branch = await ctrl.branchSandbox(parent.id, { diff: true });    // ~200 ms
+// `mode: 'live'` + `wait: false` = source pauses sub-50 ms and the
+// caller returns after ~10 ms; the background memory copy completes
+// asynchronously, snapshot reaches `status: 'ready'` afterward.
+const branch = await ctrl.branchSandbox(parent.id, { mode: 'live', wait: false });
 const kids = await ctrl.spawnSandboxes({ snapshotTag: branch.tag, n: 5, perChildNetns: true });
 ```
 
 Surface parity with the Python SDK: `spawnSandboxes` / `branchSandbox`
-take the same `prewarm` / `diff` / `measure_diff` options. See
+take the same `prewarm` / `liveFork` / `mode` / `wait` /
+`measure_diff` options. See
 [`sdk/typescript/`](./sdk/typescript/).
 
 ### MCP server
@@ -688,14 +727,25 @@ detects the missing file and falls back to the source-tag base with
 a logged warning. Full design:
 [`docs/design/diff-snapshots.md`](./docs/design/diff-snapshots.md).
 
-The bigger v0.4+ candidate, live-fork via memfd + uffd_wp, is
-tracked in [issue #101](https://github.com/deeplethe/forkd/issues/101).
-Scaffolding (`crates/forkd-uffd/`, `MemoryBackend::Userfault` enum,
-design doc) stays as a starting point if/when the cost-benefit
-changes. We explicitly chose **not** to fork Firecracker — phase 1's
-143× cleared 85 % of the original target headroom on vanilla
-upstream, and the memfd value-add (the only reason to fork) doesn't
-add capability we don't already have via `mmap MAP_PRIVATE`.
+**v0.4 live BRANCH** is wired up end-to-end on the user surface
+(REST `mode: "live"`, CLI `--live`, Python / TypeScript / MCP SDKs;
+PRs [#204](https://github.com/deeplethe/forkd/pull/204)–[#207](https://github.com/deeplethe/forkd/pull/207)).
+The mechanism: spawn with `live_fork: true` to back guest RAM with a
+memfd shared between Firecracker and the controller, then BRANCH with
+UFFD_WP capturing dirty pages out-of-band so the source resumes
+immediately after vCPU dump (sub-50 ms) and the memory copy completes
+asynchronously. We initially planned to stay on vanilla FC, but
+`mem_backend.backend_type: "Shared"` with `shared: true` is the one
+upstream gap we couldn't work around without `mmap MAP_SHARED` —
+hence the vendored fork at
+[deeplethe/firecracker:forkd-v0.4-mem-backend-shared-v1.12](https://github.com/deeplethe/firecracker/tree/forkd-v0.4-mem-backend-shared-v1.12).
+We have an open upstream proposal
+([`FIRECRACKER-UPSTREAM-PROPOSAL.md`](./FIRECRACKER-UPSTREAM-PROPOSAL.md));
+once that lands, the vendor requirement goes away. Tracking issue:
+[#101](https://github.com/deeplethe/forkd/issues/101). Bench numbers
+on a clean parent (`bench/live-fork-pause-window.md`) are in progress
+— Phase 6 E2E captured pause_ms = 41-48 ms in early tests but the
+parent had pre-baked guest Oopses contaminating the measurement.
 
 > **0.1.4 contains daemon security fixes.** Two HIGH-class
 > validation gaps in `POST /v1/sandboxes` (path-traversal via

--- a/docs/API.md
+++ b/docs/API.md
@@ -103,7 +103,8 @@ Request:
   "snapshot_tag": "py",
   "n": 10,
   "per_child_netns": true,
-  "memory_limit_mib": 256
+  "memory_limit_mib": 256,
+  "live_fork": true
 }
 ```
 
@@ -114,6 +115,11 @@ Request:
 - `memory_limit_mib` — sets `memory.max` on a per-child cgroup v2
   leaf. Requires cgroup v2 unified hierarchy and write access to
   `/sys/fs/cgroup/forkd/`.
+- `live_fork` (v0.4+, default `false`) — boot the sandbox with a
+  memfd-backed RAM region so later `POST .../branch` calls can use
+  `mode: "live"`. Requires Linux ≥ 5.7 and the vendored Firecracker
+  fork (see `docs/VENDORED-FIRECRACKER.md`). `forkd doctor` probes
+  both prerequisites.
 
 Response (201 Created): `[SandboxInfo, ...]`.
 
@@ -174,30 +180,53 @@ automatically, so grandchildren see the same persistent disks.
 Request:
 
 ```json
-{ "tag": "checkpoint-1" }
+{ "tag": "checkpoint-1", "mode": "live", "wait": false }
 ```
 
 - `tag` is optional. When unset the daemon generates
   `branch-<source-id>-<unix-ts>`. Must match
   `^[A-Za-z0-9_][A-Za-z0-9._-]{0,63}$`.
+- `mode` (v0.4+) is one of `"full"`, `"diff"`, `"live"`. Defaults to
+  `"full"` when unset. `"live"` requires the source sandbox to have
+  been spawned with `live_fork: true` and the host to support UFFD_WP
+  + memfd_create (`forkd doctor` probes both).
+- `diff: true` is the legacy v0.3 equivalent of `mode: "diff"`; kept
+  for compatibility. **Mutually exclusive with `mode`** — sending
+  both yields `400 Bad Request`.
+- `wait` (v0.4+, default `true`) is only meaningful with
+  `mode: "live"`. When `false`, the daemon returns
+  [`SnapshotInfo`](#snapshotinfo) with `status: "writing"` as soon
+  as the source resumes (~10 ms); the background memory copy
+  finishes asynchronously and the snapshot's `status` flips to
+  `"ready"` (or `"failed"`). Poll `GET /v1/snapshots` to detect
+  completion.
 
 Response (201 Created): [`SnapshotInfo`](#snapshotinfo) with
 `branched_from` set to the source sandbox id and `pause_ms`
-populated with the measured pause window in milliseconds.
+populated with the measured pause window in milliseconds. With
+`mode: "live"`, also returns `status` (`"writing"` when
+`wait: false`, otherwise `"ready"`).
 
 Errors:
 
+- `400 Bad Request` — both `mode` and `diff` set
 - `404 Not Found` — source sandbox id not in `live_vms`
 - `409 Conflict` — tag already exists on disk; `DELETE` it first
 - `409 Conflict` — a BRANCH for this exact tag is already in flight
 - `503 Service Unavailable` — daemon at branch concurrency cap (default 4)
 - `500 Internal Server Error` — pause / snapshot / resume failure
 
-**Pause-window semantics.** The source sandbox is paused at the vCPU
-level (kernel state and TCP sockets stay; application-level keepalives
-may time out) for the duration of the snapshot write — typically
-0.5–8 s depending on memory image size. Modal's "branch" operation
-has the same semantics.
+**Pause-window semantics by mode.** The source's user-visible pause:
+
+- `mode: "full"` — 0.5–8 s, whole guest RAM written.
+- `mode: "diff"` — ~200 ms idle source, sub-second for typical agent
+  workloads (v0.3+; see `bench/pause-window/RESULTS-v0.3.md`).
+- `mode: "live"` — sub-50 ms; dirty pages captured asynchronously
+  via UFFD_WP (v0.4+).
+
+The source is paused at the vCPU level (kernel state and TCP sockets
+stay; application-level keepalives may time out for `"full"`).
+Modal's "branch" operation has comparable semantics to `mode: "full"`.
 
 If `resume` fails after a successful snapshot the snapshot file is
 intact and returned to the caller; the source sandbox may be left in
@@ -232,7 +261,8 @@ rationale, use cases, and follow-up roadmap.
   "dir": "/var/lib/forkd/snapshots/py",
   "created_at_unix": 1717000000,
   "branched_from": "sb-67a1b3-0000",
-  "pause_ms": 1820
+  "pause_ms": 1820,
+  "status": "ready"
 }
 ```
 
@@ -246,6 +276,12 @@ rationale, use cases, and follow-up roadmap.
   via BRANCH. This is the daemon's ground truth; the *application*-
   observed pause (TCP stalls, missed pings) can be longer due to OS
   retransmit timers.
+- `status` (v0.4+, optional) — `"writing"` while a live BRANCH's
+  background memory copy is in flight (only seen with `mode: "live"`
+  + `wait: false`), `"ready"` once the snapshot is consumable,
+  `"failed"` if the background copy hit an error. Omitted on
+  snapshots from Diff or Full BRANCH (they're synchronous, so the
+  daemon only returns once they're `ready`).
 
 ## ErrorBody
 


### PR DESCRIPTION
## Summary

The v0.4 live BRANCH path shipped end-to-end (Phases 6 + 7, PRs #194–#207), but the README still pitched it as \"experimental, try \`forkd wp-bench\`\" and the Status section explicitly claimed we'd \"chosen not to fork Firecracker\" — which contradicts main today. This sweep brings the docs in sync with reality.

## Changes

- **README.md / README-zh.md** — v0.4 preview block rewritten as the actual user-facing surface (REST `mode: \"live\"`, CLI `--live` / `--no-wait`, SDK `mode=`). Doctor check count 14 → 16. SDK examples show `live_fork=True` / `liveFork: true` + `mode=\"live\"` + `wait=False`. Status section's stale \"we chose not to fork FC\" paragraph replaced with the honest version: we did, here's the branch, here's the upstream proposal, vendor requirement goes away if upstream takes it.
- **docs/API.md** — `POST /v1/sandboxes/:id/branch` documents `mode`, `wait`, the `mode`/`diff` mutex (HTTP 400), and per-mode pause semantics. `POST /v1/sandboxes` documents `live_fork`. `SnapshotInfo` gains the `status` field for the `wait=false` lifecycle.
- **DESIGN-v0.4.md** — status banner flipped from DRAFT to IMPLEMENTED with links to PRs; DRAFT body preserved as the architecture record.
- **CHANGELOG.md** — Unreleased gets a comprehensive \"v0.4 live-fork: user-facing surface complete\" section. Flags the one known CLI gap (`forkd fork --live-fork` for spawn-time opt-in isn't surfaced — use SDK / REST for now).

## Honest gap surfaced

The doc comment on `forkd snapshot --live` already says the source must have been \"created with `--live-fork`,\" but that CLI flag doesn't exist yet — only the REST `live_fork: true` field and the SDK `live_fork=` kwarg are wired up. CHANGELOG calls this out; tracking as a follow-up (separate PR).

## Test plan

- [x] All doc links resolve (manual check on the changed sections)
- [x] CLI snippet aligns with current `clap` flag set (verified `--live` / `--no-wait` exist; `--live-fork` honestly flagged as not yet)
- [x] REST + SDK snippets compile against the current types (verified against Phase 7.1 + 7.3 surface)
- [ ] Markdown CI (no code; CI just covers Rust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)