### PR TITLE
v0.5 Phase 6 — README + API.md + HUB.md + CHANGELOG docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 
 ## Unreleased
 
+### v0.5 — diff-snapshot chains
+
+Snapshots can now record a `parent_tag` + content-hash edge to an
+earlier snapshot, letting agents stack incremental layers on a
+warmed base (`base → +numpy → +pandas → +sklearn`) instead of
+producing a flat 1.5-GiB-each snapshot per dependency set. The
+daemon walks the chain at spawn time and assembles the memory image
+in one pass; correctness verified across depths 1-3 by the Phase 5
+bench ([`bench/chain-spawn/RESULTS-v0.5.md`](./bench/chain-spawn/RESULTS-v0.5.md))
+with 90/90 (100%) probe passes. Tracking issue
+[#216](https://github.com/deeplethe/forkd/issues/216).
+
+- **Phase 1** (PR #213) — `forkd_vmm::chain` library: `resolve_chain`,
+  `verify_parent_hashes`, `assemble_chain_memory` with a reflink-
+  preferred `cp(base) + apply_diff` walk. 7 unit tests cover cycle
+  detection, missing-parent actionable errors, and hash mismatch.
+- **Phase 2a** (PR #214) — chain-aware `POST /v1/sandboxes`: when
+  the target tag has `parent_tag` set, the controller transparently
+  walks the chain, verifies each link's `parent_content_hash`,
+  assembles memory into a per-spawn temp file, and FC-restores from
+  that. Pre-existing flat-snapshot spawns unchanged.
+- **Phase 2b** (PR #215) — `forkd snapshot-diff --from --tag --exec`
+  CLI verb. Spawns a one-shot sandbox from the base, runs the exec
+  in-guest, then BRANCHes with `parent_tag` set so the resulting
+  snapshot records the chain edge. The daemon's BRANCH endpoint
+  accepts `parent_tag` on the request body (validated against the
+  source's snapshot tag).
+- **Phase 5** (PR #217) — chain-spawn bench + a Phase 2a bug fix.
+  Headline: on a 512 MiB base (ext4), a depth-3 chain spawn took
+  p50 = 1668 ms vs 746 ms for the flat-equivalent. The ~460 ms
+  per-link tax tracks SHA-256 of the base — the mmap-once
+  incremental verify optimization is queued for v0.6. Same PR also
+  fixed a real bug where the chain-assembled `memory.bin` was
+  unlinked by `restore_many_with`'s startup sweep before FC could
+  load it (caught by running the bench, never by unit tests). New
+  regression test `work_dir_sweep_preserves_chainstage_subdirectory`.
+- **Phase 4** (PR #219) — chain-aware management verbs:
+  - `forkd snapshot-info <tag>` (`GET /v1/snapshots/:tag/info`) —
+    chain depth, ancestors, dependents, on-disk sizes.
+  - `forkd rmi <tag> [--cascade | --force]` — pre-Phase-4 `rmi`
+    silently orphaned chained children; now refuses with HTTP 409 +
+    actionable message until the caller picks an escape hatch.
+  - `forkd snapshot-compact --from <tag> --to <new>`
+    (`POST /v1/snapshots/:tag/compact`) — materialize a chain into a
+    new flat snapshot with no `parent_tag`. Stages via
+    `.compact-staging-<to>/` + `rename(2)` so a mid-compact crash
+    leaves nothing half-written.
+- **Phase 3** (PR #220) — Hub pack/unpack bumped to **manifest v2**.
+  When the head has `parent_tag.is_some()`, `forkd pack` walks the
+  chain on disk and bundles every ancestor under per-link tar
+  prefixes; `unpack` materializes one snapshot directory per link.
+  Depth-0 (base) snapshots keep emitting v1 packs so older clients
+  keep working. Unsafe `chain[].tag` entries (path traversal) are
+  rejected at manifest-parse time before any file body is extracted.
+- **Phase 6** — docs (this changelog entry, README v0.5 section,
+  `docs/API.md` `SnapshotInfoDetail` + new endpoints, `docs/HUB.md`
+  pack v2 spec, [`DESIGN-v0.5-diff-snapshot-chains.md`](./DESIGN-v0.5-diff-snapshot-chains.md)).
+
 ### v0.4 live-fork: user-facing surface complete
 
 The v0.4 live-fork path — BRANCH that pauses the source for sub-50 ms

--- a/README.md
+++ b/README.md
@@ -87,6 +87,69 @@ Requires Linux ≥ 5.7, `vm.unprivileged_userfaultfd=1` (or
 
 <br/>
 
+## v0.5: stacking diff snapshots into a chain
+
+Once an agent starts caching `pip install numpy`, `pip install pandas`,
+`pip install scikit-learn` as separate snapshots, you want them
+**stacked** — not three copies of the same 1.5 GiB base. v0.5 ships
+**diff-snapshot chains**: each layer records a `parent_tag` +
+content-hash edge to the layer below; the daemon walks the chain at
+spawn time and assembles the memory image in one pass.
+
+```bash
+# Build a 3-layer chain off a python:3.12-slim base
+forkd snapshot-diff --from py-base --tag py-numpy   --exec "pip install numpy==2.0.2"
+forkd snapshot-diff --from py-numpy --tag py-pandas --exec "pip install pandas==2.2.3"
+
+# Spawn from the chain head — daemon walks edges, verifies parent
+# content hashes, assembles memory transparently. Caller sees one
+# POST /v1/sandboxes round-trip.
+forkd fork --tag py-pandas -n 1
+
+# Inspect a chain before deciding to delete or compact
+forkd snapshot-info py-numpy
+#   chain depth:    1
+#   parent_tag:     py-base
+#   ancestors:      py-base
+#   dependents:     py-pandas (would be orphaned by `rmi`)
+
+# rmi refuses to orphan a chain parent — explicit cascade or force
+forkd rmi py-numpy                  # HTTP 409, names the dependent
+forkd rmi py-numpy --cascade        # delete subtree
+forkd rmi py-numpy --force          # orphan children
+
+# Flatten a deep chain when the per-link tax bites
+forkd snapshot-compact --from py-pandas --to py-pandas-flat
+
+# Ship the whole chain in one tarball (bundles every ancestor)
+forkd pack --tag py-pandas --out py-pandas-chain.tar.zst
+forkd unpack py-pandas-chain.tar.zst   # restores all 3 link dirs
+```
+
+**Phase 5 bench numbers** ([`bench/chain-spawn/RESULTS-v0.5.md`](./bench/chain-spawn/RESULTS-v0.5.md))
+on a 512 MiB base, ext4, i7-12700:
+
+| chain head | depth | spawn p50 | per-link tax |
+|---|---:|---:|---:|
+| base (flat) | 0 | 59 ms | — |
+| `+numpy` | 1 | 751 ms | +692 ms |
+| `+pandas` | 2 | 1 222 ms | +471 ms |
+| `+sklearn` | 3 | 1 668 ms | +446 ms |
+| flat-equivalent (3 pkgs, one diff) | 1 | 746 ms | — |
+
+Per-link tax tracks SHA-256 of the base (~460 ms for 512 MiB at
+1.1 GiB/s on this CPU) — the mmap-once-then-incremental verify
+optimization is queued as v0.6. **Correctness: 90/90 (100%) probe
+passes across L1/L2/L3 plus the flat-equivalent** — the design's
+vmstate-drift question is empirically closed.
+
+Tracking issue
+[#216](https://github.com/deeplethe/forkd/issues/216) lists every
+phase + PR. Design doc:
+[`DESIGN-v0.5-diff-snapshot-chains.md`](./DESIGN-v0.5-diff-snapshot-chains.md).
+
+<br/>
+
 ## Demo: branch a thinking agent
 
 A 24-second walkthrough of the LangGraph branch-and-fan-out demo —

--- a/docs/API.md
+++ b/docs/API.md
@@ -88,6 +88,77 @@ Remove the registry entry and delete the on-disk snapshot files.
 Returns `204 No Content`. `404` if no such tag is registered and no
 on-disk files exist.
 
+**v0.5 chain safety** — when the tag is the recorded `parent_tag` of
+one or more other snapshots, the daemon refuses with `409 Conflict`
+unless the caller opts in via a query parameter:
+
+| Query | Effect |
+|---|---|
+| `?cascade=true` | Recursively delete the tag AND every descendant snapshot. |
+| `?force=true`   | Delete the tag, leaving children orphaned (they will fail to restore). |
+
+The two flags are mutually exclusive; passing both returns
+`400 Bad Request`. The 409 response body names every blocking
+dependent so the caller can decide:
+
+```json
+{
+  "error": "snapshot `py-numpy` is the parent of 1 chained snapshot(s): [py-pandas]; rerun with `?cascade=true` to delete the whole subtree, or `?force=true` to orphan the children (they will fail to restore)"
+}
+```
+
+### GET /v1/snapshots/:tag/info
+
+**v0.5.** Return chain + on-disk info for a single snapshot. Useful
+before `rmi`-ing a chained tag (see the dependents list) or before
+deciding to `compact` a deep chain (see the depth + per-link sizes).
+
+Response body shape:
+
+```json
+{
+  "tag": "py-pandas",
+  "dir": "/var/lib/forkd/snapshots/py-pandas",
+  "created_at_unix": 1780556400,
+  "memory_logical_bytes": 536870912,
+  "memory_physical_bytes": 536875008,
+  "vmstate_bytes": 21900,
+  "parent_tag": "py-numpy",
+  "parent_content_hash": "276c99e9...",
+  "chain_depth": 2,
+  "ancestors": ["py-base", "py-numpy"],
+  "dependents": []
+}
+```
+
+`chain_depth` counts diff links between the snapshot and its chain
+root (0 for a base). `ancestors` is ordered root → direct parent.
+`dependents` lists every tag whose `parent_tag` equals this one.
+
+`404 Not Found` when the tag isn't registered and has no on-disk
+directory.
+
+### POST /v1/snapshots/:tag/compact
+
+**v0.5.** Walk the chain rooted at `tag`, verify every per-link
+parent content hash, assemble the head's memory image, and persist
+the result as a new flat (parentless) snapshot under `req.to`. The
+new snapshot restores via the original non-chain code path with no
+per-link SHA-256 tax.
+
+Request:
+```json
+{ "to": "py-pandas-flat" }
+```
+
+Response: a `SnapshotInfo` for the new flat snapshot. `409 Conflict`
+when `req.to` already exists. `400 Bad Request` when `req.to ==
+:tag` or either tag is unsafe.
+
+The implementation stages to a sibling `.compact-staging-<to>/`
+directory and `rename(2)`s into place, so a mid-compact crash never
+leaves a half-written destination snapshot behind.
+
 ---
 
 ## Sandboxes
@@ -282,6 +353,25 @@ rationale, use cases, and follow-up roadmap.
   `"failed"` if the background copy hit an error. Omitted on
   snapshots from Diff or Full BRANCH (they're synchronous, so the
   daemon only returns once they're `ready`).
+
+## SnapshotInfoDetail (v0.5)
+
+Returned by `GET /v1/snapshots/:tag/info`. Adds chain + on-disk
+fields to the registry's plain `SnapshotInfo` shape:
+
+| Field | Type | Notes |
+|---|---|---|
+| `tag` | string | The queried tag. |
+| `dir` | string | Absolute path to the snapshot directory. |
+| `created_at_unix` | u64? | From the registry; absent for on-disk-only snapshots. |
+| `memory_logical_bytes` | u64 | `stat().st_size` of `memory.bin`. |
+| `memory_physical_bytes` | u64 | `st_blocks × 512` — meaningful on reflink filesystems. |
+| `vmstate_bytes` | u64 | Size of the vmstate file. |
+| `parent_tag` | string? | Direct parent in the v0.5 chain; absent for bases. |
+| `parent_content_hash` | string? | SHA-256 of the parent's `memory.bin` at chain-build time. |
+| `chain_depth` | u32 | Number of diff links between this tag and its chain root (0 for a base). |
+| `ancestors` | string[] | Root → direct parent. Empty for bases. |
+| `dependents` | string[] | Tags whose `parent_tag` is this tag. The `rmi`-orphan set. |
 
 ## ErrorBody
 

--- a/docs/HUB.md
+++ b/docs/HUB.md
@@ -47,6 +47,85 @@ to demonstrate that a pre-warmed snapshot can ship MiB-scale binary
 state byte-identically to every child sandbox via copy-on-write,
 which a parallel-prompt API call cannot replicate.
 
+## Pack format
+
+Hub bundles are zstd-compressed tarballs (`.forkd-snapshot.tar.zst`)
+with a TOML manifest at the root. Two on-the-wire layouts coexist:
+
+### v1 — single snapshot (pre-v0.5, still the default for bases)
+
+```text
+manifest.toml
+snapshot.json
+vmstate
+memory.bin
+rootfs.ext4         # optional
+```
+
+`manifest.toml` carries `forkd_pack_version = 1` plus per-file
+`sha256` digests; `unpack` verifies every file against the digest
+after extraction.
+
+### v2 — chained snapshot (v0.5+)
+
+Emitted when `forkd pack` is invoked on a snapshot whose
+`snapshot.json` has `parent_tag` set. The bundle includes every
+ancestor — `unpack` materializes one snapshot directory per chain
+link.
+
+```text
+manifest.toml          # forkd_pack_version = 2, chain[] = root → head
+<tag-0>/snapshot.json   ┐
+<tag-0>/vmstate         │ root base
+<tag-0>/memory.bin      │
+<tag-0>/rootfs.ext4     ┘
+<tag-1>/...             # first diff link
+<tag-2>/...             # head
+```
+
+Manifest's `chain` field is an array of `ChainLinkMeta` ordered
+root → head:
+
+```toml
+forkd_pack_version = 2
+tag = "deeplethe/py-pandas"        # the head's name
+parent_tag = "deeplethe/py-numpy"  # legacy mirror of chain.last().parent_tag
+
+[[chain]]
+tag = "py-base"                    # root base
+files = [
+  { path = "snapshot.json", size = 179,       sha256 = "..." },
+  { path = "vmstate",       size = 29436,     sha256 = "..." },
+  { path = "memory.bin",    size = 536870912, sha256 = "b356ee89..." },
+]
+
+[[chain]]
+tag = "py-numpy"
+parent_tag = "py-base"
+parent_content_hash = "b356ee89..."  # SHA-256 of parent's memory.bin
+files = [ ... ]                       # paths relative to <tag>/ in the tar
+
+[[chain]]
+tag = "py-pandas"
+parent_tag = "py-numpy"
+parent_content_hash = "..."
+files = [ ... ]
+```
+
+**Back-compat invariant:** v0.5 `forkd` clients accept both v1 and
+v2 packs (`MAX_SUPPORTED_PACK_VERSION = 2`). Older clients reject v2
+with a clear "newer format" error rather than silently
+mis-extracting. The top-level `parent_tag` field on v2 manifests
+mirrors `chain.last().parent_tag` so v1 readers peeking at it before
+the version check still see something meaningful.
+
+**Safety:** `unpack` validates every `chain[].tag` against
+alnum/dash/underscore rules **before** extracting any file body, so
+a malicious bundle declaring `tag = "../etc"` is refused at
+manifest-parse time. Multi-link bundles refuse the `--tag <override>`
+flag (ambiguous which link to retag); single-link bundles accept it
+for symmetry with v1.
+
 ## Publishing a new pack
 
 ```bash


### PR DESCRIPTION
## Summary

Pulls v0.5's user-facing surface out of "shipped but undocumented" and into the docs. Closes Phase 6 of #216, which means v0.5 is now end-to-end shippable.

## What's documented

### README.md
New section right after the v0.4 live-fork story: **"v0.5: stacking diff snapshots into a chain"**. Includes a 3-command quickstart (\`snapshot-diff → snapshot-info → fork\`), the rmi safety semantics, snapshot-compact use case, pack/unpack of a chained tag, and the Phase 5 bench table.

### docs/API.md
- \`DELETE /v1/snapshots/:tag\` — new \`?cascade=true\` / \`?force=true\` semantics + 409 error body example
- \`GET /v1/snapshots/:tag/info\` — full response shape + field table
- \`POST /v1/snapshots/:tag/compact\` — request body + staging semantics
- New \`SnapshotInfoDetail\` type section

### docs/HUB.md
New "Pack format" section: v1 vs v2 layouts side-by-side, manifest TOML example with chain[] edges, MAX_SUPPORTED_PACK_VERSION back-compat statement, safety notes (unsafe-tag rejection, --tag override carve-out for multi-link bundles).

### CHANGELOG.md
v0.5 entry under Unreleased walking through Phases 1 → 6 with PR refs, including the Phase 5 risk-closure summary and the Phase 2a bug fix the bench surfaced.

## Closes

- v0.5 tracking #216 — Phase 6 done; **v0.5 is now end-to-end shippable**.
- Independent of #217 (Phase 5), #219 (Phase 4), #220 (Phase 3). Merge order doesn't matter.

## Test plan

- [x] No code touched — pure markdown.
- [x] All links resolved against existing file paths and issue numbers.
- [x] Code examples lifted from real CLI output captured on the dev box during Phase 5/4/3 smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)