### PR TITLE
chore(ci): move actions to the Node 24 runtime

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -23,8 +23,8 @@ jobs:
       run:
         working-directory: sdk/typescript
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -28,8 +28,8 @@ jobs:
     # or daemon needed — the analyzer runs on synthetic event lists.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - name: analyze.py unit tests
@@ -48,8 +48,8 @@ jobs:
     # and the _send wire protocol against an in-process socket server.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - name: install + pytest
@@ -69,8 +69,8 @@ jobs:
           # Deliberately tracks the latest compatible 1.x as an early warning.
           - 'mcp>=1.2,<2'
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v9
       - name: stdio handshake
         run: >-
           uv run --isolated --no-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
           - 'mcp>=1.2,<2'
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9
+      # setup-uv stopped publishing floating major tags after v7, so this
+      # one is pinned to an exact release while the rest track majors.
+      - uses: astral-sh/setup-uv@v9.0.0
       - name: stdio handshake
         run: >-
           uv run --isolated --no-project

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,8 +18,8 @@ jobs:
       run:
         working-directory: sdk/typescript
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-pypi-mcp.yml
+++ b/.github/workflows/publish-pypi-mcp.yml
@@ -33,9 +33,9 @@ jobs:
       id-token: write   # OIDC for Trusted Publishers
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -29,9 +29,9 @@ jobs:
       id-token: write   # OIDC for Trusted Publishers
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     name: build binaries (x86_64-linux)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -61,7 +61,7 @@ jobs:
           sha256sum forkd-*.tar.gz > SHA256SUMS
 
       - name: Create / update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           # Prefer the PAT so the `release: published` event fires
           # downstream workflows (publish-pypi.yml). Fall back to
@@ -80,19 +80,19 @@ jobs:
     name: build + push Docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build + push controller image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -123,7 +123,7 @@ jobs:
     # Python SDK publish for `v*` tags on the main package.
     if: startsWith(github.ref_name, 'v')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Dispatch publish-pypi.yml
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Every workflow run currently carries this annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-python@v5`

Nothing is broken today — GitHub is coercing the runtime — but the coercion is temporary and the warning is on every run. This declares the runtime instead.

## What moved

| action | from | to |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `actions/setup-python` | v5 | **v7** |
| `astral-sh/setup-uv` | v6 | **v9.0.0** |
| `softprops/action-gh-release` | v2 | **v3** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/login-action` | v3 | **v4** |
| `docker/build-push-action` | v6 | **v7** |

Target versions came from each action's latest GitHub release rather than from memory.

Three are deliberately untouched:

- `dtolnay/rust-toolchain@stable` and `pypa/gh-action-pypi-publish@release/v1` are branch refs, not version tags — there is no major to bump.
- `Swatinem/rust-cache@v2` is already current; its latest release is v2.9.1.

`setup-uv` is the one pinned to an exact release rather than a major. It published floating major tags through v7 and stopped from v8 onward, so `@v9` does not exist — the first push of this PR used it and CI failed to resolve the action. There is a comment in `ci.yml` noting why that line differs from the rest.

Every ref in this PR has since been checked against the GitHub refs API, including the four that a pull request **cannot** exercise: `action-gh-release@v3`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/build-push-action@v7`. All resolve. That rules out the one failure mode that actually occurred here, in the workflows where it would otherwise have surfaced during a release.

## Breaking changes across the majors being crossed

Most of these majors are only the node20 → node24 runtime move, which is the point of the PR. I read the release notes for each major being skipped to find anything else. Three had real behaviour changes, and none of them bite here:

1. **`setup-node` v7 removes the dummy `NODE_AUTH_TOKEN` export.** This is the one that could have silently broken npm publishing. `publish-npm.yml` sets `NODE_AUTH_TOKEN` itself on the publish step (line 45), so the `.npmrc` reference written by `registry-url` still resolves. Had it relied on the action's export, releases would have started failing at `npm publish` with no CI signal beforehand.
2. **`setup-node` v5 added automatic package-manager cache detection; v6 narrowed it to npm.** Both call sites pass `cache: 'npm'` explicitly, so the changed default never applies.
3. **`setup-uv` v8 removed the old custom version-manifest format.** Not used here.

## One behaviour change that does ship

`setup-uv` v9 enables caching by default — that is why upstream marked it breaking, and the stated concern is Actions cache usage and therefore cost. It affects the two `mcp-python` matrix legs. I kept the new default rather than pinning the old behaviour, since these jobs are short and the cache should help more than it costs, but `enable-cache: false` restores the previous behaviour if you would rather not take it.

## Verification

- **The deprecation warning is gone.** The `rust` check on this branch reports zero annotations; the equivalent run on `main` still carries the Node.js 20 warning. That is the whole point of the PR, confirmed rather than assumed.
- All 8 checks pass, including the Node 18 / 20 / 22 matrix — `setup-node@v7` still installs the older Node versions the TypeScript SDK is tested against.
- `actionlint` reports no findings across all six workflows. Worth noting it did **not** catch the `setup-uv@v9` problem — it validates schema and expressions, not whether a ref exists upstream. CI caught that one.

**Residual risk.** `release.yml`, `publish-npm.yml`, `publish-pypi.yml` and `publish-pypi-mcp.yml` fire on tags or release events, so a pull request cannot run them. Ref resolution for those is now verified against the API, and the compatibility notes above cover the behaviour changes, but the first real proof is the next release. If you would rather not carry even that, splitting the four release workflows into a follow-up and landing only the CI ones here is a reasonable trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
