### PR TITLE
chore(deps): bump axum-server 0.7 → 0.8 — closes #192

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive", "env"] }
 axum = "0.7"
-axum-server = { version = "0.7", features = ["tls-rustls"] }
+axum-server = { version = "0.8", features = ["tls-rustls"] }
 rustls = "0.23"
 parking_lot = "0.12"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/forkd-controller/src/lib.rs
+++ b/crates/forkd-controller/src/lib.rs
@@ -195,7 +195,7 @@ async fn load_tls(cert: &Path, key: &Path) -> Result<RustlsConfig> {
         .with_context(|| format!("load TLS cert {} / key {}", cert.display(), key.display()))
 }
 
-fn spawn_shutdown_signal(handle: Handle) {
+fn spawn_shutdown_signal(handle: Handle<SocketAddr>) {
     tokio::spawn(async move {
         let ctrl_c = async {
             let _ = tokio::signal::ctrl_c().await;


### PR DESCRIPTION
## Summary

Bumps `axum-server` from 0.7 → 0.8 to drop the unmaintained `rustls-pemfile` dependency flagged by **RUSTSEC-2025-0134** (issue #192). The 0.8 release switched to `rustls-pki-types` directly, eliminating the advisory from our tree.

## Breaking change handled

axum-server 0.8 made `Handle` generic over `A: Address`. Since the controller binds TCP, the type parameter is `std::net::SocketAddr` (axum-server's source aliases this internally as `IpSocketAddr`). Only one call site needed the explicit annotation:

```rust
fn spawn_shutdown_signal(handle: Handle<SocketAddr>) { ... }
```

`let handle = Handle::new();` infers the type from the subsequent `bind()` / `bind_rustls()` call.

## Verification (dev box)

- ✅ `cargo check --workspace`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo test -p forkd-controller --lib` → 66/66 pass
- ✅ `cargo audit` → 0 advisories; `rustls-pemfile` removed from `Cargo.lock`

## Test plan

- [ ] CI green (fmt + clippy + test + audit)
- [ ] HTTPS smoke test on dev box: `forkd daemon --tls-cert ... --tls-key ...` accepts a connection and gracefully shuts down on SIGTERM

Closes #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)