### PR TITLE
release: v0.5.1 — guest kernel rebuild + pip-install demo unblocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 
 ## Unreleased
 
+## v0.5.1 — 2026-06-05
+
 ### Guest kernel rebuild — closes #218 + #225
 
 forkd's pre-v0.5.1 vmlinux was Linux **4.14.174** built 2021-07-14.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/deeplethe/forkd"


### PR DESCRIPTION
## Summary

Workspace version 0.5.0 → 0.5.1. CHANGELOG's "Unreleased" guest-kernel section gets the dated v0.5.1 header.

Bug-fix release: pip install (and anything else that touches OpenSSL) actually works inside spawned guests for the first time.

## Test plan

- [x] Workspace version bumped.
- [x] CHANGELOG header dated.
- [x] After merge: tag \`v0.5.1\`, GitHub release with kernel-fix notes as body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)