### PR TITLE
chore(hub): re-bake python-numpy as a portable pack (rootfs sidecar)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -57,8 +57,8 @@
       "versions": {
         "latest": {
           "url": "https://github.com/deeplethe/forkd/releases/download/hub-python-numpy-v1/python-numpy.forkd-snapshot.tar.zst",
-          "sha256": "811c2f6d9e0efbfd811c3f9da4e60722db26dc535e217761ebaa8a53acf33163",
-          "size_bytes": 16597810,
+          "sha256": "0084e2eb769e2df08e04319293ad2a04585f0107d8b3101881132793859608c5",
+          "size_bytes": 16279699,
           "memory_mib": 1536,
           "base_image": "python:3.12-slim",
           "recipe_path": "recipes/python-numpy",
@@ -67,8 +67,8 @@
         },
         "v1": {
           "url": "https://github.com/deeplethe/forkd/releases/download/hub-python-numpy-v1/python-numpy.forkd-snapshot.tar.zst",
-          "sha256": "811c2f6d9e0efbfd811c3f9da4e60722db26dc535e217761ebaa8a53acf33163",
-          "size_bytes": 16597810,
+          "sha256": "0084e2eb769e2df08e04319293ad2a04585f0107d8b3101881132793859608c5",
+          "size_bytes": 16279699,
           "memory_mib": 1536,
           "base_image": "python:3.12-slim",
           "recipe_path": "recipes/python-numpy",


### PR DESCRIPTION
#242 follow-up (ops). Makes the first hub asset actually restorable off the packing host.

## What changed

- **Re-baked** `python:3.12-slim + numpy` with a current forkd (snapshot.json now records the rootfs path).
- **Re-packed** → emits the content-addressed rootfs sidecar.
- **Uploaded both** to the `hub-python-numpy-v1` release:
  - `python-numpy.forkd-snapshot.tar.zst` (15.5 MiB, new sha `0084e2eb…`)
  - `f4ae4fc74992a9eb.rootfs.zst` (48.3 MiB, zstd -19)
- **registry.json**: `python-numpy` latest+v1 `sha256`/`size_bytes` updated. No schema change — pull derives the sidecar URL as the pack's sibling.

## Verified end-to-end (clean host)

Privileged container with zero prior forkd state:

```
forkd pull https://github.com/deeplethe/forkd/releases/download/hub-python-numpy-v1/python-numpy.forkd-snapshot.tar.zst
  ✓ downloaded 15.5 MiB (pack)
  ✓ unpacked tag 'python-numpy'
  ==> downloading rootfs sidecar f4ae4fc74992a9eb.rootfs.zst
  ✓ rootfs ready at /var/cache/forkd/python-3-12-slim.ext4   (1.5 GiB placed)
forkd fork --tag python-numpy -n 2 --per-child-netns
  ✓ 2 / 2 children alive in 107 ms
```

Before #242, that pull-then-fork died with FC's `Block: backing file: No such file`.

## Remaining ops work

The other 8 hub assets (langgraph-react, coding-agent-fork, postgres-fixture, playwright-browser, nodejs, jupyter-kernel, e2b-codeinterpreter, coding-agent) still need the same re-bake + re-pack + dual-upload. Heavier ones (playwright browser, postgres) need their recipe-specific warmup state reproduced.

## Test plan
- [x] Clean-host pull → rootfs auto-placed → fork 2/2 (above)
- [ ] After merge: `forkd pull deeplethe/python-numpy` (registry path) on a clean host

🤖 Generated with [Claude Code](https://claude.com/claude-code)