### PR TITLE
fix(build-rootfs): skip docker pull when the image is already local

### DIFF
--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -57,7 +57,12 @@ say "work dir:   $WORK"
 
 # ----------------------------------------------------------------------------
 say "[1/5] pulling + creating container..."
-docker pull -q "$IMAGE"
+# Skip the registry pull when the image already exists locally — e.g. a
+# recipe-built wrapped image (coding-agent tags one as
+# forkd-coding-agent:tmp-$$). Pulling such a local-only tag forces a
+# needless registry round-trip that 429s behind a throttled mirror and
+# aborts the build.
+docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull -q "$IMAGE"
 docker create --name "$CONTAINER" "$IMAGE" /bin/true >/dev/null
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
\`build-rootfs.sh\` unconditionally \`docker pull\`ed \`\$IMAGE\` before exporting. For recipe-built **local** images that only exist on this host (the \`coding-agent\` recipe builds + tags \`forkd-coding-agent:tmp-\$\$\`), that pull is a needless registry round-trip — and behind a throttled registry mirror it returns **429 Too Many Requests** and aborts the entire rootfs build.

Fix: \`docker image inspect "\$IMAGE" >/dev/null 2>&1 || docker pull -q "\$IMAGE"\` — use a local image as-is, only fetch genuinely-remote ones.

Found while re-baking the coding-agent hub asset (#242 follow-up); the bake failed three times on this exact 429 until patched. Also makes local / air-gapped \`build-rootfs\` runs mirror-independent.

## Test plan
- [x] coding-agent recipe (local wrapped image) bakes cleanly with this fix — produced a working portable pack uploaded to hub-coding-agent-v1
- [x] \`bash -n\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)