### PR TITLE
docs(readme): doctor runs 17 checks, not 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,12 +481,12 @@ pip install forkd                         # Python SDK — calls the daemon over
 npm install @deeplethe/forkd              # TypeScript SDK
 ```
 
-`forkd doctor` runs 16 checks (KVM, hardware virt, cgroup v2, IP forward,
+`forkd doctor` runs 17 checks (KVM, hardware virt, cgroup v2, IP forward,
 tap, netns, Firecracker binary + version, Docker daemon, snapshot dir +
 disk space, kernel image, controller reachability, platform, plus
-`uffd_wp` + `memfd_create` for the v0.4 live-fork path) and emits
-specific fix hints for each non-pass. Run this first whenever something
-feels off.
+`uffd_wp` + `memfd_create` + hugepages for the v0.4 live-fork path) and
+emits specific fix hints for each non-pass. Run this first whenever
+something feels off.
 
 ![forkd doctor — 14 checks pass on a configured host](./docs/assets/doctor-14pass.webp)
 


### PR DESCRIPTION
Trivial drift fix. #230 added `check_hugepages` (16→17 checks) but the README prose still said 16. Also names hugepages in the live-fork check list.