### PR TITLE
feat(cli): `forkd fork --live-fork` — memfd-backed children for local v0.4 path

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -67,10 +67,11 @@ branch = c.branch_sandbox(parent["id"], mode="live", wait=False)
 ```
 
 ```bash
-# Live BRANCH 已经在 CLI 上(Phase 7.2):
+# CLI:本地 fork live-fork-capable 子 VM,然后对 daemon 追踪的那个
+# 做 live BRANCH。两条路径暂时还不组合 ——daemon 侧 spawn 走 CLI
+# 是下一个缺口(状态见 issue #209)。
+sudo -E forkd fork --tag pyagent -n 1 --per-child-netns --live-fork
 sudo -E forkd snapshot --from-sandbox <sb-id> --live --no-wait
-# 启动时带 live_fork 目前只走 REST/SDK ——`forkd fork --live-fork`
-# 在后续 phase 里加;现在用 SDK 或直接 POST /v1/sandboxes 启动。
 ```
 
 需要 Linux ≥ 5.7、`vm.unprivileged_userfaultfd=1`(或

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ branch = c.branch_sandbox(parent["id"], mode="live", wait=False)
 ```
 
 ```bash
-# Live BRANCH itself is exposed on the CLI (Phase 7.2):
+# CLI: spawn live-fork-capable children locally, then live-BRANCH the
+# daemon-tracked one. The two paths don't compose yet — daemon-side
+# spawn from the CLI is the next gap (see issue #209 for status).
+sudo -E forkd fork --tag pyagent -n 1 --per-child-netns --live-fork
 sudo -E forkd snapshot --from-sandbox <sb-id> --live --no-wait
-# Spawning with live_fork is REST/SDK-only today — `forkd fork
-# --live-fork` is a follow-up; for now drive spawning via the SDK
-# or POST /v1/sandboxes directly.
 ```
 
 Requires Linux ≥ 5.7, `vm.unprivileged_userfaultfd=1` (or

--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -141,6 +141,15 @@ enum Cmd {
         /// Requires root or a delegated cgroup. See `crates/forkd-vmm/src/cgroup.rs`.
         #[arg(long)]
         memory_limit_mib: Option<u64>,
+        /// Boot each child with a memfd-backed RAM region (v0.4). Required
+        /// upfront if you later want to take a v0.4 live BRANCH off this
+        /// child — `mode: "live"` arms UFFD_WP on the memfd, which only
+        /// works on shmem-backed VMAs (kernel 5.7+ + vendored Firecracker
+        /// fork; see `docs/VENDORED-FIRECRACKER.md`). `forkd doctor`
+        /// probes both prereqs. No effect at spawn time beyond the
+        /// backend swap; cost shows up on the first live BRANCH.
+        #[arg(long)]
+        live_fork: bool,
         /// Keep `/tmp/forkd-fork-<tag>/` after shutdown (default: remove).
         /// Useful for post-mortem inspection of child console logs and
         /// Firecracker API sockets.
@@ -648,6 +657,7 @@ fn main() -> Result<()> {
             settle_secs,
             per_child_netns,
             memory_limit_mib,
+            live_fork,
             keep_workdir,
         } => fork_cmd(
             tag,
@@ -655,6 +665,7 @@ fn main() -> Result<()> {
             settle_secs,
             per_child_netns,
             memory_limit_mib,
+            live_fork,
             keep_workdir,
         ),
         Cmd::Exec {
@@ -1978,6 +1989,7 @@ fn fork_cmd(
     settle_secs: u64,
     per_child_netns: bool,
     memory_limit_mib: Option<u64>,
+    live_fork: bool,
     keep_workdir: bool,
 ) -> Result<()> {
     validate_tag(&tag)?;
@@ -2016,8 +2028,15 @@ fn fork_cmd(
                 // CLI fork is one-shot — caller can re-run if cold matters.
                 // The daemon's create_sandbox path is where prewarm pays off.
                 prewarm_scratch_dir: None,
-                // v0.2 ships only File. Userfault is v0.3 scaffolding.
-                memory_backend: forkd_vmm::MemoryBackend::File,
+                // `--live-fork` opts each child into a per-child memfd
+                // (see lib.rs Phase 1.5) so a later v0.4 live BRANCH from
+                // it can arm UFFD_WP on the shmem-backed VMA. Default
+                // stays File for backward compat with v0.3.x flows.
+                memory_backend: if live_fork {
+                    forkd_vmm::MemoryBackend::MemfdShared
+                } else {
+                    forkd_vmm::MemoryBackend::File
+                },
                 // CLI fork doesn't outlive its invocation, no diff snapshots.
                 enable_diff_snapshots: false,
             },


### PR DESCRIPTION
## Summary

Adds `--live-fork` to `forkd fork`. Same v0.4 backing the daemon's `POST /v1/sandboxes { live_fork: true }` has used since Phase 6.5: per-child memfd populated from the snapshot's `memory.bin`, then `mem_backend.shared = true` on FC restore.

Closes the local-boot half of #209.

## Scope choice

Original issue listed `forkd fork`, `from-image`, and `run`. On closer reading only `fork` actually needs the flag:

- **`from-image`** builds a snapshot tag. `live_fork` is per-*spawn*, not per-*tag* — nowhere to apply at tag-build time.
- **`run`** is one-shot (build → fork 1 → exec → kill). Child dies with the command; no live-BRANCH target.

## What still isn't possible from CLI alone

`forkd fork` boots Firecracker LOCALLY — the controller daemon doesn't track those processes, so `forkd snapshot --from-sandbox <id> --live` (which calls `POST /v1/sandboxes/<id>/branch`) can't reach them. Composing the two needs a CLI verb that spawns via the daemon. The README diff calls this out honestly (\"the two paths don't compose yet\"); #209 stays open for that follow-up.

## Test plan

- [x] `cargo fmt --check --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 98/98 pass
- [x] `forkd fork --help` shows `--live-fork` with the kernel-5.7 prereq pointer
- [ ] End-to-end `forkd fork --live-fork` against a real snapshot — deferred (will be covered by the daemon-spawn CLI verb in a follow-up where the live-BRANCH leg can also be tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)