### PR TITLE
fix(kernel): swap 4.14 guest vmlinux → Linux 6.1.141 — closes #218 + #225

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 
 ## Unreleased
 
+### Guest kernel rebuild — closes #218 + #225
+
+forkd's pre-v0.5.1 vmlinux was Linux **4.14.174** built 2021-07-14.
+That kernel predated `CONFIG_HW_RANDOM_VIRTIO`, `CONFIG_RANDOM_TRUST_CPU`,
+the `random.trust_cpu=` cmdline option (Linux 4.19+), and `CONFIG_VMGENID`
+(Linux 5.20+). Symptom: `getrandom(2)` blocked forever inside a
+restored guest because the CRNG never marked itself initialized —
+anything that touched OpenSSL (`pip install`, `urllib.request` HTTPS,
+`requests`) hung indefinitely.
+
+**Replacement**: Linux **6.1.141** from Firecracker's CI bucket
+(`firecracker-ci/v1.13/x86_64/vmlinux-6.1.141`, sha256
+`b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724`).
+Verified end-to-end on the dev box on 2026-06-05:
+
+| | before | after |
+|---|---|---|
+| `uname -r` | 4.14.174 | 6.1.141 |
+| `/dev/hwrng` | absent | present (virtio-rng) |
+| `getrandom(GRND_NONBLOCK)` | EAGAIN | returns 16 bytes immediately |
+| `ssl.create_default_context()` | blocks forever | 0.01 s |
+| `urllib.request.urlopen("https://pypi.org/…")` | blocks forever | 0.25 s |
+| `pip install numpy==2.0.2` | exit 1, empty output | 21 s, exit 0 |
+| **VMGENID on FC restore** | n/a | dmesg: `random: crng reseeded due to virtual machine fork` |
+
+Two new helper scripts:
+- [`scripts/install-guest-kernel.sh`](./scripts/install-guest-kernel.sh) — downloads the FC CI vmlinux into `/var/lib/forkd/kernels/vmlinux`; the recommended path.
+- [`scripts/build-guest-kernel.sh`](./scripts/build-guest-kernel.sh) — clones Linux 6.1 LTS, applies FC's reference microvm config, builds vmlinux from source (~10 min on a 20-core box). Use this when you want to audit / tune the kernel config or target a non-x86_64 architecture.
+
+**Migration**: existing snapshot vmstates produced under 4.14 still restore on 6.1 — they just don't gain the new entropy device until they're re-baked. Run `forkd from-image <image> --tag <tag>` for each snapshot you care about to pick up CRNG init + `/dev/hwrng` + VMGENID.
+
+`forkd doctor`'s "kernel image" check now suggests running `scripts/install-guest-kernel.sh` when no vmlinux is found.
+
 ## v0.5.0 — 2026-06-05
 
 ### Diff-snapshot chains

--- a/crates/forkd-cli/src/doctor.rs
+++ b/crates/forkd-cli/src/doctor.rs
@@ -512,7 +512,9 @@ fn check_kernel_image() -> Check {
     Check::warn(
         "kernel image",
         "no vmlinux found in common locations",
-        "curl https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.10/x86_64/vmlinux-6.1.141",
+        "sudo scripts/install-guest-kernel.sh   (or override the URL: \
+         curl -L https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.13/x86_64/vmlinux-6.1.141 \
+         -o /var/lib/forkd/kernels/vmlinux)",
     )
 }
 

