### PR TITLE
fix(docker): include experiments/ in builder so workspace manifest parses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,12 @@ FROM rust:1.83-slim-bookworm AS builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock* rust-toolchain.toml ./
 COPY crates ./crates
+# `experiments/*` are not needed by `--bin forkd-controller`, but the
+# workspace Cargo.toml lists them in `members` so Cargo refuses to
+# parse the manifest without their per-crate Cargo.toml present. Copy
+# the whole dir — it's small and avoids drifting a workspace-stripping
+# shim that the rest of the repo wouldn't see.
+COPY experiments ./experiments
 RUN cargo build --release --bin forkd-controller
 
 # ---- runtime ----


### PR DESCRIPTION
## Summary

The Dockerfile only copied `crates ./crates` into the builder stage, but the workspace `Cargo.toml` lists `experiments/v0.4-*` as members. Cargo refuses to parse the workspace manifest without their per-crate manifests present, so `cargo build --release --bin forkd-controller` died with `No such file or directory` on `experiments/v0.4-uffd-wp-poc/Cargo.toml`.

This broke `release.yml`'s `build + push Docker image` job from **v0.5.0 through v0.5.2** — the tarball, PyPI, and npm publishes all succeeded each release, but the ghcr.io controller image was never pushed.

## Fix

Add `COPY experiments ./experiments` to the builder stage. Experiments aren't selected by `--bin forkd-controller` so they don't compile; cargo just needs them present to parse the workspace.

## Verification (dev box)

```
$ docker build -t forkd-controller:test .
[builds clean]
$ docker images forkd-controller:test
forkd-controller   test   4b97d5a97b24   152MB
$ docker run --rm --entrypoint /usr/local/bin/forkd-controller forkd-controller:test --version
forkd-controller 0.5.2
```

## Test plan

- [ ] CI green
- [ ] After merge: next v* tag push will exercise this in release.yml → ghcr.io/deeplethe/forkd-controller:vX.Y.Z gets pushed for the first time since v0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)