### PR TITLE
fix(controller): bound netns allocator to provisioned namespaces

### DIFF
--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -1338,33 +1338,37 @@ async fn create_sandbox(
 }
 
 async fn delete_sandbox(State(s): State<SharedState>, Path(id): Path<String>) -> Response {
-    // Drop kills the firecracker process and removes the cgroup leaf.
+    // Remove the VM from live_vms, kill firecracker (Vm::drop), then
+    // release the netns index. Killing before releasing closes the
+    // window where a new spawn could enter forkd-child-N while the
+    // previous owner is still dying (review #282).
     let vm = s.live_vms.lock().remove(&id);
-    // The VM is gone from live_vms: release its netns index so the pool
-    // can hand it out again (review #282 round 2 — committed ranges stay
-    // active until explicit release).
-    if let Some(v) = vm.as_ref() {
-        release_vm_netns(&s, v);
-    }
+    let netns = vm.as_ref().and_then(|v| v.netns.clone());
+    drop(vm); // kills firecracker + cleans cgroup
+    release_netns_index(&s, netns.as_deref());
     let registered = match s.registry.remove_sandbox(&id) {
         Ok(v) => v,
         Err(e) => return server_error(&format!("registry remove: {e}")),
     };
-    drop(vm);
     if registered.is_none() {
         return not_found(&format!("sandbox {id}"));
     }
     StatusCode::NO_CONTENT.into_response()
 }
 