--- a/scripts/build-guest-kernel.sh
+++ b/scripts/build-guest-kernel.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Build a forkd-compatible vmlinux from a recent Linux LTS source.
+#
+# This is the build recipe behind `/var/lib/forkd/kernels/vmlinux`
+# shipped with forkd v0.5.1 and later. Reproducible: same inputs
+# (kernel branch + FC reference config) → byte-equivalent vmlinux
+# modulo build environment.
+#
+# Why this exists
+# ---------------
+#
+# forkd v0.5.0 and earlier shipped a Linux 4.14.174 vmlinux built in
+# 2021. That kernel predated:
+#
+#   - CONFIG_HW_RANDOM_VIRTIO=y      (virtio-rng driver binding)
+#   - CONFIG_RANDOM_TRUST_CPU=y      (RDRAND CRNG init)
+#   - random.trust_cpu= cmdline      (Linux 4.19+)
+#   - CONFIG_VMGENID=y               (Linux 5.20+, VM-restore CRNG re-seed)
+#
+# Symptom: `getrandom(2)` blocks forever after FC restore — anything
+# that touches OpenSSL (`pip install`, `urllib` HTTPS, `requests`)
+# hangs. See #218 + #225.
+#
+# Linux 6.1 LTS has all three options enabled in FC's reference
+# microvm config and Linux 5.20+ includes VMGENID, so a straight rebuild
+# from upstream closes the bug.
+#
+# Usage
+# -----
+#
+#   # Default: Linux 6.1 LTS, install to /var/lib/forkd/kernels/vmlinux
+#   sudo ./scripts/build-guest-kernel.sh
+#
+#   # Override target version / work dir / install path:
+#   KERNEL_BRANCH=v6.6 \
+#   WORK_DIR=/tmp/my-kbuild \
+#   OUT_PATH=/tmp/vmlinux \
+#     ./scripts/build-guest-kernel.sh
+#
+# Requires
+# --------
+#
+#   gcc make bc flex bison libelf-dev libssl-dev cpio git curl
+#
+# Disk + time
+# -----------
+#
+#   ~5 GB free under WORK_DIR (Linux source ~3 GB, build artifacts ~1.5 GB)
+#   ~10 min on a 20-core x86_64 host. Mostly bound by file I/O during the
+#   initial git clone, not the actual compile.
+
+set -euo pipefail
+
+KERNEL_BRANCH="${KERNEL_BRANCH:-v6.1}"
+WORK_DIR="${WORK_DIR:-/tmp/forkd-kernel-build}"
+FC_VERSION="${FC_VERSION:-v1.12.0}"
+OUT_PATH="${OUT_PATH:-/var/lib/forkd/kernels/vmlinux}"
+ARCH="${ARCH:-x86_64}"
+
+VERSION_NUMBER="${KERNEL_BRANCH#v}"
+SRC_DIR="${WORK_DIR}/linux-${VERSION_NUMBER}"
+CONFIG_URL="https://raw.githubusercontent.com/firecracker-microvm/firecracker/${FC_VERSION}/resources/guest_configs/microvm-kernel-ci-${ARCH}-${VERSION_NUMBER}.config"
+
+echo "==> forkd guest-kernel build"
+echo "    kernel:      ${KERNEL_BRANCH}"
+echo "    arch:        ${ARCH}"
+echo "    fc config:   ${FC_VERSION}"
+echo "    work dir:    ${WORK_DIR}"
+echo "    install to:  ${OUT_PATH}"
+
+# Sanity-check the toolchain so the failure mode below is "missing
+# dep" not "make exit 2 on line 731".
+for bin in gcc make bc flex bison cpio git curl; do
+    command -v "$bin" >/dev/null 2>&1 || {
+        echo "ERROR: missing build dependency: $bin" >&2
+        echo "Ubuntu/Debian: sudo apt install gcc make bc flex bison libelf-dev libssl-dev cpio" >&2
+        exit 2
+    }
+done
+[ -f /usr/include/libelf.h ] || {
+    echo "ERROR: libelf-dev not installed (no /usr/include/libelf.h)" >&2
+    echo "Ubuntu/Debian: sudo apt install libelf-dev" >&2
+    exit 2
+}
+[ -f /usr/include/openssl/ssl.h ] || {
+    echo "ERROR: libssl-dev not installed (no /usr/include/openssl/ssl.h)" >&2
+    echo "Ubuntu/Debian: sudo apt install libssl-dev" >&2
+    exit 2
+}
+
+mkdir -p "$WORK_DIR"
+
+if [ ! -d "$SRC_DIR" ]; then
+    echo "==> cloning ${KERNEL_BRANCH} (shallow, ~5 min)"
+    git clone --depth 1 --branch "$KERNEL_BRANCH" \
+        https://github.com/gregkh/linux.git "$SRC_DIR"
+fi
+
+cd "$SRC_DIR"
+echo "==> fetching FC reference config"
+curl -sSL --fail -o .config "$CONFIG_URL" || {
+    echo "ERROR: failed to download FC reference config from $CONFIG_URL" >&2
+    echo "Pick a different KERNEL_BRANCH or FC_VERSION (must have a matching config)." >&2
+    exit 2
+}
+
+# Sanity-check the entropy-relevant configs are in place. FC's reference
+# already sets them since v1.10ish, but we re-assert in case a future
+# config drops them.
+for opt in CONFIG_HW_RANDOM_VIRTIO CONFIG_RANDOM_TRUST_CPU CONFIG_VMGENID; do
+    if ! grep -q "^$opt=y" .config; then
+        echo "    enabling $opt (not set in upstream FC config)"
+        scripts/config --file .config -e "${opt#CONFIG_}"
+    fi
+done
+
+echo "==> reconciling config"
+make olddefconfig >/dev/null
+
+echo "==> building vmlinux on $(nproc) cores"
+time make vmlinux -j"$(nproc)" 2>&1 | tail -3
+
+[ -f vmlinux ] || { echo "ERROR: build did not produce vmlinux" >&2; exit 1; }
+
+echo "==> built:"
+ls -la vmlinux
+file vmlinux | head -1
+
+if [ "$OUT_PATH" != "" ]; then
+    INSTALL_DIR="$(dirname "$OUT_PATH")"
+    if [ ! -d "$INSTALL_DIR" ]; then
+        sudo mkdir -p "$INSTALL_DIR"
+    fi
+    sudo cp vmlinux "$OUT_PATH"
+    sudo chmod 644 "$OUT_PATH"
+    echo "==> installed to $OUT_PATH"
+    echo ""
+    echo "Verify in a new guest:"
+    echo "    forkd from-image python:3.12-slim --tag test-pyt"
+    echo "    forkd fork --tag test-pyt -n 1"
+    echo "    # then in the child: python3 -c 'import ssl; ssl.create_default_context()'"
+fi

