### PR TITLE
fix(security): harden daemon auth boundaries

### DIFF
--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -107,7 +107,7 @@ enum Cmd {
         daemon_url: String,
         /// Bearer token for the controller daemon (matches `--token-file`).
         /// Read from the env var when unset.
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
         /// Path to vmlinux kernel.
         #[arg(long, env = "FORKD_KERNEL", required_unless_present = "from_sandbox")]
@@ -194,7 +194,7 @@ enum Cmd {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
         /// Bearer token for the controller daemon.
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Fork N children from a tagged snapshot.
@@ -378,7 +378,7 @@ enum Cmd {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
         /// Bearer token (matches the daemon's --token-file).
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Show chain info for a snapshot (`GET /v1/snapshots/:tag/info`):
@@ -397,7 +397,7 @@ enum Cmd {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
         /// Bearer token (matches the daemon's --token-file).
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Flatten a chained snapshot into a new base snapshot
@@ -418,7 +418,7 @@ enum Cmd {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
         /// Bearer token (matches the daemon's --token-file).
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// List live sandboxes (GET /v1/sandboxes). Table output.
@@ -427,7 +427,7 @@ enum Cmd {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
         /// Bearer token (matches the daemon's --token-file).
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Kill one or more sandboxes (DELETE /v1/sandboxes/:id).
@@ -450,7 +450,7 @@ enum Cmd {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
         /// Bearer token (matches the daemon's --token-file).
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Show where snapshots are stored.
@@ -520,7 +520,7 @@ enum Cmd {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
         /// Bearer token for the controller daemon (matches `--token-file`).
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Quick latency probe against a live daemon. Runs a representative
@@ -546,7 +546,7 @@ enum Cmd {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
         /// Bearer token for the controller daemon (matches `--token-file`).
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Remove orphaned `/tmp/forkd-{fork,parent}-*` work directories.
@@ -632,7 +632,7 @@ enum WorkspaceAction {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
         /// Controller bearer token.
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Snapshot the workspace's live sandbox and kill it. State is
@@ -646,7 +646,7 @@ enum WorkspaceAction {
         diff: bool,
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Restore the workspace from its suspended state.
@@ -654,14 +654,14 @@ enum WorkspaceAction {
         name: String,
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// List all workspaces tracked by the daemon.
     List {
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
     /// Delete a workspace. Kills the live sandbox (if any) and
@@ -670,7 +670,7 @@ enum WorkspaceAction {
         name: String,
         #[arg(long, env = "FORKD_URL", default_value = "http://127.0.0.1:8889")]
         daemon_url: String,
-        #[arg(long, env = "FORKD_TOKEN")]
+        #[arg(long, env = "FORKD_TOKEN", hide_env_values = true)]
         daemon_token: Option<String>,
     },
 }
@@ -3354,6 +3354,23 @@ mod tests {
         // splitter pure.
         assert!(shell_split("").unwrap().is_empty());
         assert!(shell_split("   \t\n  ").unwrap().is_empty());
+    }
+
+    #[test]
+    fn clap_help_does_not_print_token_env_value() {
+        use clap::CommandFactory;
+
+        std::env::set_var("FORKD_TOKEN", "pony-secret-token-123");
+        let mut cmd = Cli::command();
+        let mut out = Vec::new();
+        cmd.find_subcommand_mut("ls")
+            .unwrap()
+            .write_long_help(&mut out)
+            .unwrap();
+        std::env::remove_var("FORKD_TOKEN");
+        let help = String::from_utf8(out).unwrap();
+        assert!(help.contains("FORKD_TOKEN"));
+        assert!(!help.contains("pony-secret-token-123"));
     }
 
     #[test]

--- a/crates/forkd-controller/src/lib.rs
+++ b/crates/forkd-controller/src/lib.rs
@@ -75,6 +75,10 @@ impl Default for DaemonConfig {
     }
 }
 
+fn unauthenticated_non_loopback(bind: SocketAddr, token_file: Option<&Path>) -> bool {
+    token_file.is_none() && !bind.ip().is_loopback()
+}
+
 /// Bring up the controller daemon. Blocks until the listener exits.
 /// SIGTERM and SIGINT trigger a graceful shutdown.
 pub async fn run_daemon(cfg: DaemonConfig) -> Result<()> {
@@ -99,11 +103,11 @@ pub async fn run_daemon(cfg: DaemonConfig) -> Result<()> {
             AuthConfig::with_token(tok)
         }
         None => {
-            if !cfg.bind.ip().is_loopback() {
-                tracing::warn!(
-                    bind = %cfg.bind,
-                    "daemon is bound to a non-loopback address with no --token-file; \
-                     this is INSECURE for multi-tenant or networked use"
+            if unauthenticated_non_loopback(cfg.bind, cfg.token_file.as_deref()) {
+                anyhow::bail!(
+                    "refusing unauthenticated non-loopback bind {}; pass --token-file \
+                     or bind to 127.0.0.1/::1 for local-only use",
+                    cfg.bind
                 );
             }
             AuthConfig::open()
@@ -252,7 +256,28 @@ fn validate_token(tok: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_token;
+    use super::{unauthenticated_non_loopback, validate_token};
+    use std::path::Path;
+
+    #[test]
+    fn unauthenticated_non_loopback_is_rejected() {
+        assert!(unauthenticated_non_loopback(
+            "0.0.0.0:8889".parse().unwrap(),
+            None,
+        ));
+        assert!(unauthenticated_non_loopback(
+            "[::]:8889".parse().unwrap(),
+            None
+        ));
+        assert!(!unauthenticated_non_loopback(
+            "127.0.0.1:8889".parse().unwrap(),
+            None,
+        ));
+        assert!(!unauthenticated_non_loopback(
+            "0.0.0.0:8889".parse().unwrap(),
+            Some(Path::new("/etc/forkd/token")),
+        ));
+    }
 
     #[test]
     fn rejects_empty_token() {


### PR DESCRIPTION
## What changed

This tightens two security edges that are easy to miss in day-to-day use:

- the controller now refuses to start unauthenticated on a non-loopback bind (`0.0.0.0`, `::`, etc.) instead of only logging a warning
- the CLI no longer prints the actual `FORKD_TOKEN` value in help output when the token is supplied via env

Both keep the local dev path boring: loopback without a token still works, and authenticated network binds still work.

## Why

These are trust-boundary footguns:

- a network-exposed daemon without auth is too dangerous to allow by default
- help text leaking bearer tokens is the kind of thing that ends up in logs, terminals, screenshots, and CI output

## Checks

- `cargo fmt --check`
- `cargo test -p forkd-cli -p forkd-controller`
- `cargo clippy -p forkd-cli -p forkd-controller -- -D warnings`
- manual: `FORKD_TOKEN=pony-secret-token-123 forkd ls --help` does not print the token value
- manual: `forkd-controller serve --bind 0.0.0.0:8899` without `--token-file` exits with `refusing unauthenticated non-loopback bind`
