### PR TITLE
docs(readme): add guest/host kernel support matrix — closes #244

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,15 @@ Measured CoW overhead at N=100 is **0.12 MiB / child** on top of the parent ([be
 - **Untrusted CI** — `git clone + pip install + pytest` inside a real Linux VM, not a container namespace
 - **Fork-per-test isolated databases** — recipe: [`postgres-fixture/`](./recipes/postgres-fixture/) — ready-to-query postgres at ~10 ms per child instead of ~2 s of fresh `initdb`
 
+**Which kernels does forkd run on?** Two kernels are in play, and only one is yours to worry about:
+
+| Kernel | Who picks it | Version | Notes |
+|---|---|---|---|
+| **Guest** (boots inside each microVM) | forkd ships it | `vmlinux-6.1.141` (fixed) | Firecracker's CI-blessed image; every snapshot is taken *and* restored against this same guest kernel, so the guest side is identical on every host. `scripts/install-guest-kernel.sh` installs it; `forkd doctor` verifies it. |
+| **Host** (runs Firecracker + KVM) | your machine | **≥ 5.7 for live BRANCH**, any KVM-capable kernel otherwise | Live (`--live`) BRANCH needs `UFFDIO_WRITEPROTECT` on memfd (Linux 5.7+, `forkd doctor` probes it). Basic fork / Diff BRANCH work on older KVM kernels. Tested on 6.14 (CI + dev box); the K8s example targets 6.14. |
+
+The host kernel is where Firecracker's own version sensitivity lives (KVM ABI, snapshot compatibility) — see [Firecracker's kernel support policy](https://github.com/firecracker-microvm/firecracker/blob/main/docs/kernel-policy.md) for the authoritative host-kernel matrix rather than a copy that can drift. Snapshots are **not** portable across *Firecracker* versions or host CPU microarchitectures (a separate concern from kernel version); `forkd doctor` reports both your FC version and guest kernel so a fleet can assert they match.
+
 <br/>
 
 ## Quick start


### PR DESCRIPTION
Closes #244 (thanks @hty993).

## What

Adds a kernel support matrix to the Enterprise deployment FAQ. The framing the issue was missing: **two kernels are in play, and only the host is the user's variable.**

| Kernel | Who picks it | Version |
|---|---|---|
| Guest (inside each microVM) | forkd ships+pins it | `vmlinux-6.1.141`, constant |
| Host (runs FC + KVM) | your machine | ≥5.7 for live BRANCH, any KVM kernel otherwise |

Because every snapshot is taken *and* restored against the same shipped guest kernel, the guest side is never the reason a snapshot won't restore on another host. The host kernel is where FC's actual version sensitivity lives — so the matrix points at [Firecracker's own kernel-support policy](https://github.com/firecracker-microvm/firecracker/blob/main/docs/kernel-policy.md) rather than duplicating (and risking drift on) the authoritative host-kernel ABI table.

## What I deliberately did NOT add

The issue proposed a table with `6.6.x tested`, `6.8.x partial — restore broken on 6.8.0–6.8.4 fixed in 6.8.5`, `6.11.x untested`. None of those claims are sourceable in this repo or attributed to an upstream FC issue, and the issue itself marked them as illustrative. A wrong-but-authoritative-looking kernel matrix is an active footgun for the exact fleet-operator audience the issue cares about — so I documented what's actually true and verifiable instead.

## Test plan
- [ ] CI green (docs only)