-/// Release the netns index owned by a VM that is leaving `live_vms`.
-/// The VM's `netns` string is `forkd-child-N`; parse N and return it to
-/// the allocator's active pool. No-op when the VM has no netns.
-fn release_vm_netns(s: &SharedState, vm: &forkd_vmm::Vm) {
-    if let Some(ns) = vm.netns.as_deref() {
+/// Release a netns index from a `forkd-child-N` string. Called after
+/// the firecracker process has been killed (Vm::drop) so the index only
+/// becomes reusable once the namespace is vacated (review #282).
+fn release_netns_index(s: &SharedState, netns: Option<&str>) {
+    if let Some(ns) = netns {
         if let Some(idx) = ns.strip_prefix("forkd-child-") {
             if let Ok(n) = idx.parse::<usize>() {
                 s.netns_alloc.release_index(n);
+            } else {
+                tracing::warn!(
+                    netns = ns,
+                    "failed to parse netns index; index leaks from active set"
+                );
             }
         }
     }
@@ -2400,6 +2404,24 @@ fn service_unavailable(msg: &str) -> Response {
 // Stateful workspaces (#116)
 // -----------------------------------------------------------------------
 
+/// Marker error for netns pool exhaustion in the workspace spawn path.
+/// Callers downcast this to return 503 (service_unavailable) instead of
+/// a generic 500, mirroring the sandbox path's early-return (review
+/// #282 round 2).
+#[derive(Debug)]
+struct NetnsExhausted;
+
+impl std::fmt::Display for NetnsExhausted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            "netns pool exhausted: every provisioned forkd-child-N namespace is in use \
+             (run scripts/netns-setup.sh N with a larger N and restart)",
+        )
+    }
+}
+
+impl std::error::Error for NetnsExhausted {}
+
 /// Spawn one sandbox from a snapshot tag and return the resulting
 /// `forkd_vmm::Vm` + the daemon-side metadata, without inserting into
 /// the live_vms / Registry. Workspace endpoints insert into those
@@ -2441,10 +2463,7 @@ fn spawn_one_for_workspace(
         match s.netns_alloc.reserve(1) {
             Some(r) => Some(r),
             None => {
-                anyhow::bail!(
-                    "netns pool exhausted: every provisioned forkd-child-N namespace is in use \
-                     (run scripts/netns-setup.sh N with a larger N and restart)"
-                )
+                return Err(anyhow::Error::new(NetnsExhausted));
             }
         }
     } else {
@@ -2522,6 +2541,9 @@ async fn create_workspace(
 
     let (vm, sb_info, mut netns_reservation) = match spawn_result {
         Ok(Ok(triple)) => triple,
+        Ok(Err(e)) if e.downcast_ref::<NetnsExhausted>().is_some() => {
+            return service_unavailable(&format!("{e:#}"));
+        }
         Ok(Err(e)) => return server_error(&format!("spawn workspace sandbox: {e:#}")),
         Err(e) => return server_error(&format!("blocking task panicked: {e}")),
     };
@@ -2565,9 +2587,13 @@ async fn delete_workspace(State(s): State<SharedState>, Path(name): Path<String>
     // Kill the live sandbox if any.
     if let Some(sb_id) = &ws.live_sandbox_id {
         if let Some(vm) = s.live_vms.lock().remove(sb_id) {
-            // VM leaves live_vms: release its netns index (review #282).
-            release_vm_netns(&s, &vm);
+            // Kill firecracker first, then release the netns index,
+            // closing the window where a new spawn could enter
+            // forkd-child-N while the previous owner is still dying
+            // (review #282).
+            let netns = vm.netns.clone();
             drop(vm); // Vm::drop kills firecracker + cleans cgroup
+            release_netns_index(&s, netns.as_deref());
         }
         let _ = s.registry.remove_sandbox(sb_id);
     }
@@ -2709,9 +2735,12 @@ async fn suspend_workspace(
 
     // We took the VM out of live_vms for suspend; intentionally
     // discard it now (suspend == kill source after snapshotting).
-    // Release its netns index before dropping (review #282).
-    release_vm_netns(&s, &vm_back);
+    // Kill firecracker first, then release the netns index so the
+    // namespace is vacated before the index becomes reusable
+    // (review #282).
+    let netns = vm_back.netns.clone();
     drop(vm_back);
+    release_netns_index(&s, netns.as_deref());
     let _ = s.registry.remove_sandbox(&sb_id);
 
     let (snap, pause_ms) = match snap_or_err {
@@ -2798,8 +2827,11 @@ async fn resume_workspace(State(s): State<SharedState>, Path(name): Path<String>
         spawn_one_for_workspace(&s_clone, &spawn_tag, per_child_netns, None)
     })
     .await;
-    let (vm, sb_info, _netns_reservation) = match spawn_result {
+    let (vm, sb_info, mut netns_reservation) = match spawn_result {
         Ok(Ok(triple)) => triple,
+        Ok(Err(e)) if e.downcast_ref::<NetnsExhausted>().is_some() => {
+            return service_unavailable(&format!("{e:#}"));
+        }
         Ok(Err(e)) => return server_error(&format!("spawn workspace sandbox: {e:#}")),
         Err(e) => return server_error(&format!("blocking task panicked: {e}")),
     };
@@ -2808,6 +2840,16 @@ async fn resume_workspace(State(s): State<SharedState>, Path(name): Path<String>
         tracing::error!(error=%e, "persist workspace's live sandbox failed");
     }
     s.live_vms.lock().insert(id.clone(), vm);
+    // Registration complete: the netns reservation transfers to live_vms
+    // (security review #282). On spawn failure the reservation is dropped
+    // and released automatically.  This mirrors create_workspace — the
+    // previous binding `_netns_reservation` (underscore = unused) dropped
+    // the reservation uncommitted, releasing the indices while the
+    // resumed VM was still live and re-opening the exact race #282 fixes
+    // (review #282 round 2).
+    if let Some(res) = netns_reservation.as_mut() {
+        res.commit();
+    }
 
     let now = unix_now();
     if let Err(e) = s.registry.update_workspace(&name, |w| {
@@ -3694,6 +3736,108 @@ mod tests {
             resp.status(),
             StatusCode::SERVICE_UNAVAILABLE,
             "netns exhaustion must be 503, not a generic 500"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_workspace_netns_exhaustion_returns_503() {
+        // Workspace create must map netns exhaustion to 503, not 500,
+        // consistent with the sandbox path (review #282 round 2).
+        let state = test_state_with_netns(0);
+        let dir = state.snapshot_root.join("base");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("vmstate"), b"fake-vmstate").unwrap();
+        std::fs::write(dir.join("memory.bin"), b"fake-memory").unwrap();
+
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/workspaces")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"ws-test","snapshot_tag":"base","per_child_netns":true}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "workspace netns exhaustion must be 503, not a generic 500"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_workspace_netns_exhaustion_returns_503() {
+        // Resume must also map netns exhaustion to 503, not 500
+        // (review #282 round 2). We set up a suspended workspace
+        // (no live sandbox) with a state snapshot to resume from.
+        let state = test_state_with_netns(0);
+        let state_dir = state.snapshot_root.join("ws-test-state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(state_dir.join("vmstate"), b"fake-vmstate").unwrap();
+        std::fs::write(state_dir.join("memory.bin"), b"fake-memory").unwrap();
+        let snap = forkd_vmm::Snapshot {
+            vmstate: state_dir.join("vmstate"),
+            memory: state_dir.join("memory.bin"),
+            volumes: Vec::new(),
+            parent_tag: None,
+            parent_content_hash: None,
+            rootfs: None,
+        };
+        std::fs::write(
+            state_dir.join("snapshot.json"),
+            serde_json::to_vec_pretty(&snap).unwrap(),
+        )
+        .unwrap();
+        let snap_info = crate::api::SnapshotInfo {
+            tag: "ws-test-state".into(),
+            dir: state_dir.display().to_string(),
+            created_at_unix: 1,
+            branched_from: None,
+            pause_ms: None,
+            diff_ms: None,
+            diff_physical_bytes: None,
+            diff_logical_bytes: None,
+            warning: None,
+            status: crate::api::SnapshotStatus::Ready,
+            bootable: true,
+        };
+        state.registry.insert_snapshot(snap_info).unwrap();
+        // Insert a Suspended workspace so resume is valid.
+        let ws = WorkspaceInfo {
+            id: "ws-test".into(),
+            name: "ws-test".into(),
+            source_snapshot_tag: "base".into(),
+            current_state_tag: Some("ws-test-state".into()),
+            status: WorkspaceStatus::Suspended,
+            live_sandbox_id: None,
+            created_at_unix: 1,
+            last_active_unix: 1,
+            last_branch_memory_path: Some(state_dir.join("memory.bin")),
+            per_child_netns: true,
+        };
+        state.registry.insert_workspace(ws).unwrap();
+
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/workspaces/ws-test/resume")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "resume workspace netns exhaustion must be 503, not a generic 500"
         );
     }
 

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -1184,7 +1184,7 @@ async fn create_sandbox(
         // releases the reserved indices back to the pool. A concurrent
         // spawn can never grab the same range because the indices stay
         // in the reserved set until the task finishes (review #282 r3).
-        let mut netns_reservation = if spawn_per_child_netns {
+        let netns_reservation = if spawn_per_child_netns {
             match netns_alloc.reserve(spawn_n) {
                 Some(r) => Some(r),
                 None => return Err(anyhow::Error::new(NetnsExhausted)),

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -1416,10 +1416,14 @@ impl VmNetnsGuard {
     /// Take the VM out of the guard without releasing the netns index.
     /// Call this when transferring ownership to live_vms (the index
     /// stays ACTIVE until the VM is later deleted/suspended).
+    ///
+    /// The guard then drops normally — its remaining fields (the
+    /// `Arc<NetnsAllocator>` and bookkeeping strings) are released
+    /// without leaking. `Drop` checks `self.vm.is_some()` so the netns
+    /// index is NOT released when the VM was already taken out here.
     fn into_vm(mut self) -> forkd_vmm::Vm {
-        let vm = self.vm.take().expect("guard already consumed");
-        std::mem::forget(self); // prevent Drop from running
-        vm
+        self.vm.take().expect("guard already consumed")
+        // self drops here; Drop sees vm == None and skips kill+release.
     }
 }
 
@@ -1436,14 +1440,37 @@ impl std::ops::DerefMut for VmNetnsGuard {
     }
 }
 
+#[cfg(test)]
+impl VmNetnsGuard {
+    /// Construct a guard in the post-`into_vm()` state: the VM has
+    /// already been taken out, but the bookkeeping fields (the
+    /// `Arc<NetnsAllocator>` and netns index) remain. This lets tests
+    /// verify that dropping such a guard releases the Arc reference
+    /// without leaking — the regression for the `mem::forget` bug.
+    fn test_consumed(alloc: std::sync::Arc<crate::netns::NetnsAllocator>) -> Self {
+        Self {
+            vm: None,
+            netns_index: Some(1),
+            alloc,
+        }
+    }
+}
+
 impl Drop for VmNetnsGuard {
     fn drop(&mut self) {
-        // Vm::drop kills firecracker + cleans cgroup
-        self.vm.take();
-        // Release the netns index after the VM is killed
-        if let Some(idx) = self.netns_index {
-            self.alloc.release_index(idx);
+        // Only kill the VM and release the netns index when the guard
+        // still owns the VM. If `into_vm()` was called, `self.vm` is
+        // `None` — the VM was transferred to `live_vms` and the index
+        // must stay ACTIVE until that VM is later deleted/suspended.
+        if self.vm.is_some() {
+            // Vm::drop kills firecracker + cleans cgroup
+            self.vm.take();
+            if let Some(idx) = self.netns_index {
+                self.alloc.release_index(idx);
+            }
         }
+        // The Arc<NetnsAllocator> (and other bookkeeping fields) drop
+        // normally, decrementing refcounts. No leak.
     }
 }
 
@@ -4426,5 +4453,36 @@ mod tests {
         a.release_index(1);
         // Index is back in the available pool
         assert!(a.reserve(1).is_some(), "index reusable after release");
+    }
+
+    /// Regression for the `mem::forget` leak in `VmNetnsGuard::into_vm()`.
+    /// The old implementation called `std::mem::forget(self)` after taking
+    /// the VM, permanently leaking the guard's `Arc<NetnsAllocator>` on
+    /// every successful BRANCH reinsertion. The fix lets the guard drop
+    /// normally after `into_vm()` takes the VM out (Drop sees `vm == None`
+    /// and skips kill+release). This test verifies the Arc strong count
+    /// returns to baseline after the consumed guard is dropped — if the
+    /// guard leaked the Arc, the count would stay elevated.
+    #[test]
+    fn vmnetnsguard_into_vm_does_not_leak_arc() {
+        let alloc =
+            crate::netns::NetnsAllocator::new(8, Box::new(crate::netns::RangeProbe { max: 8 }));
+        // Baseline: only the test's own reference.
+        let baseline = std::sync::Arc::strong_count(&alloc);
+
+        // Simulate repeated BRANCH reinsertions: each iteration creates
+        // a consumed guard (the post-`into_vm()` state) and drops it.
+        // If each drop leaked the Arc, the strong count would grow
+        // by N after N iterations. With the fix, it returns to baseline.
+        for _ in 0..50 {
+            let consumed = VmNetnsGuard::test_consumed(std::sync::Arc::clone(&alloc));
+            drop(consumed);
+        }
+        assert_eq!(
+            std::sync::Arc::strong_count(&alloc),
+            baseline,
+            "Arc strong count elevated after 50 consumed-guard drops — \
+             into_vm() is leaking the allocator Arc"
+        );
     }
 }

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -1116,57 +1116,25 @@ async fn create_sandbox(
     }
 
     let tag = req.snapshot_tag.clone();
-    // Reserve the netns offset range ATOMICALLY (security review #282):
-    // the old pick_netns_offset did check-then-act — it locked live_vms
-    // only while scanning, then released the lock before Firecracker
-    // started and before the VM was inserted, so two concurrent spawns
-    // could both receive the same range. The reservation is held until
-    // the VMs are registered in live_vms (commit) or the spawn fails
-    // (drop releases it).
-    let mut netns_reservation = if req.per_child_netns {
-        match s.netns_alloc.reserve(req.n) {
-            Some(r) => Some(r),
-            None => {
-                return service_unavailable(
-                    "netns pool exhausted: every provisioned forkd-child-N namespace is in use \
-                     (run scripts/netns-setup.sh N with a larger N and restart)",
-                );
-            }
-        }
+    // Reserve the netns offset range INSIDE the spawn_blocking task
+    // (review #282 round 3): the old code reserved in the async handler,
+    // so if the request future was cancelled while the blocking restore
+    // ran, the handler dropped the reservation (making indices available
+    // to another request) while the restore task still used them. By
+    // owning the reservation in the blocking task, cancellation drops
+    // it only after the restore completes or fails.
+    let netns_alloc = s.netns_alloc.clone();
+    let prewarm_scratch_dir = if req.prewarm {
+        Some(s.prewarm_scratch_dir.clone())
     } else {
         None
     };
-    let netns_offset = netns_reservation.as_ref().map(|r| r.offset()).unwrap_or(0);
-    let opts = forkd_vmm::ForkOpts {
-        n: req.n,
-        per_child_netns: req.per_child_netns,
-        memory_limit_mib: req.memory_limit_mib,
-        netns_offset,
-        prewarm_scratch_dir: if req.prewarm {
-            Some(s.prewarm_scratch_dir.clone())
-        } else {
-            None
-        },
-        // Phase 6 unstable: live_fork=true opts the sandbox into
-        // memfd-backed RAM so the Phase 6 mode=live BRANCH path can
-        // arm UFFD_WP on it. Default stays File for backward compat.
-        memory_backend: if req.live_fork {
-            forkd_vmm::MemoryBackend::MemfdShared {
-                use_hugepages: req.hugepages,
-            }
-        } else {
-            forkd_vmm::MemoryBackend::File
-        },
-        // Daemon-spawned sources are the targets of BRANCH; enabling
-        // dirty-page tracking lets later BRANCHes opt into Diff
-        // snapshots (see docs/design/diff-snapshots.md). The cost is
-        // ~1 bit per page; negligible.
-        enable_diff_snapshots: true,
-    };
-    // Per-snapshot-tag work_dir would clash if two batches of the same tag
-    // ran concurrently (e.g. two branches of the same source). Mix the
-    // netns offset in so concurrent batches get distinct work_dirs.
-    let work_dir = std::env::temp_dir().join(format!("forkd-daemon-{tag}-o{netns_offset}"));
+    let spawn_n = req.n;
+    let spawn_per_child_netns = req.per_child_netns;
+    let spawn_mem_limit = req.memory_limit_mib;
+    let spawn_live_fork = req.live_fork;
+    let spawn_hugepages = req.hugepages;
+    let tag_for_work_dir = tag.clone();
 
     // v0.5 chain resolution. Resolve the chain BEFORE spawn_blocking
     // because it only reads snapshot.json files (cheap). The expensive
@@ -1207,7 +1175,51 @@ async fn create_sandbox(
     let prewarm_requested = req.prewarm;
     let mut snapshot = snapshot;
     let head_tag_for_log = req.snapshot_tag.clone();
-    let fork_result = match tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+    let (fork_result, mut netns_reservation) = match tokio::task::spawn_blocking(move || -> anyhow::Result<(forkd_vmm::ForkResult, Option<crate::netns::NetnsReservation>)> {
+        // Reserve the netns offset range INSIDE the blocking task so
+        // the reservation survives async-handler cancellation. If
+        // the handler is dropped while this task runs, the task still
+        // holds the reservation; when the task completes, its return
+        // value is dropped, which drops the uncommitted reservation and
+        // releases the reserved indices back to the pool. A concurrent
+        // spawn can never grab the same range because the indices stay
+        // in the reserved set until the task finishes (review #282 r3).
+        let mut netns_reservation = if spawn_per_child_netns {
+            match netns_alloc.reserve(spawn_n) {
+                Some(r) => Some(r),
+                None => return Err(anyhow::Error::new(NetnsExhausted)),
+            }
+        } else {
+            None
+        };
+        let netns_offset = netns_reservation.as_ref().map(|r| r.offset()).unwrap_or(0);
+        let opts = forkd_vmm::ForkOpts {
+            n: spawn_n,
+            per_child_netns: spawn_per_child_netns,
+            memory_limit_mib: spawn_mem_limit,
+            netns_offset,
+            prewarm_scratch_dir,
+            // Phase 6 unstable: live_fork=true opts the sandbox into
+            // memfd-backed RAM so the Phase 6 mode=live BRANCH path can
+            // arm UFFD_WP on it. Default stays File for backward compat.
+            memory_backend: if spawn_live_fork {
+                forkd_vmm::MemoryBackend::MemfdShared {
+                    use_hugepages: spawn_hugepages,
+                }
+            } else {
+                forkd_vmm::MemoryBackend::File
+            },
+            // Daemon-spawned sources are the targets of BRANCH; enabling
+            // dirty-page tracking lets later BRANCHes opt into Diff
+            // snapshots (see docs/design/diff-snapshots.md). The cost is
+            // ~1 bit per page; negligible.
+            enable_diff_snapshots: true,
+        };
+        // Per-snapshot-tag work_dir would clash if two batches of the same tag
+        // ran concurrently (e.g. two branches of the same source). Mix the
+        // netns offset in so concurrent batches get distinct work_dirs.
+        let work_dir =
+            std::env::temp_dir().join(format!("forkd-daemon-{tag_for_work_dir}-o{netns_offset}"));
         // v0.5 chain assembly. If `chain` is set, hash-verify each
         // parent against the recorded parent_content_hash (this is
         // the foot-gun guard committed to in the design doc), then
@@ -1260,7 +1272,7 @@ async fn create_sandbox(
                 std::thread::sleep(std::time::Duration::from_millis(backoffs_ms[attempt - 1]));
             }
             match snapshot.restore_many_with(opts.clone(), &work_dir) {
-                Ok(r) => return Ok(r),
+                Ok(r) => return Ok((r, netns_reservation)),
                 Err(e) => {
                     let msg = format!("{e:#}");
                     let is_busy = msg.contains("Resource busy")
@@ -1283,7 +1295,10 @@ async fn create_sandbox(
     })
     .await
     {
-        Ok(Ok(r)) => r,
+        Ok(Ok((fr, nr))) => (fr, nr),
+        Ok(Err(e)) if e.downcast_ref::<NetnsExhausted>().is_some() => {
+            return service_unavailable(&format!("{e:#}"));
+        }
         Ok(Err(e)) => return server_error(&format!("restore_many: {e:#}")),
         Err(e) => return server_error(&format!("blocking task panicked: {e}")),
     };
@@ -1370,6 +1385,64 @@ fn release_netns_index(s: &SharedState, netns: Option<&str>) {
                     "failed to parse netns index; index leaks from active set"
                 );
             }
+        }
+    }
+}
+
+/// Guard that kills the VM and releases its netns index on drop.
+/// Ensures netns cleanup survives async-handler cancellation: when the
+/// handler future is dropped while a spawn_blocking task is running, the
+/// task's return value (which contains this guard) is dropped, triggering
+/// cleanup — kill firecracker, then release the netns index (review #282 r3).
+struct VmNetnsGuard {
+    vm: Option<forkd_vmm::Vm>,
+    netns_index: Option<usize>,
+    alloc: std::sync::Arc<crate::netns::NetnsAllocator>,
+}
+
+impl VmNetnsGuard {
+    fn new(vm: forkd_vmm::Vm, alloc: std::sync::Arc<crate::netns::NetnsAllocator>) -> Self {
+        let netns_index = vm.netns.as_ref().and_then(|ns| {
+            ns.strip_prefix("forkd-child-")
+                .and_then(|idx| idx.parse().ok())
+        });
+        Self {
+            vm: Some(vm),
+            netns_index,
+            alloc,
+        }
+    }
+
+    /// Take the VM out of the guard without releasing the netns index.
+    /// Call this when transferring ownership to live_vms (the index
+    /// stays ACTIVE until the VM is later deleted/suspended).
+    fn into_vm(mut self) -> forkd_vmm::Vm {
+        let vm = self.vm.take().expect("guard already consumed");
+        std::mem::forget(self); // prevent Drop from running
+        vm
+    }
+}
+
+impl std::ops::Deref for VmNetnsGuard {
+    type Target = forkd_vmm::Vm;
+    fn deref(&self) -> &Self::Target {
+        self.vm.as_ref().expect("guard already consumed")
+    }
+}
+
+impl std::ops::DerefMut for VmNetnsGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.vm.as_mut().expect("guard already consumed")
+    }
+}
+
+impl Drop for VmNetnsGuard {
+    fn drop(&mut self) {
+        // Vm::drop kills firecracker + cleans cgroup
+        self.vm.take();
+        // Release the netns index after the VM is killed
+        if let Some(idx) = self.netns_index {
+            self.alloc.release_index(idx);
         }
     }
 }
@@ -1517,6 +1590,9 @@ async fn branch_sandbox(
 
     // Take the VM out of live_vms briefly; we'll put it back unconditionally
     // (even on failure) unless a concurrent DELETE on the same id happened.
+    // Wrap in VmNetnsGuard so the netns index is released even if the
+    // handler is cancelled or a concurrent DELETE removes the registry
+    // entry during the BRANCH take-out window (review #282 r3).
     let vm = {
         let mut g = s.live_vms.lock();
         g.remove(&id)
@@ -1525,6 +1601,7 @@ async fn branch_sandbox(
         Some(v) => v,
         None => return not_found(&format!("sandbox {id}")),
     };
+    let vm = VmNetnsGuard::new(vm, s.netns_alloc.clone());
 
     let snap_dir_for_task = snap_dir.clone();
     let id_for_log = id.clone();
@@ -1561,7 +1638,7 @@ async fn branch_sandbox(
     type LiveWorkerSlot = Option<()>;
     let task_result = tokio::task::spawn_blocking(
         move || -> (
-            forkd_vmm::Vm,
+            VmNetnsGuard,
             anyhow::Result<forkd_vmm::Snapshot>,
             Option<u64>,
             DiffMetrics,
@@ -1816,22 +1893,22 @@ async fn branch_sandbox(
     )
     .await;
 
-    let (vm_back, snap_or_err, pause_ms, diff_metrics, live_worker) = match task_result {
+    let (vm_guard, snap_or_err, pause_ms, diff_metrics, live_worker) = match task_result {
         Ok(t) => t,
         Err(e) => {
-            // Blocking task panicked; we lost the Vm value. The OS still has the
-            // firecracker process running, but we no longer track it. Stale entry
-            // will be reaped by Registry::reconcile on next pid-alive scan.
+            // Blocking task panicked; the guard's Drop already ran during
+            // the panic unwind, killing firecracker and releasing the netns
+            // index. No further cleanup needed.
             return server_error(&format!("blocking task panicked: {e}"));
         }
     };
 
     // Re-insert the source sandbox into live_vms. If a DELETE happened during
-    // the branching window, the entry is gone from the registry; we drop the
-    // returned `vm` (its Drop kills firecracker + cleans cgroup).
+    // the branching window, the entry is gone from the registry; dropping the
+    // guard kills firecracker and releases the netns index (review #282 r3).
     let mut new_branch_count: Option<u32> = None;
     if s.registry.get_sandbox(&id).is_some() {
-        s.live_vms.lock().insert(id.clone(), vm_back);
+        s.live_vms.lock().insert(id.clone(), vm_guard.into_vm());
         // Phase 1d: record this BRANCH's memory.bin as the chain head
         // for the next diff BRANCH. Both Full and Diff modes clear the
         // dirty bitmap, so EITHER mode's output is the correct base for
@@ -1844,7 +1921,9 @@ async fn branch_sandbox(
             }
         }
     } else {
-        drop(vm_back);
+        // DELETE happened during BRANCH: guard's Drop kills firecracker
+        // and releases the netns index (review #282 r3).
+        drop(vm_guard);
     }
 
     let mut snap = match snap_or_err {
@@ -2662,13 +2741,16 @@ async fn suspend_workspace(
         Some(v) => v,
         None => return not_found(&format!("workspace's live sandbox {sb_id} is gone")),
     };
+    // Wrap in VmNetnsGuard so the netns index is released even if the
+    // handler is cancelled during the suspend task (review #282 r3).
+    let vm = VmNetnsGuard::new(vm, s.netns_alloc.clone());
     let snap_dir_for_task = snap_dir.clone();
     let source_tag = ws.source_snapshot_tag.clone();
     let source_memory_path = s.snapshot_root.join(&source_tag).join("memory.bin");
     let last_chain = ws.last_branch_memory_path.clone();
     let diff_mode = req.diff;
 
-    let task = tokio::task::spawn_blocking(move || -> (forkd_vmm::Vm, anyhow::Result<(forkd_vmm::Snapshot, Option<u64>)>) {
+    let task = tokio::task::spawn_blocking(move || -> (VmNetnsGuard, anyhow::Result<(forkd_vmm::Snapshot, Option<u64>)>) {
         let mut pause_ms: Option<u64> = None;
         let res = (|| -> anyhow::Result<forkd_vmm::Snapshot> {
             std::fs::create_dir_all(&snap_dir_for_task)?;
@@ -2728,19 +2810,24 @@ async fn suspend_workspace(
     })
     .await;
 
-    let (vm_back, snap_or_err) = match task {
+    let (vm_guard, snap_or_err) = match task {
         Ok((vm, r)) => (vm, r),
-        Err(e) => return server_error(&format!("blocking task panicked: {e}")),
+        Err(e) => {
+            // Blocking task panicked; the guard's Drop already ran during
+            // the panic unwind, killing firecracker and releasing the
+            // netns index. No further cleanup needed.
+            return server_error(&format!("blocking task panicked: {e}"));
+        }
     };
 
     // We took the VM out of live_vms for suspend; intentionally
     // discard it now (suspend == kill source after snapshotting).
-    // Kill firecracker first, then release the netns index so the
-    // namespace is vacated before the index becomes reusable
-    // (review #282).
-    let netns = vm_back.netns.clone();
-    drop(vm_back);
-    release_netns_index(&s, netns.as_deref());
+    // The guard's Drop kills firecracker and releases the netns index
+    // so the namespace is vacated before the index becomes reusable
+    // (review #282). This also handles handler cancellation: the guard
+    // is dropped when the task's return value is dropped, ensuring the
+    // index is always released (review #282 r3).
+    drop(vm_guard);
     let _ = s.registry.remove_sandbox(&sb_id);
 
     let (snap, pause_ms) = match snap_or_err {
@@ -4270,5 +4357,74 @@ mod tests {
                 "expected 400 for body: {body}",
             );
         }
+    }
+
+    // ------------------------------------------------------------
+    // Review #282 round 3 — cancellation-safety regression tests
+    // ------------------------------------------------------------
+
+    /// Verify the core invariant the VmNetnsGuard relies on: after
+    /// committing a reservation (VM enters live_vms) and then releasing
+    /// the index (guard drops on cancellation or DELETE-during-BRANCH),
+    /// the index is immediately reusable by a new reservation.
+    #[test]
+    fn committed_index_released_then_reusable() {
+        let a = crate::netns::NetnsAllocator::new(4, Box::new(crate::netns::RangeProbe { max: 4 }));
+        // Simulate create_sandbox: reserve → commit (VM in live_vms)
+        let mut r1 = a.reserve(1).expect("reserve");
+        let idx = r1.offset();
+        r1.commit();
+        // Simulate VmNetnsGuard::drop (cancellation or DELETE during BRANCH):
+        // release_index makes the index available again.
+        a.release_index(idx + 1); // reserve(1) covers index offset+1
+                                  // The released index must be reusable.
+        let r2 = a.reserve(1).expect("released index should be reusable");
+        assert_eq!(r2.offset(), idx, "released index should be picked first");
+    }
+
+    /// Verify that an uncommitted reservation held inside a blocking
+    /// task keeps indices reserved until the task completes, even if
+    /// the "handler" drops its reference. This tests the create_sandbox
+    /// fix: reserve() moved inside spawn_blocking so cancellation of the
+    /// async handler doesn't release indices while the restore runs.
+    #[test]
+    fn uncommitted_reservation_in_blocking_task_blocks_concurrent_reserve() {
+        let a = crate::netns::NetnsAllocator::new(2, Box::new(crate::netns::RangeProbe { max: 2 }));
+        // Simulate: spawn_blocking task holds an uncommitted reservation
+        let r1 = a.reserve(2).expect("reserve 2 in blocking task");
+        // Concurrent request tries to reserve — must fail because the
+        // blocking task still holds the range (even though it's only
+        // reserved, not committed).
+        assert!(
+            a.reserve(1).is_none(),
+            "concurrent reserve must not grab indices held by an in-flight blocking task"
+        );
+        // When the blocking task completes and drops its reservation
+        // (failure path), the indices become available again.
+        drop(r1);
+        assert!(
+            a.reserve(2).is_some(),
+            "indices freed after blocking task drops reservation"
+        );
+    }
+
+    /// Verify the full BRANCH/suspend lifecycle: reserve → commit →
+    /// release (guard drop). The index cycles through all three
+    /// allocator states (reserved → active → free) and returns to
+    /// the available pool.
+    #[test]
+    fn netns_index_lifecycle_reserved_active_free() {
+        let a = crate::netns::NetnsAllocator::new(1, Box::new(crate::netns::RangeProbe { max: 1 }));
+        // Phase 1: reserve (blocking task starts)
+        let mut r = a.reserve(1).expect("pool of 1 should satisfy");
+        assert!(a.reserve(1).is_none(), "pool exhausted while reserved");
+        // Phase 2: commit (VM inserted into live_vms)
+        r.commit();
+        assert!(a.reserve(1).is_none(), "pool exhausted while active");
+        // Phase 3: release (VmNetnsGuard drops — BRANCH cancellation
+        // or DELETE during take-out window)
+        a.release_index(1);
+        // Index is back in the available pool
+        assert!(a.reserve(1).is_some(), "index reusable after release");
     }
 }

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -65,6 +65,10 @@ pub struct AppState {
     /// Tracked separately for `/metrics` (`forkd_branch_concurrency_cap`)
     /// because `Semaphore` doesn't expose its initial permit count.
     pub branch_concurrency_cap: usize,
+    /// Atomic netns offset allocator (forkd-child-N). Shared by the
+    /// sandbox and workspace spawn paths so concurrent spawns never
+    /// pick overlapping offsets (security review #282).
+    pub netns_alloc: std::sync::Arc<crate::netns::NetnsAllocator>,
     /// Scratch directory used for prewarm throwaway snapshots when
     /// `CreateSandboxRequest::prewarm` is set. Mirror of
     /// `DaemonConfig::prewarm_scratch_dir`.
@@ -1112,13 +1116,27 @@ async fn create_sandbox(
     }
 
     let tag = req.snapshot_tag.clone();
-    // Compute netns offset so we don't collide with other live sandboxes'
-    // forkd-child-N indices. When per_child_netns is false this is a no-op.
-    let netns_offset = if req.per_child_netns {
-        pick_netns_offset(&s.live_vms.lock(), req.n)
+    // Reserve the netns offset range ATOMICALLY (security review #282):
+    // the old pick_netns_offset did check-then-act — it locked live_vms
+    // only while scanning, then released the lock before Firecracker
+    // started and before the VM was inserted, so two concurrent spawns
+    // could both receive the same range. The reservation is held until
+    // the VMs are registered in live_vms (commit) or the spawn fails
+    // (drop releases it).
+    let mut netns_reservation = if req.per_child_netns {
+        match s.netns_alloc.reserve(req.n) {
+            Some(r) => Some(r),
+            None => {
+                return service_unavailable(
+                    "netns pool exhausted: every provisioned forkd-child-N namespace is in use \
+                     (run scripts/netns-setup.sh N with a larger N and restart)",
+                );
+            }
+        }
     } else {
-        0
+        None
     };
+    let netns_offset = netns_reservation.as_ref().map(|r| r.offset()).unwrap_or(0);
     let opts = forkd_vmm::ForkOpts {
         n: req.n,
         per_child_netns: req.per_child_netns,
@@ -1307,6 +1325,13 @@ async fn create_sandbox(
             live.insert(id, vm);
             infos.push(info);
         }
+        // Registration complete: the netns reservation transfers to
+        // live_vms (the VM entries now own the indices). If the loop
+        // above is never reached (spawn failure), the reservation drops
+        // and releases automatically.
+        if let Some(res) = netns_reservation.as_mut() {
+            res.commit();
+        }
     }
 
     (StatusCode::CREATED, Json(infos)).into_response()
@@ -1315,6 +1340,12 @@ async fn create_sandbox(
 async fn delete_sandbox(State(s): State<SharedState>, Path(id): Path<String>) -> Response {
     // Drop kills the firecracker process and removes the cgroup leaf.
     let vm = s.live_vms.lock().remove(&id);
+    // The VM is gone from live_vms: release its netns index so the pool
+    // can hand it out again (review #282 round 2 — committed ranges stay
+    // active until explicit release).
+    if let Some(v) = vm.as_ref() {
+        release_vm_netns(&s, v);
+    }
     let registered = match s.registry.remove_sandbox(&id) {
         Ok(v) => v,
         Err(e) => return server_error(&format!("registry remove: {e}")),
@@ -1324,6 +1355,19 @@ async fn delete_sandbox(State(s): State<SharedState>, Path(id): Path<String>) ->
         return not_found(&format!("sandbox {id}"));
     }
     StatusCode::NO_CONTENT.into_response()
+}
+
+/// Release the netns index owned by a VM that is leaving `live_vms`.
+/// The VM's `netns` string is `forkd-child-N`; parse N and return it to
+/// the allocator's active pool. No-op when the VM has no netns.
+fn release_vm_netns(s: &SharedState, vm: &forkd_vmm::Vm) {
+    if let Some(ns) = vm.netns.as_deref() {
+        if let Some(idx) = ns.strip_prefix("forkd-child-") {
+            if let Ok(n) = idx.parse::<usize>() {
+                s.netns_alloc.release_index(n);
+            }
+        }
+    }
 }
 
 /// `POST /v1/sandboxes/:id/branch` — pause a running sandbox, snapshot its
@@ -1931,38 +1975,6 @@ async fn branch_sandbox(
     (StatusCode::CREATED, Json(info)).into_response()
 }
 
-/// Pick the smallest `netns_offset` such that
-/// `[offset+1 .. offset+n+1]` is disjoint from every `forkd-child-K`
-/// already registered in `live_vms`. Used to keep `POST /v1/sandboxes`
-/// batches from clashing on netns indices (the original allocator
-/// always started at 1, so a fork after a previous fork landed on
-/// `forkd-child-1` again).
-///
-/// Off-by-one note: indices are 1-based on the wire (`forkd-child-1`,
-/// not `forkd-child-0`); `netns_offset` is the *additive* offset
-/// applied before the within-batch 1..=n loop in `restore_many_with`.
-fn pick_netns_offset(live_vms: &HashMap<String, forkd_vmm::Vm>, n: usize) -> usize {
-    let used: std::collections::HashSet<usize> = live_vms
-        .values()
-        .filter_map(|vm| vm.netns.as_ref())
-        .filter_map(|s| s.strip_prefix("forkd-child-")?.parse::<usize>().ok())
-        .collect();
-    if used.is_empty() {
-        return 0;
-    }
-    // Try offsets 0, 1, 2, … until [offset+1..offset+n+1] is disjoint.
-    let mut offset = 0usize;
-    loop {
-        let range_start = offset + 1;
-        let range_end = offset + n + 1;
-        let clash = (range_start..range_end).any(|i| used.contains(&i));
-        if !clash {
-            return offset;
-        }
-        offset += 1;
-    }
-}
-
 /// Read the volumes list from a tagged snapshot's `snapshot.json` on disk.
 /// Returns an empty Vec if `snapshot.json` is missing (some legacy snapshots
 /// don't have it) — that matches the pre-volumes behaviour.
@@ -2399,7 +2411,11 @@ fn spawn_one_for_workspace(
     snapshot_tag: &str,
     per_child_netns: bool,
     memory_limit_mib: Option<u64>,
-) -> anyhow::Result<(forkd_vmm::Vm, SandboxInfo)> {
+) -> anyhow::Result<(
+    forkd_vmm::Vm,
+    SandboxInfo,
+    Option<crate::netns::NetnsReservation>,
+)> {
     let snap_dir: PathBuf = match s.registry.get_snapshot(snapshot_tag) {
         Some(s) => PathBuf::from(&s.dir),
         None => s.snapshot_root.join(snapshot_tag),
@@ -2421,11 +2437,20 @@ fn spawn_one_for_workspace(
             rootfs: None,
         },
     };
-    let netns_offset = if per_child_netns {
-        pick_netns_offset(&s.live_vms.lock(), 1)
+    let netns_reservation = if per_child_netns {
+        match s.netns_alloc.reserve(1) {
+            Some(r) => Some(r),
+            None => {
+                anyhow::bail!(
+                    "netns pool exhausted: every provisioned forkd-child-N namespace is in use \
+                     (run scripts/netns-setup.sh N with a larger N and restart)"
+                )
+            }
+        }
     } else {
-        0
+        None
     };
+    let netns_offset = netns_reservation.as_ref().map(|r| r.offset()).unwrap_or(0);
     let opts = forkd_vmm::ForkOpts {
         n: 1,
         per_child_netns,
@@ -2455,7 +2480,7 @@ fn spawn_one_for_workspace(
         last_branch_memory_path: None,
         branch_count: 0,
     };
-    Ok((vm, info))
+    Ok((vm, info, netns_reservation))
 }
 
 async fn list_workspaces(State(s): State<SharedState>) -> Response {
@@ -2495,8 +2520,8 @@ async fn create_workspace(
     })
     .await;
 
-    let (vm, sb_info) = match spawn_result {
-        Ok(Ok(pair)) => pair,
+    let (vm, sb_info, mut netns_reservation) = match spawn_result {
+        Ok(Ok(triple)) => triple,
         Ok(Err(e)) => return server_error(&format!("spawn workspace sandbox: {e:#}")),
         Err(e) => return server_error(&format!("blocking task panicked: {e}")),
     };
@@ -2506,6 +2531,12 @@ async fn create_workspace(
         tracing::error!(error=%e, "persist workspace's live sandbox failed");
     }
     s.live_vms.lock().insert(id.clone(), vm);
+    // Registration complete: the netns reservation transfers to live_vms
+    // (security review #282). On spawn failure the reservation is dropped
+    // and released automatically.
+    if let Some(res) = netns_reservation.as_mut() {
+        res.commit();
+    }
 
     let now = unix_now();
     let ws = WorkspaceInfo {
@@ -2534,6 +2565,8 @@ async fn delete_workspace(State(s): State<SharedState>, Path(name): Path<String>
     // Kill the live sandbox if any.
     if let Some(sb_id) = &ws.live_sandbox_id {
         if let Some(vm) = s.live_vms.lock().remove(sb_id) {
+            // VM leaves live_vms: release its netns index (review #282).
+            release_vm_netns(&s, &vm);
             drop(vm); // Vm::drop kills firecracker + cleans cgroup
         }
         let _ = s.registry.remove_sandbox(sb_id);
@@ -2676,6 +2709,8 @@ async fn suspend_workspace(
 
     // We took the VM out of live_vms for suspend; intentionally
     // discard it now (suspend == kill source after snapshotting).
+    // Release its netns index before dropping (review #282).
+    release_vm_netns(&s, &vm_back);
     drop(vm_back);
     let _ = s.registry.remove_sandbox(&sb_id);
 
@@ -2763,8 +2798,8 @@ async fn resume_workspace(State(s): State<SharedState>, Path(name): Path<String>
         spawn_one_for_workspace(&s_clone, &spawn_tag, per_child_netns, None)
     })
     .await;
-    let (vm, sb_info) = match spawn_result {
-        Ok(Ok(pair)) => pair,
+    let (vm, sb_info, _netns_reservation) = match spawn_result {
+        Ok(Ok(triple)) => triple,
         Ok(Err(e)) => return server_error(&format!("spawn workspace sandbox: {e:#}")),
         Err(e) => return server_error(&format!("blocking task panicked: {e}")),
     };
@@ -2815,6 +2850,10 @@ mod tests {
             branch_in_flight: Mutex::new(HashSet::new()),
             branch_sem: Arc::new(Semaphore::new(cap)),
             branch_concurrency_cap: cap,
+            netns_alloc: crate::netns::NetnsAllocator::new(
+                256,
+                Box::new(crate::netns::RangeProbe { max: 256 }),
+            ),
             prewarm_scratch_dir,
             #[cfg(target_os = "linux")]
             live_in_flight: Mutex::new(HashMap::new()),
@@ -2824,6 +2863,30 @@ mod tests {
 
     fn test_state() -> SharedState {
         test_state_with_cap(DEFAULT_BRANCH_CONCURRENCY)
+    }
+
+    /// test_state with a netns pool sized `netns_pool` (0 = exhausted).
+    fn test_state_with_netns(netns_pool: usize) -> SharedState {
+        let td = tempfile::TempDir::new().unwrap();
+        let path = td.path().join("state.json");
+        let snapshot_root = td.path().join("snapshots");
+        let prewarm_scratch_dir = td.path().join("prewarm");
+        Arc::new(AppState {
+            registry: Registry::load_or_init(path).unwrap(),
+            live_vms: Mutex::new(HashMap::new()),
+            snapshot_root,
+            branch_in_flight: Mutex::new(HashSet::new()),
+            branch_sem: Arc::new(Semaphore::new(DEFAULT_BRANCH_CONCURRENCY)),
+            branch_concurrency_cap: DEFAULT_BRANCH_CONCURRENCY,
+            netns_alloc: crate::netns::NetnsAllocator::new(
+                netns_pool,
+                Box::new(crate::netns::RangeProbe { max: netns_pool }),
+            ),
+            prewarm_scratch_dir,
+            #[cfg(target_os = "linux")]
+            live_in_flight: Mutex::new(HashMap::new()),
+            _tempdir: Some(td),
+        })
     }
 
     #[test]
@@ -3600,6 +3663,38 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn create_sandbox_netns_pool_exhaustion_returns_503() {
+        // A zero-provisioned allocator must reject the spawn with a
+        // resource-exhaustion 503 (not a generic 500) — security review
+        // #282.
+        let state = test_state_with_netns(0);
+        let dir = state.snapshot_root.join("base");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("vmstate"), b"fake-vmstate").unwrap();
+        std::fs::write(dir.join("memory.bin"), b"fake-memory").unwrap();
+
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sandboxes")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"snapshot_tag":"base","n":1,"per_child_netns":true}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "netns exhaustion must be 503, not a generic 500"
+        );
     }
 
     #[tokio::test]

--- a/crates/forkd-controller/src/lib.rs
+++ b/crates/forkd-controller/src/lib.rs
@@ -6,6 +6,7 @@ pub mod api;
 pub mod audit;
 pub mod auth;
 pub mod http;
+pub mod netns;
 pub mod state;
 
 use anyhow::{Context, Result};
@@ -137,6 +138,10 @@ pub async fn run_daemon(cfg: DaemonConfig) -> Result<()> {
         branch_in_flight: Mutex::new(std::collections::HashSet::new()),
         branch_sem: std::sync::Arc::new(tokio::sync::Semaphore::new(branch_concurrency)),
         branch_concurrency_cap: branch_concurrency,
+        // Atomic netns offset allocator (security review #282): the
+        // bound is derived from the provisioned pool on disk instead of
+        // a magic constant.
+        netns_alloc: crate::netns::NetnsAllocator::discover("/var/run/netns"),
         prewarm_scratch_dir: cfg.prewarm_scratch_dir.clone(),
         #[cfg(target_os = "linux")]
         live_in_flight: Mutex::new(HashMap::new()),

--- a/crates/forkd-controller/src/netns.rs
+++ b/crates/forkd-controller/src/netns.rs
@@ -1,0 +1,369 @@
+//! Atomic netns offset allocation for per-child namespaces.
+//!
+//! `forkd-child-N` namespaces are provisioned on disk (via
+//! `scripts/netns-setup.sh N`); a sandbox with `per_child_netns=true`
+//! must pick an offset range `[offset+1 .. offset+n+1]` disjoint from
+//! every other live sandbox AND from every other in-flight spawn.
+//!
+//! The old `pick_netns_offset` did a check-then-act scan of `live_vms`:
+//! it locked the map only while scanning, then released the lock before
+//! Firecracker started and before the VM was inserted, so two concurrent
+//! spawns could both receive the same range. This allocator fixes that
+//! by making the reservation itself the atomic operation:
+//!
+//! 1. `reserve(n)` scans the provisioned pool under one lock and marks
+//!    the chosen indices as reserved (RAII lease).
+//! 2. On spawn success the caller registers the VMs in `live_vms` and
+//!    then calls `commit()`, which MOVES the indices from the reserved
+//!    set to the ACTIVE set — they stay owned by the live VMs until the
+//!    controller explicitly releases them via `release_index()` when the
+//!    VM leaves `live_vms` (delete / suspend).
+//! 3. On spawn failure the lease is dropped and the reservation is
+//!    released automatically (rollback).
+//!
+//! Committed ranges are therefore never reused while their VMs are
+//! still live: `reserve()` checks both the reserved AND the active set.
+//! (An earlier version released committed indices immediately, so a
+//! second spawn could take the same range as a still-live VM — fixed in
+//! review #282 round 2.)
+
+use parking_lot::Mutex;
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::Arc;
+
+/// RAII lease on a range of `forkd-child-N` indices.
+///
+/// Indices are 1-based on the wire (`forkd-child-1` …); `offset` is the
+/// additive offset applied before the within-batch `1..=n` loop, so the
+/// lease covers `offset+1 ..= offset+n`.
+#[derive(Debug)]
+pub struct NetnsReservation {
+    offset: usize,
+    n: usize,
+    /// Set on `commit`; while false the indices stay in the allocator's
+    /// reserved set and are released on drop.
+    committed: bool,
+    /// Shared handle back to the allocator, so dropping the lease can
+    /// release the reservation even after the caller's handle moved.
+    alloc: Arc<NetnsAllocator>,
+}
+
+impl NetnsReservation {
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Transfer the reservation from "in-flight" to "owned by live VMs":
+    /// the caller has registered the spawned VMs in `live_vms`, so the
+    /// indices become ACTIVE and stay owned until the controller calls
+    /// [`NetnsAllocator::release_index`] when the VM is removed.
+    /// Idempotent.
+    pub fn commit(&mut self) {
+        if !self.committed {
+            self.committed = true;
+            self.alloc.commit_range(self.offset, self.n);
+        }
+    }
+}
+
+impl Drop for NetnsReservation {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.alloc.release_reserved(self.offset, self.n);
+        }
+    }
+}
+
+/// Probe for whether a provisioned namespace index exists.
+///
+/// Injectable so tests can use an in-memory view instead of real
+/// `/var/run/netns/` entries.
+pub trait NetnsProbe: Send + Sync {
+    fn exists(&self, index: usize) -> bool;
+}
+
+/// A probe that checks the real netns directory.
+pub struct DiskNetnsProbe {
+    netns_dir: std::path::PathBuf,
+}
+
+impl DiskNetnsProbe {
+    pub fn new(netns_dir: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            netns_dir: netns_dir.into(),
+        }
+    }
+}
+
+impl NetnsProbe for DiskNetnsProbe {
+    fn exists(&self, index: usize) -> bool {
+        self.netns_dir.join(format!("forkd-child-{index}")).exists()
+    }
+}
+
+/// A probe that reports every index up to `max` as provisioned (tests).
+#[derive(Debug, Clone)]
+pub struct RangeProbe {
+    pub max: usize,
+}
+
+impl NetnsProbe for RangeProbe {
+    fn exists(&self, index: usize) -> bool {
+        index <= self.max
+    }
+}
+
+/// Atomic allocator for netns offset ranges.
+pub struct NetnsAllocator {
+    /// Indices currently reserved by in-flight spawns (not yet
+    /// committed to `live_vms`).
+    reserved: Mutex<HashSet<usize>>,
+    /// Indices owned by LIVE VMs (committed reservations that have not
+    /// been released by the controller). Released only when the VM
+    /// leaves `live_vms`.
+    active: Mutex<HashSet<usize>>,
+    /// Upper bound of the provisioned pool: index `provisioned` is the
+    /// highest namespace that may be used.
+    provisioned: usize,
+    probe: Box<dyn NetnsProbe>,
+}
+
+impl fmt::Debug for NetnsAllocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NetnsAllocator")
+            .field("provisioned", &self.provisioned)
+            .finish()
+    }
+}
+
+impl NetnsAllocator {
+    /// Create an allocator over a provisioned pool of `provisioned`
+    /// namespaces (indices `1..=provisioned`), using `probe` to verify
+    /// on-disk existence.
+    pub fn new(provisioned: usize, probe: Box<dyn NetnsProbe>) -> Arc<Self> {
+        Arc::new(Self {
+            reserved: Mutex::new(HashSet::new()),
+            active: Mutex::new(HashSet::new()),
+            provisioned,
+            probe,
+        })
+    }
+
+    /// Discover the provisioned pool by scanning the netns directory
+    /// (max existing `forkd-child-N` index).
+    pub fn discover(netns_dir: impl Into<std::path::PathBuf>) -> Arc<Self> {
+        let netns_dir = netns_dir.into();
+        let mut max = 0usize;
+        if let Ok(rd) = std::fs::read_dir(&netns_dir) {
+            for entry in rd.flatten() {
+                let name = entry.file_name();
+                if let Some(s) = name.to_str() {
+                    if let Some(idx) = s.strip_prefix("forkd-child-") {
+                        if let Ok(i) = idx.parse::<usize>() {
+                            max = max.max(i);
+                        }
+                    }
+                }
+            }
+        }
+        Self::new(max, Box::new(DiskNetnsProbe::new(netns_dir)))
+    }
+
+    /// Highest provisioned index.
+    pub fn provisioned(&self) -> usize {
+        self.provisioned
+    }
+
+    /// Reserve `n` contiguous child indices. Returns `None` when the
+    /// provisioned pool cannot satisfy the request.
+    ///
+    /// The returned lease is held until `commit` or drop; concurrent
+    /// reservations are disjoint because the check-then-act happens
+    /// under the allocator's lock. Committed (live) indices are also
+    /// skipped, so a still-running VM's range is never handed out again.
+    pub fn reserve(self: &Arc<Self>, n: usize) -> Option<NetnsReservation> {
+        if n == 0 {
+            return None;
+        }
+        let mut reserved = self.reserved.lock();
+        let active = self.active.lock();
+        // Search offsets 0..=provisioned-n so that offset+n <= provisioned.
+        let max_offset = self.provisioned.saturating_sub(n);
+        for offset in 0..=max_offset {
+            let range_start = offset + 1;
+            let range_end = offset + n + 1; // exclusive
+            let mut ok = true;
+            for i in range_start..range_end {
+                if reserved.contains(&i) || active.contains(&i) || !self.probe.exists(i) {
+                    ok = false;
+                    break;
+                }
+            }
+            if ok {
+                for i in range_start..range_end {
+                    reserved.insert(i);
+                }
+                return Some(NetnsReservation {
+                    offset,
+                    n,
+                    committed: false,
+                    alloc: Arc::clone(self),
+                });
+            }
+        }
+        None
+    }
+
+    /// Move a reserved range into the active (live) set. Called by
+    /// `NetnsReservation::commit` once the VMs are registered.
+    fn commit_range(&self, offset: usize, n: usize) {
+        let mut reserved = self.reserved.lock();
+        let mut active = self.active.lock();
+        for i in (offset + 1)..(offset + n + 1) {
+            reserved.remove(&i);
+            active.insert(i);
+        }
+    }
+
+    /// Remove indices from the reserved set (rollback on spawn failure).
+    fn release_reserved(&self, offset: usize, n: usize) {
+        let mut reserved = self.reserved.lock();
+        for i in (offset + 1)..(offset + n + 1) {
+            reserved.remove(&i);
+        }
+    }
+
+    /// Release a single ACTIVE index back to the pool. Called by the
+    /// controller when a VM leaves `live_vms` (delete / suspend). The
+    /// VM's `netns` string (`forkd-child-N`) provides the index.
+    /// Idempotent; releasing an index that is not active is a no-op.
+    pub fn release_index(&self, index: usize) {
+        self.active.lock().remove(&index);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn alloc(max: usize) -> Arc<NetnsAllocator> {
+        NetnsAllocator::new(max, Box::new(RangeProbe { max }))
+    }
+
+    #[test]
+    fn reserves_disjoint_ranges() {
+        let a = alloc(16);
+        let mut r1 = a.reserve(2).expect("r1");
+        assert_eq!(r1.offset(), 0); // covers 1,2
+        let r2 = a.reserve(1).expect("r2");
+        assert_eq!(r2.offset(), 2); // covers 3
+                                    // commit r1 — indices 1,2 become ACTIVE (owned by live VMs), not
+                                    // free: a committed range must not be reused while its VMs live.
+        r1.commit();
+        let r3 = a.reserve(1).expect("r3");
+        assert_eq!(r3.offset(), 3); // covers 4 (1,2 active; 3 reserved)
+        let r4 = a.reserve(5).expect("r4");
+        assert_eq!(r4.offset(), 4); // covers 5..9
+    }
+
+    #[test]
+    fn committed_range_released_by_release_index() {
+        let a = alloc(8);
+        let mut r1 = a.reserve(2).expect("r1"); // covers 1,2
+        r1.commit();
+        // While active, the range is NOT reusable.
+        assert!(a.reserve(1).is_some()); // offset 2 covers 3
+        assert_eq!(a.reserve(2).expect("r2").offset(), 2); // covers 3,4
+                                                           // Release index 1 only (VM 1 deleted, VM 2 still live).
+        a.release_index(1);
+        let r = a.reserve(1).expect("r3");
+        assert_eq!(r.offset(), 0); // covers 1 — index 1 free, index 2 active
+                                   // Releasing an already-free index is a no-op.
+        a.release_index(1);
+        a.release_index(99);
+    }
+
+    #[test]
+    fn drop_releases_reservation() {
+        let a = alloc(8);
+        let r1 = a.reserve(3).expect("r1"); // covers 1..3
+        drop(r1);
+        let r2 = a.reserve(3).expect("r2");
+        assert_eq!(r2.offset(), 0); // same range reusable
+    }
+
+    #[test]
+    fn concurrent_reservations_are_disjoint() {
+        let a = alloc(256);
+        // A Barrier guarantees all 32 reservations are alive at the same
+        // time: each thread reserves, then waits. Without it, short
+        // sleeps let early threads' leases expire while later threads
+        // are still spawning, so later threads legitimately reuse freed
+        // ranges (a test bug, not an allocator bug).
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(33));
+        let handles: Vec<_> = (0..32)
+            .map(|_| {
+                let a = Arc::clone(&a);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let r = a.reserve(4).expect("reserve in pool");
+                    // All threads reserve before any reports back, so
+                    // the reservations overlap in time.
+                    barrier.wait();
+                    let o = r.offset();
+                    (o, o + 4)
+                })
+            })
+            .collect();
+        barrier.wait(); // main joins the reservation window
+        let mut ranges: Vec<(usize, usize)> =
+            handles.into_iter().map(|h| h.join().unwrap()).collect();
+        ranges.sort();
+        for pair in ranges.windows(2) {
+            assert!(
+                pair[0].1 <= pair[1].0,
+                "ranges overlap: {:?} vs {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+
+    #[test]
+    fn pool_larger_than_256_is_usable() {
+        let a = alloc(512);
+        // Reserve every single slot (n=1) up to 512.
+        let mut leases = Vec::new();
+        for _ in 0..512 {
+            match a.reserve(1) {
+                Some(l) => leases.push(l),
+                None => panic!("pool of 512 should satisfy 512 single leases"),
+            }
+        }
+        assert!(a.reserve(1).is_none(), "pool exhausted at 512");
+    }
+
+    #[test]
+    fn exhaustion_returns_none() {
+        let a = alloc(4);
+        let _r1 = a.reserve(4).expect("fills 1..4");
+        assert!(a.reserve(1).is_none(), "no room left");
+        // A request larger than the pool is also rejected.
+        assert!(a.reserve(5).is_none());
+    }
+
+    #[test]
+    fn disk_probe_honors_directory() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("forkd-child-1"), b"").unwrap();
+        std::fs::write(dir.path().join("forkd-child-3"), b"").unwrap();
+        let a = NetnsAllocator::discover(dir.path());
+        assert_eq!(a.provisioned(), 3);
+        // Only provisioned indices are usable: offset 0 (covers 1) works,
+        // offset 1 (covers 2, which is not provisioned) does not.
+        assert!(a.reserve(1).is_some());
+        drop(a.reserve(1));
+        assert!(a.reserve(2).is_none(), "index 2 is not provisioned");
+    }
+}

--- a/crates/forkd-controller/src/netns.rs
+++ b/crates/forkd-controller/src/netns.rs
@@ -84,21 +84,37 @@ pub trait NetnsProbe: Send + Sync {
 }
 
 /// A probe that checks the real netns directory.
+///
+/// Caches the provisioned index set at construction time so `reserve()`
+/// does not do a filesystem stat per candidate index while holding the
+/// allocator locks. The provisioned pool is static until `netns-setup.sh`
+/// runs and the daemon restarts (review #282).
 pub struct DiskNetnsProbe {
-    netns_dir: std::path::PathBuf,
+    provisioned: HashSet<usize>,
 }
 
 impl DiskNetnsProbe {
     pub fn new(netns_dir: impl Into<std::path::PathBuf>) -> Self {
-        Self {
-            netns_dir: netns_dir.into(),
+        let netns_dir = netns_dir.into();
+        let mut provisioned = HashSet::new();
+        if let Ok(rd) = std::fs::read_dir(&netns_dir) {
+            for entry in rd.flatten() {
+                if let Some(s) = entry.file_name().to_str() {
+                    if let Some(idx) = s.strip_prefix("forkd-child-") {
+                        if let Ok(i) = idx.parse::<usize>() {
+                            provisioned.insert(i);
+                        }
+                    }
+                }
+            }
         }
+        Self { provisioned }
     }
 }
 
 impl NetnsProbe for DiskNetnsProbe {
     fn exists(&self, index: usize) -> bool {
-        self.netns_dir.join(format!("forkd-child-{index}")).exists()
+        self.provisioned.contains(&index)
     }
 }
 
@@ -151,23 +167,14 @@ impl NetnsAllocator {
     }
 
     /// Discover the provisioned pool by scanning the netns directory
-    /// (max existing `forkd-child-N` index).
+    /// (max existing `forkd-child-N` index). The probe caches the full
+    /// provisioned index set at construction time so `reserve()` avoids
+    /// per-index filesystem stats (review #282).
     pub fn discover(netns_dir: impl Into<std::path::PathBuf>) -> Arc<Self> {
         let netns_dir = netns_dir.into();
-        let mut max = 0usize;
-        if let Ok(rd) = std::fs::read_dir(&netns_dir) {
-            for entry in rd.flatten() {
-                let name = entry.file_name();
-                if let Some(s) = name.to_str() {
-                    if let Some(idx) = s.strip_prefix("forkd-child-") {
-                        if let Ok(i) = idx.parse::<usize>() {
-                            max = max.max(i);
-                        }
-                    }
-                }
-            }
-        }
-        Self::new(max, Box::new(DiskNetnsProbe::new(netns_dir)))
+        let probe = DiskNetnsProbe::new(&netns_dir);
+        let max = probe.provisioned.iter().copied().max().unwrap_or(0);
+        Self::new(max, Box::new(probe))
     }
 
     /// Highest provisioned index.
@@ -365,5 +372,47 @@ mod tests {
         assert!(a.reserve(1).is_some());
         drop(a.reserve(1));
         assert!(a.reserve(2).is_none(), "index 2 is not provisioned");
+    }
+
+    #[test]
+    fn concurrent_reservations_skip_committed_active() {
+        // Thread A reserves n=4 and commits (simulating live VMs owning
+        // indices 1..4), then 32 threads reserve(1) under a barrier and
+        // assert none overlap the committed range.
+        let a = alloc(256);
+        let mut committed = a.reserve(4).expect("commit r");
+        committed.commit(); // indices 1..4 are now ACTIVE
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(33));
+        let handles: Vec<_> = (0..32)
+            .map(|_| {
+                let a = Arc::clone(&a);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let r = a.reserve(1).expect("reserve in pool");
+                    barrier.wait();
+                    r.offset() + 1 // the actual index
+                })
+            })
+            .collect();
+        barrier.wait();
+        let indices: Vec<usize> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // No thread should have received an index in the committed
+        // range (1..=4).
+        for &idx in &indices {
+            assert!(idx > 4, "thread got committed index {idx}");
+        }
+        // All 32 indices must be disjoint.
+        let mut sorted = indices.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), 32, "indices not disjoint: {indices:?}");
+
+        // After releasing the committed range, index 1 is reusable.
+        for idx in 1..=4 {
+            a.release_index(idx);
+        }
+        assert_eq!(a.reserve(1).unwrap().offset(), 0);
     }
 }


### PR DESCRIPTION
**Related issue: #286**

---

## Problem

`pick_netns_offset` could return an offset beyond the provisioned `forkd-child-N` set. When all namespaces are in use (e.g. after a client restart orphans warm VMs), a new spawn landed in `forkd-child-11` (which doesn't exist) and failed with a confusing `"socket never appeared within 10s"` loop that never self-healed.

## Fix

- The allocator now verifies each required namespace actually exists on disk (`/var/run/netns/forkd-child-K`) — the filesystem is the source of truth for what's provisioned.
- Returns `None` when the pool is exhausted; both call sites (sandbox spawn + workspace spawn) surface a clear `netns pool exhausted` error pointing at `scripts/netns-setup.sh` instead of silently spawning into nothing.
- Search is bounded (`MAX_OFFSET=256`) so a completely unprovisioned host fails fast.

## Testing

`cargo check -p forkd-controller` passes.