### PR TITLE
feat(vmm): forward-prep for #218 — virtio-rng + random.trust_cpu=on

### DIFF
--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -123,7 +123,18 @@ impl BootConfig {
             rootfs,
             vcpu_count: 2,
             mem_size_mib: 512,
-            boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro".into(),
+            // `random.trust_cpu=on` tells the guest kernel to trust
+            // RDRAND for CRNG init — one of two paths out of the #218
+            // entropy-starvation hang (the other being a virtio-rng
+            // device, attached in `Vm::boot`). Requires Linux 4.19+
+            // to be honored; forkd's shipped 4.14 vmlinux silently
+            // ignores it but the option is forward-compatible. When
+            // the kernel is updated this immediately resolves
+            // `getrandom(2)`-blocking for OpenSSL workloads.
+            // RDRAND is universal on x86_64 hosts forkd targets
+            // (Intel since Ivy Bridge 2012, AMD since Zen 2017).
+            boot_args:
+                "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro random.trust_cpu=on".into(),
             work_dir,
             rootfs_read_only: true,
             network: None,
@@ -143,7 +154,7 @@ impl BootConfig {
             vcpu_count: 2,
             mem_size_mib: 512,
             boot_args:
-                "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw init=/forkd-init.sh".into(),
+                "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw init=/forkd-init.sh random.trust_cpu=on".into(),
             work_dir,
             rootfs_read_only: false,
             network: None,
@@ -966,6 +977,26 @@ impl Vm {
             api_call(&sock, "PUT", &path, &body.to_string())?;
         }
 
+        // Attach a virtio-rng device. Empty body = no rate limiter
+        // (FC reads from the host's /dev/urandom as fast as the
+        // guest drains).
+        //
+        // This is the **device-side half** of fixing #218 (guest
+        // CRNG never initializes → `getrandom(2)` blocks → anything
+        // that touches OpenSSL hangs). The other half — the guest
+        // kernel binding /dev/hwrng to this device — requires the
+        // kernel image to be built with `CONFIG_HW_RANDOM_VIRTIO=y`.
+        // forkd's shipped 4.14 vmlinux lacks that, so for now this
+        // PUT just adds an inert virtio-mmio device on the bus.
+        // When the kernel is updated (tracked separately) the
+        // device immediately starts feeding the guest CRNG and the
+        // issue clears with no further code change here.
+        //
+        // Forward-only on the snapshot side: existing snapshot
+        // vmstate files won't have the entropy device until they're
+        // re-baked via `forkd from-image`.
+        api_call(&sock, "PUT", "/entropy", "{}")?;
+
         api_call(
             &sock,
             "PUT",
@@ -1693,6 +1724,16 @@ mod tests {
         assert!(cfg.boot_args.contains("console=ttyS0"));
         assert!(cfg.boot_args.contains("root=/dev/vda"));
         assert!(cfg.boot_args.contains(" ro"));
+        // Forward-prep for #218: random.trust_cpu=on resolves
+        // `getrandom(2)` blocking once the guest kernel is rebuilt
+        // with Linux 4.19+. Quietly ignored on the shipped 4.14
+        // image, but if a future commit ever drops the option the
+        // post-kernel-rebuild fix silently regresses — defend it.
+        assert!(
+            cfg.boot_args.contains("random.trust_cpu=on"),
+            "quickstart boot_args must include random.trust_cpu=on (see #218): `{}`",
+            cfg.boot_args
+        );
         assert!(cfg.rootfs_read_only);
     }
 


### PR DESCRIPTION
## Summary

Adds the two host-side knobs that resolve the guest CRNG-starvation hang once the shipped guest kernel is rebuilt:

1. \`PUT /entropy {}\` to FC's API right before \`InstanceStart\` — attaches a virtio-rng device backed by the host's /dev/urandom.
2. \`random.trust_cpu=on\` on the kernel cmdline — tells Linux ≥4.19 to trust RDRAND for CRNG init.

Both inert on the shipped 4.14 vmlinux, both forward-compatible.

## Why this doesn't close #218 by itself

Root cause investigation produced clean signals:

- \`getrandom(GRND_NONBLOCK)\` → EAGAIN (errno 11) — CRNG never initializes.
- \`/dev/hwrng\` absent — virtio-rng device wasn't being attached.
- \`uname -r\` → \`4.14.174\` — guest kernel predates both knobs in this PR.
- \`/proc/cmdline\` after the FC fix shows the device IS attached (3 virtio_mmio entries vs 2 before), but the 4.14 kernel doesn't know how to bind it.

So fixing the symptom needs the guest kernel rebuilt with \`CONFIG_HW_RANDOM_VIRTIO=y\` (and ideally \`CONFIG_RANDOM_TRUST_CPU=y\` for backup). Tracked separately. Landing this code now means as soon as the kernel ships, the issue clears with no further FC change.

## Regression guard

\`boot_config_quickstart_has_sane_defaults\` now asserts \`random.trust_cpu=on\` is present — a future style cleanup that drops the option silently regresses the post-kernel-rebuild fix.

## Test plan

- [x] \`cargo test -p forkd-vmm --lib\` — 34/34 pass
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] End-to-end on the dev box: rebuilt demo-pyt, confirmed FC accepts /entropy (3 virtio devices instead of 2), confirmed cmdline carries trust_cpu, confirmed 4.14 still doesn't init CRNG (= expected, this PR is forward-prep)

## Progresses

- #218 — entropy starvation root cause documented + half the fix landed; full close awaits guest kernel rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)