### PR TITLE
fix(vmm): force clocksource=kvm-clock to prevent stale TSC after snapshot restore

### DIFF
--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -2512,4 +2512,216 @@ mod tests {
         // WorkDirGuard drops work_dir.
         drop(vm);
     }
+
+    /// Integration test: verify kvm-clock survives snapshot/restore on
+    /// modern x86 kernels (≥ 5.16 with KVM_CLOCK_REALTIME).
+    ///
+    /// This test complements boot_vm_uses_kvm_clock (which tests fresh
+    /// boot only). The snapshot-restore path is where stale TSC actually
+    /// manifests: after restore, KVM_SET_CLOCK restores the saved clock
+    /// state from the snapshot. On Linux ≥ 5.16, the KVM_CLOCK_REALTIME
+    /// flag makes kvm-clock auto-correct to host wall time, so the boot
+    /// arg alone is sufficient. On older kernels (< 5.16) or aarch64,
+    /// the restored clock is stale — see PR #300 (guest-side date -s)
+    /// for the complementary fix.
+    ///
+    /// This test verifies #289's contribution: the boot arg keeps
+    /// kvm-clock as the clocksource through the snapshot/restore cycle,
+    /// and on modern kernels the restored clock is correct without any
+    /// guest-side intervention.
+    #[test]
+    #[ignore = "requires firecracker, kernel, rootfs, and tap device"]
+    #[cfg(target_os = "linux")]
+    fn kvm_clock_survives_snapshot_restore() {
+        let kernel = std::env::var("FORKD_TEST_KERNEL")
+            .unwrap_or_else(|_| "/var/lib/forkd/kernels/vmlinux".to_string());
+        let rootfs = std::env::var("FORKD_TEST_ROOTFS")
+            .expect("FORKD_TEST_ROOTFS must point to an ext4 rootfs image");
+
+        assert!(
+            std::path::Path::new(&kernel).exists(),
+            "FORKD_TEST_KERNEL not found at {kernel}"
+        );
+        assert!(
+            std::path::Path::new(&rootfs).exists(),
+            "FORKD_TEST_ROOTFS not found at {rootfs}"
+        );
+
+        let boot_dir =
+            std::env::temp_dir().join(format!("forkd-restore-test-boot-{}", std::process::id()));
+        let snap_dir =
+            std::env::temp_dir().join(format!("forkd-restore-test-snap-{}", std::process::id()));
+        let restore_dir =
+            std::env::temp_dir().join(format!("forkd-restore-test-restore-{}", std::process::id()));
+
+        let _ = std::fs::remove_dir_all(&boot_dir);
+        let _ = std::fs::remove_dir_all(&snap_dir);
+        let _ = std::fs::remove_dir_all(&restore_dir);
+
+        let _boot_guard = WorkDirGuard(boot_dir.clone());
+        let _snap_guard = WorkDirGuard(snap_dir.clone());
+        let _restore_guard = WorkDirGuard(restore_dir.clone());
+
+        let addr = "10.42.0.2:8888";
+
+        assert!(
+            ping_at(addr).is_err(),
+            "{addr} is already reachable — a stale VM may occupy the address; \
+             kill it before running this test"
+        );
+
+        // --- Phase 1: Boot fresh VM and verify kvm-clock ---
+
+        let cfg = BootConfig::ext4_rw(kernel.into(), rootfs.into(), boot_dir.clone())
+            .with_network(NetworkConfig::default_tap("forkd-tap0"));
+
+        let vm = Vm::boot(&cfg).expect("boot VM");
+
+        let mut connected = false;
+        for _ in 0..60 {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            if ping_at(addr).is_ok() {
+                connected = true;
+                break;
+            }
+        }
+        assert!(
+            connected,
+            "guest agent at {addr} did not respond within 30s; \
+             check console log at {}/fc.console",
+            boot_dir.display()
+        );
+
+        // Verify clocksource on fresh boot
+        let resp = exec_at(
+            addr,
+            vec![
+                "cat".into(),
+                "/sys/devices/system/clocksource/clocksource0/current_clocksource".into(),
+            ],
+            std::time::Duration::from_secs(10),
+        )
+        .expect("exec clocksource check");
+        assert_eq!(resp.exit_code, 0, "cat clocksource failed: {}", resp.stderr);
+        assert_eq!(
+            resp.stdout.trim(),
+            "kvm-clock",
+            "expected clocksource=kvm-clock on fresh boot"
+        );
+
+        // --- Phase 2: Snapshot the VM ---
+
+        vm.pause().expect("pause VM for snapshot");
+
+        let vmstate_path = snap_dir.join("vmstate.bin");
+        let memory_path = snap_dir.join("memory.bin");
+        let snapshot = vm
+            .snapshot_to(vmstate_path, memory_path, vec![])
+            .expect("create snapshot");
+
+        // Kill the original VM to free the tap device and guest agent
+        // address. Vm::drop kills firecracker and removes the socket.
+        // The tap device persists (pre-created by scripts/host-tap.sh).
+        drop(vm);
+
+        // Wait a few seconds so any stale clock would be visibly wrong.
+        // On modern kernels with KVM_CLOCK_REALTIME, kvm-clock
+        // auto-corrects on restore, so this wait doesn't affect
+        // correctness. On older kernels, the restored clock would be
+        // off by this amount (which is why PR #300 exists).
+        std::thread::sleep(std::time::Duration::from_secs(3));
+
+        // --- Phase 3: Restore from snapshot and verify kvm-clock ---
+
+        assert!(
+            ping_at(addr).is_err(),
+            "{addr} is still reachable after killing the source VM"
+        );
+
+        let opts = ForkOpts {
+            n: 1,
+            per_child_netns: false,
+            memory_limit_mib: None,
+            netns_offset: 0,
+            prewarm_scratch_dir: None,
+            memory_backend: MemoryBackend::File,
+            enable_diff_snapshots: false,
+        };
+
+        let fork_result = snapshot
+            .restore_many_with(opts, &restore_dir)
+            .expect("restore from snapshot");
+
+        assert_eq!(
+            fork_result.children.len(),
+            1,
+            "expected 1 restored child, got {}",
+            fork_result.children.len()
+        );
+
+        let mut restored_vm = fork_result.children.into_iter().next().unwrap();
+
+        // Wait for guest agent on the restored VM
+        let mut connected = false;
+        for _ in 0..60 {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            if ping_at(addr).is_ok() {
+                connected = true;
+                break;
+            }
+        }
+        assert!(
+            connected,
+            "guest agent at {addr} did not respond after restore within 30s; \
+             check console log at {}/child-1.console",
+            restore_dir.display()
+        );
+
+        // Verify clocksource is still kvm-clock after restore
+        let resp = exec_at(
+            addr,
+            vec![
+                "cat".into(),
+                "/sys/devices/system/clocksource/clocksource0/current_clocksource".into(),
+            ],
+            std::time::Duration::from_secs(10),
+        )
+        .expect("exec clocksource check after restore");
+        assert_eq!(resp.exit_code, 0, "cat clocksource failed: {}", resp.stderr);
+        assert_eq!(
+            resp.stdout.trim(),
+            "kvm-clock",
+            "clocksource changed after snapshot/restore — \
+             expected kvm-clock to persist"
+        );
+
+        // Verify wall clock is correct after restore. On modern x86
+        // (≥ 5.16), KVM_CLOCK_REALTIME makes kvm-clock auto-correct to
+        // host time on restore. On older kernels, the clock would be
+        // stale — that gap is addressed by PR #300 (guest-side date -s
+        // after restore).
+        let host_time = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .expect("host time before epoch")
+            .as_secs();
+        let time_resp = exec_at(
+            addr,
+            vec!["date".into(), "-u".into(), "+%s".into()],
+            std::time::Duration::from_secs(10),
+        )
+        .expect("exec date check after restore");
+        assert_eq!(time_resp.exit_code, 0, "date failed: {}", time_resp.stderr);
+        let guest_time: u64 = time_resp.stdout.trim().parse().expect("parse guest time");
+        let drift = host_time.abs_diff(guest_time);
+        assert!(
+            drift <= 5,
+            "guest wall clock drifts {drift}s from host after restore \
+             (host={host_time}, guest={guest_time}) — on modern kernels (≥ 5.16) \
+             KVM_CLOCK_REALTIME should auto-correct kvm-clock; if this fails on \
+             an older kernel, that's expected — see PR #300 for the complementary fix"
+        );
+
+        // Clean up
+        drop(restored_vm);
+    }
 }

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -133,8 +133,25 @@ impl BootConfig {
             // `getrandom(2)`-blocking for OpenSSL workloads.
             // RDRAND is universal on x86_64 hosts forkd targets
             // (Intel since Ivy Bridge 2012, AMD since Zen 2017).
+            // `clocksource=kvm-clock` forces the guest to use the KVM
+            // paravirtualized clock, which always reflects the host's
+            // wall clock time. Without this, the kernel boots with
+            // kvm-clock but switches to TSC early in init — and when
+            // sandboxes are created via snapshot restore, the TSC is
+            // stale (frozen at the snapshot creation time). This causes
+            // the guest wall clock to be wrong by days/weeks, breaking
+            // TLS certificate validation and any time-sensitive logic.
+            //
+            // x86_64-only: kvm-clock (CONFIG_KVM_CLOCK) is an x86
+            // paravirtualized clock. On aarch64 the parameter is
+            // silently ignored (the kernel falls back to auto-select).
+            //
+            // Forward-only on the snapshot side: existing snapshots
+            // created before this change have the kernel locked to
+            // TSC and must be re-baked via `forkd from-image` before
+            // restored sandboxes inherit the kvm-clock fix.
             boot_args:
-                "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro random.trust_cpu=on".into(),
+                "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro random.trust_cpu=on clocksource=kvm-clock".into(),
             work_dir,
             rootfs_read_only: true,
             network: None,
@@ -153,8 +170,11 @@ impl BootConfig {
             rootfs,
             vcpu_count: 2,
             mem_size_mib: 512,
+            // clocksource=kvm-clock: see quickstart() for rationale.
+            // Forward-only on the snapshot side: existing snapshots
+            // must be re-baked via `forkd from-image` to inherit this fix.
             boot_args:
-                "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw init=/forkd-init.sh random.trust_cpu=on".into(),
+                "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw init=/forkd-init.sh random.trust_cpu=on clocksource=kvm-clock".into(),
             work_dir,
             rootfs_read_only: false,
             network: None,
@@ -1791,6 +1811,15 @@ fn lseek_data_or_hole(f: &std::fs::File, offset: i64, want_data: bool) -> std::i
 mod tests {
     use super::*;
 
+    /// RAII guard that removes a directory on drop — even on panic.
+    /// Used by integration tests to avoid leaking work_dir on failure.
+    struct WorkDirGuard(std::path::PathBuf);
+    impl Drop for WorkDirGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
     // #261: a deadline-bounded accept must give up instead of hanging
     // forever when no peer ever connects.
     #[test]
@@ -1842,6 +1871,26 @@ mod tests {
             cfg.boot_args
         );
         assert!(cfg.rootfs_read_only);
+        // clocksource=kvm-clock prevents the guest from switching to TSC,
+        // which is stale after snapshot restore and breaks TLS validation.
+        // Assert both presence AND that it is the last clocksource= token
+        // (a later clocksource=tsc would silently override it).
+        assert!(
+            cfg.boot_args.contains("clocksource=kvm-clock"),
+            "quickstart boot_args must include clocksource=kvm-clock: `{}`",
+            cfg.boot_args
+        );
+        let after = cfg
+            .boot_args
+            .split("clocksource=kvm-clock")
+            .nth(1)
+            .unwrap_or("");
+        assert!(
+            !after.contains("clocksource="),
+            "quickstart boot_args has a clocksource= token after kvm-clock \
+             which would override it: `{}`",
+            cfg.boot_args
+        );
     }
 
     #[test]
@@ -1924,6 +1973,22 @@ mod tests {
         );
         // and the warmup init script is referenced
         assert!(cfg.boot_args.contains("init=/forkd-init.sh"));
+        assert!(
+            cfg.boot_args.contains("clocksource=kvm-clock"),
+            "ext4_rw boot_args must include clocksource=kvm-clock: `{}`",
+            cfg.boot_args
+        );
+        let after = cfg
+            .boot_args
+            .split("clocksource=kvm-clock")
+            .nth(1)
+            .unwrap_or("");
+        assert!(
+            !after.contains("clocksource="),
+            "ext4_rw boot_args has a clocksource= token after kvm-clock \
+             which would override it: `{}`",
+            cfg.boot_args
+        );
     }
 
     #[test]
@@ -2292,5 +2357,159 @@ mod tests {
         assert_eq!(bytes, b"PRETEND-ASSEMBLED-MEMORY");
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // -----------------------------------------------------------------
+    // Integration test: boot a real Firecracker VM and verify the
+    // guest clocksource is kvm-clock (not TSC).
+    //
+    // This test verifies the *effect* of `clocksource=kvm-clock` in
+    // boot_args, not just that the string is present. It boots an
+    // actual firecracker VM with a real kernel and rootfs, waits for
+    // the guest agent, and reads
+    //   /sys/devices/system/clocksource/clocksource0/current_clocksource
+    // inside the VM.
+    //
+    // Requirements:
+    //   - Linux host with Firecracker installed
+    //   - forkd-tap0 tap device configured (run `scripts/host-tap.sh`)
+    //   - FORKD_TEST_KERNEL env var pointing to a vmlinux (default:
+    //     /var/lib/forkd/kernels/vmlinux)
+    //   - FORKD_TEST_ROOTFS env var pointing to an ext4 rootfs image
+    //     that includes python3 (for forkd-agent.py / forkd-init.sh)
+    //
+    // Run with:
+    //   FORKD_TEST_ROOTFS=/var/cache/forkd/dev-base.ext4 \
+    //     cargo test -p forkd-vmm --lib boot_vm_uses_kvm_clock -- --ignored
+    // -----------------------------------------------------------------
+    #[cfg(target_os = "linux")]
+    #[ignore = "requires firecracker, kernel, rootfs, and tap device"]
+    #[test]
+    fn boot_vm_uses_kvm_clock() {
+        let kernel = std::env::var("FORKD_TEST_KERNEL")
+            .unwrap_or_else(|_| "/var/lib/forkd/kernels/vmlinux".to_string());
+        let rootfs = std::env::var("FORKD_TEST_ROOTFS")
+            .expect("FORKD_TEST_ROOTFS must point to an ext4 rootfs image");
+
+        // Pre-flight: verify kernel and rootfs exist for actionable errors.
+        assert!(
+            std::path::Path::new(&kernel).exists(),
+            "FORKD_TEST_KERNEL not found at {kernel}"
+        );
+        assert!(
+            std::path::Path::new(&rootfs).exists(),
+            "FORKD_TEST_ROOTFS not found at {rootfs}"
+        );
+
+        let work_dir =
+            std::env::temp_dir().join(format!("forkd-clocksource-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&work_dir);
+        // RAII guard: removes work_dir on drop, even on panic.
+        let _work_dir_guard = WorkDirGuard(work_dir.clone());
+
+        let addr = "10.42.0.2:8888";
+
+        // Pre-flight: ensure no stale VM is already using 10.42.0.2.
+        assert!(
+            ping_at(addr).is_err(),
+            "10.42.0.2:8888 is already reachable — a stale VM may occupy \
+             the address; kill it before running this test"
+        );
+
+        let cfg = BootConfig::ext4_rw(kernel.into(), rootfs.into(), work_dir.clone())
+            .with_network(NetworkConfig::default_tap("forkd-tap0"));
+
+        // Boot the VM. Vm::boot blocks until Firecracker accepts
+        // InstanceStart but does NOT wait for guest userspace.
+        let vm = Vm::boot(&cfg).expect("boot VM");
+
+        // Poll the guest agent until it responds. The guest needs
+        // time to run forkd-init.sh and start the agent listener.
+        // Worst case is ~120s if the tap blocks SYN (2s connect_timeout
+        // × 60 iterations), but typically connection is refused and
+        // the loop completes in ~30s.
+        let mut connected = false;
+        for _ in 0..60 {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            if ping_at(addr).is_ok() {
+                connected = true;
+                break;
+            }
+        }
+        assert!(
+            connected,
+            "guest agent at {addr} did not respond within 30s; \
+             check console log at {}/fc.console",
+            work_dir.display()
+        );
+
+        // Read the active clocksource from inside the VM.
+        let resp = exec_at(
+            addr,
+            vec![
+                "cat".into(),
+                "/sys/devices/system/clocksource/clocksource0/current_clocksource".into(),
+            ],
+            std::time::Duration::from_secs(10),
+        )
+        .expect("exec clocksource check");
+
+        assert_eq!(
+            resp.exit_code, 0,
+            "cat clocksource failed with exit {}:\n{}",
+            resp.exit_code, resp.stderr
+        );
+        let clocksource = resp.stdout.trim();
+        assert_eq!(
+            clocksource, "kvm-clock",
+            "expected clocksource=kvm-clock but guest reports '{clocksource}' \
+             — the kernel may have switched to TSC despite the boot parameter; \
+             check if the guest kernel supports clocksource=kvm-clock"
+        );
+
+        // Verify the symptom: guest wall clock should match the host
+        // (within a tolerance). This catches the actual bug — stale
+        // TSC after snapshot restore makes the guest clock wrong by
+        // days/weeks. A fresh boot with kvm-clock should be within a
+        // few seconds of the host.
+        //
+        // Note: this test boots a fresh VM, not a snapshot-restored
+        // one. The snapshot-restore path (where stale TSC actually
+        // manifests) is not directly tested here — that would require
+        // creating a snapshot, restoring it, and re-checking. This
+        // test verifies the *mechanism* (clocksource stays kvm-clock)
+        // and the *symptom on fresh boot* (correct wall clock). A
+        // follow-up restore-path test would close the remaining gap.
+        let host_time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("host time before epoch")
+            .as_secs();
+        let time_resp = exec_at(
+            addr,
+            vec!["date".into(), "-u".into(), "+%s".into()],
+            std::time::Duration::from_secs(10),
+        )
+        .expect("exec date check");
+        assert_eq!(
+            time_resp.exit_code, 0,
+            "date command failed with exit {}: {}",
+            time_resp.exit_code, time_resp.stderr
+        );
+        let guest_time: u64 = time_resp
+            .stdout
+            .trim()
+            .parse()
+            .expect("guest date output is not a valid epoch");
+        let drift = host_time.abs_diff(guest_time);
+        assert!(
+            drift <= 5,
+            "guest wall clock drifts {drift}s from host (host={host_time}, guest={guest_time}) \
+             — kvm-clock should keep the guest synced to the host; \
+             large drift indicates the clocksource is not working as expected"
+        );
+
+        // Vm::drop kills firecracker and removes the socket.
+        // WorkDirGuard drops work_dir.
+        drop(vm);
     }
 }

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -776,6 +776,7 @@ pub fn ping_at(addr: &str) -> Result<serde_json::Value> {
 /// Used by tests to determine whether KVM_CLOCK_REALTIME is available
 /// (needs kernel ≥ 5.16). Returns `None` if `/proc/sys/kernel/osrelease`
 /// cannot be read (non-Linux).
+#[cfg(test)]
 fn host_kernel_release() -> Option<String> {
     #[cfg(target_os = "linux")]
     {
@@ -794,6 +795,7 @@ fn host_kernel_release() -> Option<String> {
 /// On x86 this makes kvm-clock auto-correct to host wall time on
 /// snapshot restore; on older kernels the restored kvm-clock stays
 /// stale and needs a complementary guest-side correction (PR #300).
+#[cfg(test)]
 fn kernel_supports_kvm_clock_realtime(release: &str) -> bool {
     // Parse the first two numeric components of the release string.
     let parts: Vec<&str> = release.split('.').collect();

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -2659,7 +2659,7 @@ mod tests {
             fork_result.children.len()
         );
 
-        let mut restored_vm = fork_result.children.into_iter().next().unwrap();
+        let restored_vm = fork_result.children.into_iter().next().unwrap();
 
         // Wait for guest agent on the restored VM
         let mut connected = false;

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -772,6 +772,39 @@ pub fn ping_at(addr: &str) -> Result<serde_json::Value> {
     Ok(v)
 }
 
+/// Get the host kernel release string (e.g. "6.1.0-foo").
+/// Used by tests to determine whether KVM_CLOCK_REALTIME is available
+/// (needs kernel ≥ 5.16). Returns `None` if `/proc/sys/kernel/osrelease`
+/// cannot be read (non-Linux).
+fn host_kernel_release() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .ok()
+            .map(|s| s.trim().to_string())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// Parse a kernel release string (e.g. "5.15.0-foo", "6.1.0-bar") and
+/// return whether the kernel supports `KVM_CLOCK_REALTIME` (≥ 5.16).
+/// On x86 this makes kvm-clock auto-correct to host wall time on
+/// snapshot restore; on older kernels the restored kvm-clock stays
+/// stale and needs a complementary guest-side correction (PR #300).
+fn kernel_supports_kvm_clock_realtime(release: &str) -> bool {
+    // Parse the first two numeric components of the release string.
+    let parts: Vec<&str> = release.split('.').collect();
+    if parts.len() < 2 {
+        return false;
+    }
+    let major: u32 = parts[0].parse().unwrap_or(0);
+    let minor: u32 = parts[1].parse().unwrap_or(0);
+    major > 5 || (major == 5 && minor >= 16)
+}
+
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
@@ -1820,6 +1853,19 @@ mod tests {
         }
     }
 
+    #[test]
+    fn kernel_supports_kvm_clock_realtime_parses_versions() {
+        assert!(!kernel_supports_kvm_clock_realtime("5.10.0-foo"));
+        assert!(!kernel_supports_kvm_clock_realtime("5.15.0-foo"));
+        assert!(kernel_supports_kvm_clock_realtime("5.16.0-foo"));
+        assert!(kernel_supports_kvm_clock_realtime("5.16.1-foo"));
+        assert!(kernel_supports_kvm_clock_realtime("6.1.0-foo"));
+        assert!(kernel_supports_kvm_clock_realtime("6.1.141"));
+        assert!(!kernel_supports_kvm_clock_realtime("5.14.0-foo"));
+        assert!(!kernel_supports_kvm_clock_realtime("garbage"));
+        assert!(!kernel_supports_kvm_clock_realtime(""));
+    }
+
     // #261: a deadline-bounded accept must give up instead of hanging
     // forever when no peer ever connects.
     #[test]
@@ -2624,12 +2670,17 @@ mod tests {
         // The tap device persists (pre-created by scripts/host-tap.sh).
         drop(vm);
 
-        // Wait a few seconds so any stale clock would be visibly wrong.
-        // On modern kernels with KVM_CLOCK_REALTIME, kvm-clock
-        // auto-corrects on restore, so this wait doesn't affect
-        // correctness. On older kernels, the restored clock would be
-        // off by this amount (which is why PR #300 exists).
-        std::thread::sleep(std::time::Duration::from_secs(3));
+        // Wait comfortably longer than the allowed drift so a guest
+        // that simply resumes at the saved timestamp is caught. On
+        // modern kernels (≥ 5.16) KVM_CLOCK_REALTIME makes kvm-clock
+        // auto-correct on restore, so this wait doesn't affect
+        // correctness. On older kernels (5.10/5.15) the restored clock
+        // would be off by ~this amount, and the drift assertion will
+        // fail — directing the operator to PR #300 for the complementary
+        // guest-side fix. The wait must be comfortably larger than the
+        // allowed drift (≤ 2 s) so a stale clock cannot pass by accident.
+        let wait_secs: u64 = 20;
+        std::thread::sleep(std::time::Duration::from_secs(wait_secs));
 
         // --- Phase 3: Restore from snapshot and verify kvm-clock ---
 
@@ -2697,9 +2748,12 @@ mod tests {
 
         // Verify wall clock is correct after restore. On modern x86
         // (≥ 5.16), KVM_CLOCK_REALTIME makes kvm-clock auto-correct to
-        // host time on restore. On older kernels, the clock would be
-        // stale — that gap is addressed by PR #300 (guest-side date -s
-        // after restore).
+        // host time on restore. On older kernels (5.10/5.15),
+        // KVM_CLOCK_REALTIME is unavailable and the restored kvm-clock
+        // stays stale — that gap is addressed by PR #300 (guest-side
+        // date -s after restore). We detect the host kernel version
+        // here so the behavior is explicit rather than silent.
+        let host_kernel = host_kernel_release();
         let host_time = std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .expect("host time before epoch")
@@ -2713,13 +2767,40 @@ mod tests {
         assert_eq!(time_resp.exit_code, 0, "date failed: {}", time_resp.stderr);
         let guest_time: u64 = time_resp.stdout.trim().parse().expect("parse guest time");
         let drift = host_time.abs_diff(guest_time);
-        assert!(
-            drift <= 5,
-            "guest wall clock drifts {drift}s from host after restore \
-             (host={host_time}, guest={guest_time}) — on modern kernels (≥ 5.16) \
-             KVM_CLOCK_REALTIME should auto-correct kvm-clock; if this fails on \
-             an older kernel, that's expected — see PR #300 for the complementary fix"
-        );
+
+        // The wait (20 s) is comfortably larger than the allowed drift
+        // (2 s), so a guest that resumes at the saved timestamp
+        // (~20 s in the past) cannot pass by accident.
+        let max_drift: u64 = 2;
+        let modern = host_kernel
+            .as_ref()
+            .map(|k| kernel_supports_kvm_clock_realtime(k))
+            .unwrap_or(true); // assume modern if we can't detect
+        if modern {
+            assert!(
+                drift <= max_drift,
+                "guest wall clock drifts {drift}s from host after restore \
+                 (host={host_time}, guest={guest_time}, kernel={host_kernel:?}) — \
+                 KVM_CLOCK_REALTIME (kernel ≥ 5.16) should auto-correct kvm-clock \
+                 on restore; drift > {max_drift}s means the correction is not working"
+            );
+        } else {
+            // On older kernels (5.10/5.15) KVM_CLOCK_REALTIME is
+            // unavailable. The boot-arg fix alone is insufficient —
+            // the guest clock stays stale after restore. This is the
+            // documented gap that PR #300 (guest-side date -s) fills.
+            // We still assert so the limitation is visible, but the
+            // message points to the complementary fix.
+            assert!(
+                drift <= max_drift,
+                "guest wall clock drifts {drift}s from host after restore \
+                 (host={host_time}, guest={guest_time}, kernel={host_kernel:?}) — \
+                 this kernel does not support KVM_CLOCK_REALTIME (needs ≥ 5.16); \
+                 the boot-arg fix alone cannot correct the clock on restore. \
+                 PR #300 (guest-side date -s after restore) is required for \
+                 this kernel range"
+            );
+        }
 
         // Clean up
         drop(restored_vm);


### PR DESCRIPTION
## Summary

Related to #288. This is a defense-in-depth fix for modern x86 hosts; it does not fully close #288 on older kernels or aarch64.

Forces `clocksource=kvm-clock` in both guest kernel boot configurations to prevent the kernel from switching to a TSC that is stale after snapshot restore.

## Scope

- Adds `clocksource=kvm-clock` to `quickstart()` and `ext4_rw()`.
- Keeps it as the final `clocksource=` override.
- Adds unit coverage plus an ignored boot → snapshot → wait 20s → restore hardware test with a 2s drift tolerance.
- Detects whether the host kernel supports `KVM_CLOCK_REALTIME` (Linux 5.16+).

This is forward-only for snapshots: existing snapshots must be re-baked with `forkd from-image`. Older kernels and aarch64 still require a general restore-time correction, so #288 must remain open.

## Verification

- Rust CI passes on the reviewed implementation.
- The real Firecracker test remains `#[ignore]` because it requires Linux, KVM, Firecracker, a kernel image, rootfs, and TAP setup.