--- a/scripts/install-guest-kernel.sh
+++ b/scripts/install-guest-kernel.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Install a forkd-compatible vmlinux. Two paths:
+#
+#   1. Download — fetch Firecracker's CI-blessed vmlinux-6.1.141 from
+#      AWS S3. ~40 MiB, takes seconds. Recommended for almost everyone.
+#
+#   2. Build from source — clone Linux 6.1 LTS, apply FC's reference
+#      microvm config, build vmlinux. Takes ~10 min on a 20-core box.
+#      Use this if you want to audit / tune the kernel config, or your
+#      target architecture isn't x86_64.
+#
+# This is the recipe behind /var/lib/forkd/kernels/vmlinux as of
+# forkd v0.5.1. The shipped pre-v0.5.1 kernel was Linux 4.14.174 from
+# 2021 — predated CONFIG_HW_RANDOM_VIRTIO, CONFIG_RANDOM_TRUST_CPU,
+# CONFIG_VMGENID, random.trust_cpu= cmdline, and io_uring; in
+# particular CRNG never initialized inside a restored guest, so
+# `getrandom(2)` blocked forever and `pip install` / urllib HTTPS hung.
+# See #218 + #225 for the full root cause walk.
+#
+# Usage
+# -----
+#
+#   # Download path (default, recommended):
+#   sudo ./scripts/install-guest-kernel.sh
+#
+#   # Build-from-source path:
+#   sudo ./scripts/install-guest-kernel.sh --build
+#
+#   # Custom install path:
+#   sudo OUT_PATH=/tmp/vmlinux ./scripts/install-guest-kernel.sh
+#
+# Verify after install:
+#
+#   forkd from-image python:3.12-slim --tag test-pyt
+#   # then inside a forked child:
+#   python3 -c 'import ssl; ssl.create_default_context(); print("ok")'
+
+set -euo pipefail
+
+OUT_PATH="${OUT_PATH:-/var/lib/forkd/kernels/vmlinux}"
+KERNEL_URL="${KERNEL_URL:-https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.13/x86_64/vmlinux-6.1.141}"
+# sha256 pin for the FC CI vmlinux. Verified end-to-end on the dev
+# box on 2026-06-05 — `getrandom(2)` initializes, `import ssl` works,
+# `pip install numpy` completes. Override `EXPECTED_SHA256=""` to skip
+# the check (e.g. when pointing KERNEL_URL at a private mirror).
+EXPECTED_SHA256="${EXPECTED_SHA256:-b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724}"
+MODE="download"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --build) MODE="build" ;;
+        --download) MODE="download" ;;
+        --help|-h)
+            sed -n '2,/^$/p' "$0"
+            exit 0
+            ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+INSTALL_DIR="$(dirname "$OUT_PATH")"
+sudo mkdir -p "$INSTALL_DIR"
+
+case "$MODE" in
+    download)
+        echo "==> downloading Firecracker CI vmlinux-6.1.141"
+        echo "    from: $KERNEL_URL"
+        echo "    to:   $OUT_PATH"
+        TMP="$(mktemp -t forkd-vmlinux.XXXXXX)"
+        # shellcheck disable=SC2064
+        trap "rm -f '$TMP'" EXIT
+        curl -fL --progress-bar -o "$TMP" "$KERNEL_URL"
+        if [ -n "$EXPECTED_SHA256" ]; then
+            echo "==> verifying sha256"
+            ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
+            if [ "$ACTUAL" != "$EXPECTED_SHA256" ]; then
+                echo "ERROR: sha256 mismatch (got $ACTUAL, want $EXPECTED_SHA256)" >&2
+                exit 1
+            fi
+        fi
+        sudo cp "$TMP" "$OUT_PATH"
+        sudo chmod 644 "$OUT_PATH"
+        ;;
+    build)
+        echo "==> building from source via scripts/build-guest-kernel.sh"
+        SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+        "$SCRIPT_DIR/build-guest-kernel.sh"
+        ;;
+esac
+
+echo
+echo "==> installed:"
+ls -la "$OUT_PATH"
+file "$OUT_PATH" | head -1
+strings "$OUT_PATH" 2>/dev/null | grep -E "^Linux version" | head -1
+
+echo
+echo "==> next: rebuild any v0.5.0-era snapshots so they pick up the"
+echo "    virtio-rng device and #218's CRNG fix:"
+echo
+echo "    forkd ls --snapshots   # see what you have"
+echo "    forkd rmi <tag>"
+echo "    forkd from-image python:3.12-slim --tag <tag>"


