### PR TITLE
fix(controller): stop leaking test tempdirs (closes #273)

### DIFF
--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -78,6 +78,14 @@ pub struct AppState {
     /// associated snapshot files are unrecoverable.
     #[cfg(target_os = "linux")]
     pub live_in_flight: Mutex<HashMap<String, LiveBranchHandle>>,
+    /// Test-only owner of the scratch `TempDir` backing `snapshot_root`,
+    /// the registry file and `prewarm_scratch_dir`. Tying the directory's
+    /// lifetime to the state means dropping the last `Arc` reaps it; the
+    /// unit tests used to `std::mem::forget` the `TempDir` instead, which
+    /// orphaned one directory per construction on every `cargo test` run
+    /// (issue #273). Declared last so it drops after `registry`.
+    #[cfg(test)]
+    pub _tempdir: Option<tempfile::TempDir>,
 }
 
 /// Phase 6.4: handle for a background bulk-copy thread driving the
@@ -2784,23 +2792,32 @@ mod tests {
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
-    fn test_state() -> SharedState {
+    /// `AppState` on a private scratch `TempDir` that the state itself owns,
+    /// so the directory is reaped when the last `Arc` goes away. Every path
+    /// the daemon writes to — registry file, `snapshot_root`, prewarm
+    /// scratch — lives inside it, so a test run leaves nothing behind in
+    /// `$TMPDIR` (issue #273).
+    fn test_state_with_cap(cap: usize) -> SharedState {
         let td = tempfile::TempDir::new().unwrap();
         let path = td.path().join("state.json");
         let snapshot_root = td.path().join("snapshots");
-        // Leak the TempDir so it survives the test (Drop deletes the dir).
-        std::mem::forget(td);
+        let prewarm_scratch_dir = td.path().join("prewarm");
         Arc::new(AppState {
             registry: Registry::load_or_init(path).unwrap(),
             live_vms: Mutex::new(HashMap::new()),
             snapshot_root,
             branch_in_flight: Mutex::new(HashSet::new()),
-            branch_sem: Arc::new(Semaphore::new(DEFAULT_BRANCH_CONCURRENCY)),
-            branch_concurrency_cap: DEFAULT_BRANCH_CONCURRENCY,
-            prewarm_scratch_dir: std::env::temp_dir().join("forkd-test-prewarm"),
+            branch_sem: Arc::new(Semaphore::new(cap)),
+            branch_concurrency_cap: cap,
+            prewarm_scratch_dir,
             #[cfg(target_os = "linux")]
             live_in_flight: Mutex::new(HashMap::new()),
+            _tempdir: Some(td),
         })
+    }
+
+    fn test_state() -> SharedState {
+        test_state_with_cap(DEFAULT_BRANCH_CONCURRENCY)
     }
 
     #[test]
@@ -3500,21 +3517,7 @@ mod tests {
     #[test]
     fn branch_slot_global_cap_blocks() {
         // Cap = 2 so the test stays deterministic. Reaches the 503 path.
-        let td = tempfile::TempDir::new().unwrap();
-        let path = td.path().join("state.json");
-        let snapshot_root = td.path().join("snapshots");
-        std::mem::forget(td);
-        let s = Arc::new(AppState {
-            registry: Registry::load_or_init(path).unwrap(),
-            live_vms: Mutex::new(HashMap::new()),
-            snapshot_root,
-            branch_in_flight: Mutex::new(HashSet::new()),
-            branch_sem: Arc::new(Semaphore::new(2)),
-            branch_concurrency_cap: 2,
-            prewarm_scratch_dir: std::env::temp_dir().join("forkd-test-prewarm"),
-            #[cfg(target_os = "linux")]
-            live_in_flight: Mutex::new(HashMap::new()),
-        });
+        let s = test_state_with_cap(2);
         let _a = s.try_acquire_branch_slot("t1").unwrap();
         let _b = s.try_acquire_branch_slot("t2").unwrap();
         let err = s
@@ -3525,21 +3528,7 @@ mod tests {
 
     #[test]
     fn branch_slot_capacity_recovers_on_drop() {
-        let td = tempfile::TempDir::new().unwrap();
-        let path = td.path().join("state.json");
-        let snapshot_root = td.path().join("snapshots");
-        std::mem::forget(td);
-        let s = Arc::new(AppState {
-            registry: Registry::load_or_init(path).unwrap(),
-            live_vms: Mutex::new(HashMap::new()),
-            snapshot_root,
-            branch_in_flight: Mutex::new(HashSet::new()),
-            branch_sem: Arc::new(Semaphore::new(1)),
-            branch_concurrency_cap: 1,
-            prewarm_scratch_dir: std::env::temp_dir().join("forkd-test-prewarm"),
-            #[cfg(target_os = "linux")]
-            live_in_flight: Mutex::new(HashMap::new()),
-        });
+        let s = test_state_with_cap(1);
         let a = s.try_acquire_branch_slot("t1").unwrap();
         assert!(s.try_acquire_branch_slot("t2").is_err());
         drop(a);

--- a/crates/forkd-controller/src/lib.rs
+++ b/crates/forkd-controller/src/lib.rs
@@ -140,6 +140,8 @@ pub async fn run_daemon(cfg: DaemonConfig) -> Result<()> {
         prewarm_scratch_dir: cfg.prewarm_scratch_dir.clone(),
         #[cfg(target_os = "linux")]
         live_in_flight: Mutex::new(HashMap::new()),
+        #[cfg(test)]
+        _tempdir: None,
     });
 
     let auth_layer_cfg = auth_cfg.clone();


### PR DESCRIPTION
Closes #273.

## The leak

`test_state` and the two `branch_slot_*` tests in `crates/forkd-controller/src/http.rs` each built their scratch directory like this:

```rust
let td = tempfile::TempDir::new().unwrap();
// Leak the TempDir so it survives the test (Drop deletes the dir).
std::mem::forget(td);
```

It keeps the directory alive, but `Drop` never runs — so every `cargo test -p forkd-controller` orphans one directory per construction in `$TMPDIR`. The issue reported ~10 per run; on today's test count it is **56**.

## The fix

Bind the `TempDir` to the state rather than leaking it — the "cheapest" option from the issue. `AppState` gains a `#[cfg(test)] pub _tempdir: Option<tempfile::TempDir>` field, declared **last** so it drops after `registry`. Dropping the final `Arc` now reaps the directory.

This mirrors the `_td: TempDir` ownership pattern that `tests/http_integration.rs` already uses, so the unit tests and the integration tests handle scratch dirs the same way.

Two cleanups carried along:

- The duplicated inline `AppState` literals in `branch_slot_global_cap_blocks` and `branch_slot_capacity_recovers_on_drop` collapse into a shared `test_state_with_cap(cap)`; `test_state()` delegates to it. Net −24 lines, and there is now one place to update when `AppState` grows a field.
- `prewarm_scratch_dir` moves off the shared `$TMPDIR/forkd-test-prewarm` into the per-test tempdir, so nothing the daemon writes escapes it.

## Verification

Run on Linux, using the reporter's own measurement (`ls -d /tmp/.tmp* | wc -l` after a `cargo test -p forkd-controller` in a fresh container):

| | tests | leftover `/tmp/.tmp*` |
|---|---|---|
| before | 71 + 7 passed | **56** |
| after | 71 + 7 passed | **0** |

Full CI matrix green locally: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` (no warnings), `cargo build --all`, `cargo test --all`.

## Notes

- No CHANGELOG entry — this is test-only hygiene with no user-facing effect.
- `#[cfg(test)]` only applies to the lib crate's own unit-test build, so the field does not exist for integration tests or downstream consumers; the single production construction site in `lib.rs` gets a matching `#[cfg(test)] _tempdir: None`.
- Swept the rest of the tree for the same class of leak: no remaining `mem::forget`, `ManuallyDrop`, `TempDir::into_path()`, or `.keep()` anywhere in `crates/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
