### PR TITLE
release: v0.5.0 — workspace version bump + CHANGELOG header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 
 ## Unreleased
 
-### v0.5 — diff-snapshot chains
+## v0.5.0 — 2026-06-05
+
+### Diff-snapshot chains
 
 Snapshots can now record a `parent_tag` + content-hash edge to an
 earlier snapshot, letting agents stack incremental layers on a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/deeplethe/forkd"


### PR DESCRIPTION
## Summary

Workspace \`version\` 0.3.4 → 0.5.0. Promotes the CHANGELOG's "Unreleased › v0.5" entry to "v0.5.0 — 2026-06-05".

This is the first formal release that captures both v0.4 (live BRANCH, UFFD_WP, memfd) AND v0.5 (diff-snapshot chains). v0.4 shipped to main earlier without a version bump, so v0.5.0 folds it in.

## Closes

After merge:
- Tag \`v0.5.0\` at the merge commit.
- \`gh release create v0.5.0\` with the CHANGELOG section as body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)