### PR TITLE
fix(ci): pypi-publish skip-existing=true so re-pushed tags don't go red

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -59,3 +59,8 @@ jobs:
         with:
           packages-dir: sdk/python/dist
           print-hash: true
+          # Idempotent under force-pushed / re-run tags: a 400 "File
+          # already exists" on PyPI is a no-op, not a release failure.
+          # PyPI immutability means we never overwrite an existing
+          # version — re-pushing a tag just becomes a green skip.
+          skip-existing: true


### PR DESCRIPTION
## Why

publish-pypi.yml currently fails with HTTP 400 \`File already exists\` whenever a v* tag gets force-pushed (which I did earlier today to fix release.yml's Docker job for v0.5.2 — see #235). The publish step has logically nothing to do (PyPI versions are immutable, so a re-push is a no-op), but the action defaults to \`skip-existing: false\`, so the no-op shows up as a red X on the publish-pypi workflow.

## What

Set \`skip-existing: true\` on the \`pypa/gh-action-pypi-publish\` step. PyPI's immutability guarantee means we never overwrite an existing version anyway; this just turns "no-op publish" from a failure into a green skip.

## Test plan

- [ ] CI green
- [ ] After merge: rerun the failed [publish-pypi run for v0.5.2 (id 27256637354)](https://github.com/deeplethe/forkd/actions/runs/27256637354) using the updated workflow definition → expected outcome: green-with-skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)