### PR TITLE
fix(mcp): constrain incompatible SDK versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,24 @@ jobs:
           python -m pip install --quiet pytest
           python -m pip install --quiet -e .
           python -m pytest tests/ -q
+
+  mcp-python:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mcp:
+          - 'mcp==1.2.0'
+          # Deliberately tracks the latest compatible 1.x as an early warning.
+          - 'mcp>=1.2,<2'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: stdio handshake
+        run: >-
+          uv run --isolated --no-project
+          --with-editable ./sdk/mcp
+          --with anyio
+          --with pytest
+          --with '${{ matrix.mcp }}'
+          pytest -q sdk/mcp/tests/test_stdio.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning](https://semver.org/spec/v2.0.0.html) once it reaches
 
 ## Unreleased
 
+### MCP compatibility
+
+Constrain `forkd-mcp` to MCP `>=1.2,<2`: its FastMCP import is unavailable
+in older 1.x releases and was removed in MCP 2.x. CI now verifies the stdio
+initialize handshake and all registered tools against MCP 1.2.0 and the
+latest compatible 1.x release. Closes #275.
+
 ## v0.5.3 - 2026-07-22
 
 ### KSM / memfd release catch-up

--- a/sdk/mcp/pyproject.toml
+++ b/sdk/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "forkd-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Model Context Protocol server for forkd microVM sandboxes (BRANCH, diff snapshots, prewarm)"
 readme = "README.md"
 authors = [{name = "Deeplethe", email = "info@deeplethe.com"}]
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "mcp>=1.0",
+    "mcp>=1.2,<2",
     "httpx>=0.27",
 ]
 

--- a/sdk/mcp/tests/test_stdio.py
+++ b/sdk/mcp/tests/test_stdio.py
@@ -1,0 +1,38 @@
+import sys
+
+import anyio
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+EXPECTED_TOOLS = {
+    "branch_sandbox",
+    "create_snapshot",
+    "eval_code",
+    "exec_command",
+    "get_sandbox",
+    "kill_sandbox",
+    "list_sandboxes",
+    "list_snapshots",
+    "ping_sandbox",
+    "spawn_sandboxes",
+    "wait_for_text",
+}
+
+
+def test_stdio_initialize_and_tool_registration() -> None:
+    async def scenario() -> None:
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "forkd_mcp.server"],
+        )
+        with anyio.fail_after(10):
+            async with stdio_client(params) as (read_stream, write_stream):
+                async with ClientSession(read_stream, write_stream) as session:
+                    result = await session.initialize()
+                    tools = await session.list_tools()
+
+        assert result.serverInfo.name == "forkd"
+        assert len(tools.tools) == len(EXPECTED_TOOLS)
+        assert {tool.name for tool in tools.tools} == EXPECTED_TOOLS
+
+    anyio.run(scenario)


### PR DESCRIPTION
Closes #275.

## Summary

- release the fix as `forkd-mcp 0.2.1`
- constrain the MCP SDK to `mcp>=1.2,<2`
- add a stdio regression test covering initialize and all 11 tools
- run CI against MCP 1.2.0 and the latest compatible 1.x release
- document the user-visible compatibility fix in `CHANGELOG.md`

The latest-compatible CI leg is intentionally unpinned as an early-warning signal. `anyio` is installed explicitly for the test instead of relying on MCP's transitive dependencies.

## Validation

- MCP 1.2.0: `1 passed`
- latest `mcp>=1.2,<2`: `1 passed`
- `ruff check --output-format=json sdk/mcp`: `[]`
- built wheel metadata:
  - `Version: 0.2.1`
  - `Requires-Dist: mcp<2,>=1.2`
- Gitleaks: one commit scanned, no leaks
- no documentation changes that assume 0.2.1 is already published
- no `docs/superpowers/**` paths