### PR TITLE
fix(controller): persist per_child_netns across workspace resume

### DIFF
--- a/crates/forkd-controller/src/api.rs
+++ b/crates/forkd-controller/src/api.rs
@@ -400,6 +400,12 @@ pub struct WorkspaceInfo {
     /// `suspend?diff=true`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_branch_memory_path: Option<std::path::PathBuf>,
+    /// Whether this workspace's live sandboxes use a per-child netns.
+    /// Persisted so that `resume` respawns on the same netns layout
+    /// the workspace was created with (the shared forkd-tap0 is not a
+    /// safe fallback when several workspaces are active).
+    #[serde(default)]
+    pub per_child_netns: bool,
 }
 
 /// `POST /v1/workspaces/:name/suspend` request body.

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -2510,6 +2510,7 @@ async fn create_workspace(
         created_at_unix: now,
         last_active_unix: now,
         last_branch_memory_path: None,
+        per_child_netns,
     };
     if let Err(e) = s.registry.insert_workspace(ws.clone()) {
         return server_error(&format!("persist workspace: {e:#}"));
@@ -2745,8 +2746,13 @@ async fn resume_workspace(State(s): State<SharedState>, Path(name): Path<String>
         .clone()
         .unwrap_or_else(|| ws.source_snapshot_tag.clone());
     let s_clone = s.clone();
+    // Respawn with the same netns layout the workspace was created
+    // with (per_child_netns is persisted on WorkspaceInfo). Hardcoding
+    // false here puts resumed sandboxes on the shared forkd-tap0,
+    // which collides when several workspaces are active.
+    let per_child_netns = ws.per_child_netns;
     let spawn_result = tokio::task::spawn_blocking(move || {
-        spawn_one_for_workspace(&s_clone, &spawn_tag, false, None)
+        spawn_one_for_workspace(&s_clone, &spawn_tag, per_child_netns, None)
     })
     .await;
     let (vm, sb_info) = match spawn_result {


### PR DESCRIPTION
**Related issue: #287**

---

## Problem

`resume_workspace` hardcodes `per_child_netns: false`, respawning the live sandbox on the shared `forkd-tap0` even when the workspace was created with a per-child netns (`per_child_netns: true`).

With several active workspaces this causes:
- **Tap collisions** — a second restart can fail with `Open tap device failed: Resource busy … forkd-tap0`
- **Broken proxy routing** — downstream consumers that `setns` into the sandbox's netns get `setns: invalid argument` / 502s because the endpoint has no netns path

## Fix

- Add `per_child_netns: bool` to `WorkspaceInfo` with `#[serde(default)]` — existing state files stay backward compatible
- Set it at `create_workspace` from the request field
- Honor it at `resume_workspace` instead of hardcoding `false`

## Notes

- No behavior change for existing workspaces (they default to `false`, matching current resume behavior)
- `spawn_one_for_workspace` already takes the flag; only the resume call site ignored it