### PR TITLE
Add daemon sandbox spawn and harden rootfs cleanup

### DIFF
--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -421,6 +421,40 @@ enum Cmd {
         #[arg(long, env = "FORKD_TOKEN")]
         daemon_token: Option<String>,
     },
+    /// Spawn daemon-managed sandboxes from a registered snapshot.
+    ///
+    /// Use this when you want the controller to track the child so it can
+    /// be listed, killed, exec'd, or BRANCHed later.
+    Spawn {
+        /// Snapshot tag to fork from.
+        #[arg(long)]
+        tag: String,
+        /// Number of sandboxes to spawn.
+        #[arg(long, short, default_value_t = 1)]
+        n: usize,
+        /// Spawn each sandbox inside its own `forkd-child-<i>` netns.
+        #[arg(long)]
+        per_child_netns: bool,
+        /// Optional cgroup v2 memory limit per sandbox, in MiB.
+        #[arg(long)]
+        memory_limit_mib: Option<u64>,
+        /// Prewarm pages immediately after restore so the first BRANCH is hot.
+        #[arg(long)]
+        prewarm: bool,
+        /// Spawn with memfd-backed RAM so later `snapshot --from-sandbox --live`
+        /// can take a live BRANCH from this sandbox.
+        #[arg(long)]
+        live_fork: bool,
+        /// Back `--live-fork` memfds with 2 MiB hugepages when available.
+        #[arg(long, requires = "live_fork")]
+        hugepages: bool,
+        /// Controller daemon base URL.
+        #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
+        daemon_url: String,
+        /// Bearer token (matches the daemon's --token-file).
+        #[arg(long, env = "FORKD_TOKEN")]
+        daemon_token: Option<String>,
+    },
     /// List live sandboxes (GET /v1/sandboxes). Table output.
     Ls {
         /// Controller daemon base URL.
@@ -886,6 +920,27 @@ fn main() -> Result<()> {
             daemon_url,
             daemon_token,
         } => snapshot_compact_cmd(&daemon_url, daemon_token, &from, &to),
+        Cmd::Spawn {
+            tag,
+            n,
+            per_child_netns,
+            memory_limit_mib,
+            prewarm,
+            live_fork,
+            hugepages,
+            daemon_url,
+            daemon_token,
+        } => sandbox::spawn(
+            &daemon_url,
+            daemon_token,
+            &tag,
+            n,
+            per_child_netns,
+            memory_limit_mib,
+            prewarm,
+            live_fork,
+            hugepages,
+        ),
         Cmd::Ls {
             daemon_url,
             daemon_token,

--- a/crates/forkd-cli/src/sandbox.rs
+++ b/crates/forkd-cli/src/sandbox.rs
@@ -1,8 +1,8 @@
-//! `forkd ls` + `forkd kill` — direct sandbox lifecycle without curl.
+//! `forkd spawn`, `forkd ls`, `forkd kill` — direct sandbox lifecycle without curl.
 //!
-//! Wraps the two endpoints (GET /v1/sandboxes, DELETE /v1/sandboxes/:id)
-//! that previously required hand-written curl invocations. Output is
-//! a formatted table for `ls` and a per-id status line for `kill`.
+//! Wraps the sandbox endpoints that previously required hand-written curl
+//! invocations. Output is a compact status line for `spawn` / `kill` and a
+//! formatted table for `ls`.
 
 use anyhow::{Context, Result};
 use std::time::Duration;
@@ -80,6 +80,52 @@ pub fn ls(daemon_url: &str, token: Option<String>) -> Result<()> {
     Ok(())
 }
 
+/// `forkd spawn` — create daemon-managed sandboxes via POST /v1/sandboxes.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn(
+    daemon_url: &str,
+    token: Option<String>,
+    tag: &str,
+    n: usize,
+    per_child_netns: bool,
+    memory_limit_mib: Option<u64>,
+    prewarm: bool,
+    live_fork: bool,
+    hugepages: bool,
+) -> Result<()> {
+    if n == 0 {
+        anyhow::bail!("n must be ≥ 1");
+    }
+    let agent = ureq::AgentBuilder::new()
+        .timeout(Duration::from_secs(120))
+        .build();
+    let url = format!("{}/v1/sandboxes", daemon_url.trim_end_matches('/'));
+    let body = create_sandbox_body(
+        tag,
+        n,
+        per_child_netns,
+        memory_limit_mib,
+        prewarm,
+        live_fork,
+        hugepages,
+    );
+    let mut req = agent.post(&url).set("Content-Type", "application/json");
+    if let Some(t) = token.as_deref() {
+        req = req.set("Authorization", &format!("Bearer {t}"));
+    }
+    let resp = req.send_string(&body.to_string()).map_err(map_err)?;
+    let body = resp.into_string().context("read body")?;
+    let sandboxes: Vec<serde_json::Value> =
+        serde_json::from_str(&body).with_context(|| format!("parse JSON: {body}"))?;
+    for s in &sandboxes {
+        let id = s.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+        let guest = s.get("guest_addr").and_then(|v| v.as_str()).unwrap_or("?");
+        let netns = s.get("netns").and_then(|v| v.as_str()).unwrap_or("—");
+        println!("  ✓ {id}  guest={guest}  netns={netns}");
+    }
+    Ok(())
+}
+
 /// `forkd kill` — terminate one or more sandboxes via DELETE.
 pub fn kill(
     daemon_url: &str,
@@ -133,6 +179,29 @@ pub fn kill(
 // ----------------------------------------------------------------------
 // HTTP helpers
 // ----------------------------------------------------------------------
+
+fn create_sandbox_body(
+    tag: &str,
+    n: usize,
+    per_child_netns: bool,
+    memory_limit_mib: Option<u64>,
+    prewarm: bool,
+    live_fork: bool,
+    hugepages: bool,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "snapshot_tag": tag,
+        "n": n,
+        "per_child_netns": per_child_netns,
+        "prewarm": prewarm,
+        "live_fork": live_fork,
+        "hugepages": hugepages,
+    });
+    if let Some(mib) = memory_limit_mib {
+        body["memory_limit_mib"] = serde_json::json!(mib);
+    }
+    body
+}
 
 fn list_sandboxes(daemon_url: &str, token: Option<&str>) -> Result<Vec<serde_json::Value>> {
     let agent = ureq::AgentBuilder::new()
@@ -192,7 +261,7 @@ fn map_err(e: ureq::Error) -> anyhow::Error {
 
 #[cfg(test)]
 mod tests {
-    use super::{delete_sandbox, is_valid_sandbox_id};
+    use super::{create_sandbox_body, delete_sandbox, is_valid_sandbox_id};
 
     #[test]
     fn accepts_real_daemon_ids() {
@@ -215,5 +284,17 @@ mod tests {
         // nonsense daemon_url never matters here.
         let err = delete_sandbox("http://0.0.0.0:1", None, "../etc").unwrap_err();
         assert!(err.to_string().contains("invalid sandbox id"), "got: {err}");
+    }
+
+    #[test]
+    fn create_sandbox_body_includes_live_fork_flags() {
+        let body = create_sandbox_body("pyagent", 2, true, Some(512), true, true, true);
+        assert_eq!(body["snapshot_tag"], "pyagent");
+        assert_eq!(body["n"], 2);
+        assert_eq!(body["per_child_netns"], true);
+        assert_eq!(body["memory_limit_mib"], 512);
+        assert_eq!(body["prewarm"], true);
+        assert_eq!(body["live_fork"], true);
+        assert_eq!(body["hugepages"], true);
     }
 }

--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -39,10 +39,24 @@ say() { printf "\033[1;34m==>\033[0m %s\n" "$*"; }
 die() { printf "\033[1;31merror:\033[0m %s\n" "$*" >&2; cleanup; exit 1; }
 
 cleanup() {
-    $SUDO umount "$WORK/dev"  2>/dev/null || true
-    $SUDO umount "$WORK/sys"  2>/dev/null || true
-    $SUDO umount "$WORK/proc" 2>/dev/null || true
+    for mnt in dev sys proc; do
+        $SUDO umount -l "$WORK/$mnt" 2>/dev/null || true
+    done
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+
+    case "$WORK" in
+        /tmp/forkd-rootfs-*) ;;
+        *)
+            say "warning: refusing to remove unexpected work dir: $WORK"
+            return
+            ;;
+    esac
+    for mnt in dev sys proc; do
+        if mountpoint -q "$WORK/$mnt" 2>/dev/null; then
+            say "warning: refusing to remove $WORK; $WORK/$mnt is still mounted"
+            return
+        fi
+    done
     $SUDO rm -rf "$WORK" 2>/dev/null || true
 }
 trap cleanup EXIT

--- a/scripts/tests/build-rootfs-cleanup-static.sh
+++ b/scripts/tests/build-rootfs-cleanup-static.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/build-rootfs.sh"
+
+# Issue #264: cleanup must not rm -rf while bind mounts are still below $WORK.
+grep -F 'umount -l "$WORK/$mnt"' "$script" >/dev/null
+grep -F 'mountpoint -q "$WORK/$mnt"' "$script" >/dev/null
+# Also refuse unexpected rm targets before running sudo rm -rf.
+grep -F '/tmp/forkd-rootfs-' "$script" >/dev/null


### PR DESCRIPTION
## Summary
- add `forkd spawn` so the CLI can create daemon-managed sandboxes through `POST /v1/sandboxes`
- pass through `--live-fork`, `--hugepages`, netns, prewarm, and memory limit options for that path
- make rootfs cleanup avoid removing the workdir while pseudo-fs mounts are still live

Fixes #209.
Fixes #264.

## Test plan
- `bash scripts/tests/build-rootfs-cleanup-static.sh`
- Docker: `cargo fmt --check && cargo test -p forkd-cli && cargo clippy -p forkd-cli -- -D warnings`
- Docker: `cargo run -q -p forkd-cli -- spawn --help`