### PR DESCRIPTION
## Summary

Pre-v0.5.1 forkd shipped Linux **4.14.174** built 2021-07-14 as the guest kernel. That kernel lacks every entropy modernization since:

| Feature | Available since | 4.14.174 |
|---|---|---|
| \`CONFIG_HW_RANDOM_VIRTIO\` | — | not built in |
| \`CONFIG_RANDOM_TRUST_CPU\` | — | not set |
| \`random.trust_cpu=\` cmdline | Linux 4.19 | silently ignored |
| \`CONFIG_VMGENID\` | Linux 5.20 | absent |

Net effect: \`getrandom(2)\` blocks forever after FC restore, anything that touches OpenSSL hangs forever. Filed as #218, root-caused in #225.

## Fix

Use Firecracker's CI-blessed **Linux 6.1.141** vmlinux from \`firecracker-ci/v1.13/x86_64/\`. SHA-256 pinned: \`b36a4a1b10f33b9cfdcde3d1a787d9c090556a3edb211cd06d1f3f9a6c7e8724\`.

End-to-end on the dev box, 2026-06-05:

| | before | after |
|---|---|---|
| \`uname -r\` | 4.14.174 | **6.1.141** |
| \`/dev/hwrng\` | absent | crw, virtio-rng |
| \`getrandom(GRND_NONBLOCK)\` | EAGAIN | 16 bytes, errno=0 |
| \`ssl.create_default_context()\` | ∞ | **0.01 s** |
| \`urllib.urlopen("https://pypi.org/…")\` | ∞ | **200, 0.25 s** |
| \`pip install numpy==2.0.2\` | exit 1, empty output | **21 s, exit 0** |
| VMGENID after restore | n/a | \`crng reseeded due to virtual machine fork\` ✓ |

## What ships

- \`scripts/install-guest-kernel.sh\` — downloads FC CI vmlinux into \`/var/lib/forkd/kernels/vmlinux\`. SHA-256 pinned. **Default path** — recommended for almost everyone.
- \`scripts/build-guest-kernel.sh\` — clones Linux 6.1 LTS, applies FC's reference microvm config (auto-asserts the entropy options), builds vmlinux from source. ~10 min on 20-core box. For users who want to audit / tune / target non-x86_64.
- \`crates/forkd-cli/src/doctor.rs\` — updates the "no vmlinux" hint to point at the install script and the **correct** v1.13 CI bucket URL (the prior hint was v1.10 which 404s now).
- \`CHANGELOG.md\` — Unreleased section documents migration + before/after table.

## Migration

Existing snapshot vmstates from 4.14 restore fine on 6.1 — they just don't get the new entropy device until rebuilt. Run \`forkd from-image <image> --tag <tag>\` to pick up the fix per snapshot.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test -p forkd-cli\` — 21/21 pass
- [x] End-to-end: \`scripts/install-guest-kernel.sh\` downloads + verifies SHA-256, rebuilds demo-pyt via from-image on the new kernel, spawn → \`pip install numpy\` completes in 21 s, \`import numpy\` returns the version

## Closes

- #218 (guest TLS hang — the user-visible bug)
- #225 (guest kernel rebuild tracking — the root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)