### PR TITLE
fix(agent): use container PATH from /etc/environment for subprocess calls

### DIFF
--- a/rootfs-init/forkd-agent.py
+++ b/rootfs-init/forkd-agent.py
@@ -81,7 +81,7 @@ def _load_container_env(path: str = "/etc/environment") -> dict:
                 if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
                     val = val[1:-1]
                 env[key] = val
-    except FileNotFoundError:
+    except OSError:
         pass
     return env
 
@@ -91,7 +91,7 @@ def _load_container_env(path: str = "/etc/environment") -> dict:
 # container's value.  Callers can still override individual vars per
 # command — see _subprocess_env() below.
 _CONTAINER_ENV = _load_container_env()
-_CONTAINER_PATH = _CONTAINER_ENV.get("PATH", _DEFAULT_PATH)
+_CONTAINER_PATH = _CONTAINER_ENV.get("PATH") or _DEFAULT_PATH
 GUEST_ENV = dict(os.environ)
 GUEST_ENV["PATH"] = _CONTAINER_PATH
 # Carry over any other /etc/environment vars not already in environ.
@@ -100,18 +100,16 @@ for _k, _v in _CONTAINER_ENV.items():
         GUEST_ENV[_k] = _v
 
 
-def _subprocess_env(caller_env: dict | None = None) -> dict | None:
+def _subprocess_env(caller_env: dict | None = None) -> dict:
     """Build the env dict for a subprocess call.
 
     If the caller provides an env, it is merged on top of GUEST_ENV so
     that PATH (and other container defaults) are still present unless
     the caller explicitly overrides them.  If the caller provides
-    nothing, GUEST_ENV is returned as-is.  Returns None only if both
-    GUEST_ENV is empty and caller_env is None (which won't happen in
-    practice — GUEST_ENV always has at least PATH).
+    nothing, a copy of GUEST_ENV is returned.
     """
     if caller_env is None:
-        return GUEST_ENV
+        return dict(GUEST_ENV)
     merged = dict(GUEST_ENV)
     merged.update(caller_env)
     return merged
@@ -204,6 +202,7 @@ def _start_warmup() -> None:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             bufsize=0,
+            env=GUEST_ENV,
         )
     except Exception as e:
         print(f"forkd: failed to spawn warmup: {e}", flush=True)

--- a/rootfs-init/forkd-agent.py
+++ b/rootfs-init/forkd-agent.py
@@ -39,6 +39,83 @@ import threading
 import time
 import traceback
 
+# ---------------------------------------------------------------------------
+# Container environment
+#
+# forkd-agent runs as PID 1 inside the sandbox VM.  Its own environment is
+# inherited from the kernel boot / init script, which may leak host PATH
+# values (e.g. /opt/homebrew/bin, /Users/.../.cargo/bin) into the guest.
+# Every exec/stream command would then resolve binaries against the host
+# PATH instead of the container's, causing "command not found" or silent
+# wrong-binary usage.
+#
+# To fix this we read /etc/environment (the standard Linux system-wide
+# env file, written by pam_env and most Docker/base images) at startup
+# and use its PATH as the default for all subprocess calls.  If the file
+# is missing or has no PATH, we fall back to a sane Linux default.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+
+def _load_container_env(path: str = "/etc/environment") -> dict:
+    """Parse /etc/environment for KEY=VALUE pairs (pam_env format).
+
+    Unlike shell scripts, /etc/environment has no `export` keyword and
+    no command substitution — just simple KEY=VALUE lines, optionally
+    quoted.  This is the canonical source of system-wide environment
+    defaults on Linux.
+    """
+    env: dict = {}
+    try:
+        with open(path) as f:
+            for raw in f:
+                s = raw.strip()
+                if not s or s.startswith("#"):
+                    continue
+                key, sep, val = s.partition("=")
+                if not sep:
+                    continue
+                key = key.strip()
+                val = val.strip()
+                if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+                    val = val[1:-1]
+                env[key] = val
+    except FileNotFoundError:
+        pass
+    return env
+
+
+# Base environment for all subprocess calls: start from the agent's own
+# environ (to keep HOME, USER, etc.) but override PATH with the
+# container's value.  Callers can still override individual vars per
+# command — see _subprocess_env() below.
+_CONTAINER_ENV = _load_container_env()
+_CONTAINER_PATH = _CONTAINER_ENV.get("PATH", _DEFAULT_PATH)
+GUEST_ENV = dict(os.environ)
+GUEST_ENV["PATH"] = _CONTAINER_PATH
+# Carry over any other /etc/environment vars not already in environ.
+for _k, _v in _CONTAINER_ENV.items():
+    if _k not in GUEST_ENV:
+        GUEST_ENV[_k] = _v
+
+
+def _subprocess_env(caller_env: dict | None = None) -> dict | None:
+    """Build the env dict for a subprocess call.
+
+    If the caller provides an env, it is merged on top of GUEST_ENV so
+    that PATH (and other container defaults) are still present unless
+    the caller explicitly overrides them.  If the caller provides
+    nothing, GUEST_ENV is returned as-is.  Returns None only if both
+    GUEST_ENV is empty and caller_env is None (which won't happen in
+    practice — GUEST_ENV always has at least PATH).
+    """
+    if caller_env is None:
+        return GUEST_ENV
+    merged = dict(GUEST_ENV)
+    merged.update(caller_env)
+    return merged
+
 # Optional warm-up: importing numpy into PID 1's memory is the canonical
 # demo of "fork from warmed state". If the image doesn't have numpy, we
 # still serve the agent — just without that particular warm import.
@@ -237,13 +314,19 @@ def handle(conn: socket.socket, addr) -> None:
                     "pid": os.getpid(),
                     "agent_lang": AGENT_LANG,
                     "warmup_ready": _warmup_ready,
+                    "path": _CONTAINER_PATH,
                 },
             )
 
         elif action == "exec":
             args = cmd["args"]
             timeout = cmd.get("timeout", 30)
-            r = subprocess.run(args, capture_output=True, timeout=timeout)
+            r = subprocess.run(
+                args,
+                capture_output=True,
+                timeout=timeout,
+                env=_subprocess_env(cmd.get("env")),
+            )
             _send_json(
                 conn,
                 {

--- a/rootfs-init/tests/test_agent_env.py
+++ b/rootfs-init/tests/test_agent_env.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Unit tests for forkd-agent.py container environment helpers.
+
+Tests _load_container_env (parsing /etc/environment) and _subprocess_env
+(merging caller env on top of GUEST_ENV). These are pure-Python functions
+that don't require firecracker or a real rootfs.
+
+Run with: python3 -m pytest rootfs-init/tests/test_agent_env.py -v
+Or:      python3 rootfs-init/tests/test_agent_env.py
+"""
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+
+
+def _load_agent_module():
+    """Import forkd-agent.py as a module, handling its module-level side effects."""
+    # Save and restore os.environ to avoid test pollution
+    orig_env = dict(os.environ)
+    try:
+        # The agent reads /etc/environment at import time, so we point it at
+        # a temp file we control.
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.env', delete=False) as f:
+            f.write('PATH=/usr/local/test:/usr/bin\n')
+            f.write('CARGO_HOME=/usr/local/cargo\n')
+            f.write('# comment line\n')
+            f.write('EMPTY=\n')
+            env_path = f.name
+
+        # Patch the default path before import
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            'forkd_agent_test', os.path.join(os.path.dirname(__file__), '..', 'forkd-agent.py')
+        )
+        module = importlib.util.module_from_spec(spec)
+
+        # Monkey-p the default path argument
+        orig_open = open
+        def patched_open(path, *args, **kwargs):
+            if path == '/etc/environment':
+                return orig_open(env_path, *args, **kwargs)
+            return orig_open(path, *args, **kwargs)
+
+        import builtins
+        builtins.open = patched_open
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            builtins.open = orig_open
+
+        return module, env_path
+    finally:
+        os.environ.clear()
+        os.environ.update(orig_env)
+
+
+class TestLoadContainerEnv(unittest.TestCase):
+    """Test _load_container_env parsing of /etc/environment format."""
+
+    def setUp(self):
+        self.module, self.env_path = _load_agent_module()
+
+    def tearDown(self):
+        os.unlink(self.env_path)
+
+    def test_parses_simple_key_value(self):
+        """Simple KEY=VALUE pairs are parsed correctly."""
+        result = self.module._load_container_env(self.env_path)
+        self.assertEqual(result.get('CARGO_HOME'), '/usr/local/cargo')
+
+    def test_parses_path(self):
+        """PATH is parsed from /etc/environment."""
+        result = self.module._load_container_env(self.env_path)
+        self.assertEqual(result.get('PATH'), '/usr/local/test:/usr/bin')
+
+    def test_skips_comments(self):
+        """Comment lines starting with # are skipped."""
+        result = self.module._load_container_env(self.env_path)
+        self.assertNotIn('# comment', result)
+
+    def test_empty_value(self):
+        """Empty values are preserved as empty strings."""
+        result = self.module._load_container_env(self.env_path)
+        self.assertEqual(result.get('EMPTY'), '')
+
+    def test_missing_file_returns_empty(self):
+        """Missing file returns empty dict."""
+        result = self.module._load_container_env('/nonexistent/path/file')
+        self.assertEqual(result, {})
+
+    def test_quoted_values(self):
+        """Quoted values have their quotes stripped."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.env', delete=False) as f:
+            f.write('VAR1="double quoted"\n')
+            f.write("VAR2='single quoted'\n")
+            f.write('VAR3=unquoted\n')
+            qpath = f.name
+        try:
+            result = self.module._load_container_env(qpath)
+            self.assertEqual(result['VAR1'], 'double quoted')
+            self.assertEqual(result['VAR2'], 'single quoted')
+            self.assertEqual(result['VAR3'], 'unquoted')
+        finally:
+            os.unlink(qpath)
+
+    def test_equals_in_value(self):
+        """Values containing = are preserved (first = is the separator)."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.env', delete=False) as f:
+            f.write('URL=http://host:8080/path?a=b\n')
+            eqpath = f.name
+        try:
+            result = self.module._load_container_env(eqpath)
+            self.assertEqual(result['URL'], 'http://host:8080/path?a=b')
+        finally:
+            os.unlink(eqpath)
+
+    def test_lines_without_equals_skipped(self):
+        """Lines without = are silently skipped."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.env', delete=False) as f:
+            f.write('no_equals_here\n')
+            f.write('GOOD=value\n')
+            nepath = f.name
+        try:
+            result = self.module._load_container_env(nepath)
+            self.assertEqual(result, {'GOOD': 'value'})
+        finally:
+            os.unlink(nepath)
+
+
+class TestSubprocessEnv(unittest.TestCase):
+    """Test _subprocess_env merge semantics."""
+
+    def setUp(self):
+        self.module, self.env_path = _load_agent_module()
+
+    def tearDown(self):
+        os.unlink(self.env_path)
+
+    def test_none_returns_copy_of_guest_env(self):
+        """None caller_env returns a copy of GUEST_ENV."""
+        result = self.module._subprocess_env(None)
+        self.assertIn('PATH', result)
+        self.assertEqual(result['PATH'], '/usr/local/test:/usr/bin')
+        # Verify it's a copy, not the original
+        result['TEST_KEY'] = 'test'
+        self.assertNotIn('TEST_KEY', self.module.GUEST_ENV)
+
+    def test_caller_env_merged(self):
+        """Caller env is merged on top of GUEST_ENV."""
+        caller = {'CUSTOM': 'value'}
+        result = self.module._subprocess_env(caller)
+        self.assertEqual(result['CUSTOM'], 'value')
+        self.assertIn('PATH', result)
+
+    def test_caller_path_overrides(self):
+        """Caller can override PATH."""
+        caller = {'PATH': '/override:/bin'}
+        result = self.module._subprocess_env(caller)
+        self.assertEqual(result['PATH'], '/override:/bin')
+
+    def test_guest_env_vars_preserved(self):
+        """Non-PATH GUEST_ENV vars are preserved when caller provides env."""
+        caller = {'EXTRA': 'val'}
+        result = self.module._subprocess_env(caller)
+        self.assertIn('CARGO_HOME', result)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -94,9 +94,12 @@ $SUDO du -sh "$WORK"
 # no PATH in /etc/environment and fall back to a default that misses
 # tool-specific directories, causing "command not found" for cargo, go, etc.
 IMAGE_PATH=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$CONTAINER" 2>/dev/null \
-    | grep '^PATH=' | head -1 | cut -d= -f2- || true)
+    | grep '^PATH=' | tail -1 | cut -d= -f2- || true)
 if [ -n "$IMAGE_PATH" ]; then
     say "    materializing Docker PATH into /etc/environment"
+    # Defense-in-depth: break symlinks before writing (a malicious image
+    # could symlink /etc/environment to a host file).
+    [ -L "$WORK/etc/environment" ] && $SUDO rm -f "$WORK/etc/environment"
     $SUDO touch "$WORK/etc/environment"
     $SUDO sed -i '/^PATH=/d' "$WORK/etc/environment" 2>/dev/null || true
     echo "PATH=$IMAGE_PATH" | $SUDO tee -a "$WORK/etc/environment" >/dev/null

--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -85,6 +85,25 @@ mkdir -p "$WORK"
 docker export "$CONTAINER" | $SUDO tar -xf - -C "$WORK"
 $SUDO du -sh "$WORK"
 
+# Materialize the Docker image's Config.Env PATH into /etc/environment.
+# docker export gives us the filesystem contents but NOT the image's
+# configured environment variables.  For images like rust:latest or
+# golang:1.25, tool directories (e.g. /usr/local/cargo/bin,
+# /usr/local/go/bin) exist only in Config.Env, not in /etc/environment.
+# Without this step, the guest agent's _load_container_env() would find
+# no PATH in /etc/environment and fall back to a default that misses
+# tool-specific directories, causing "command not found" for cargo, go, etc.
+IMAGE_PATH=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$CONTAINER" 2>/dev/null \
+    | grep '^PATH=' | head -1 | cut -d= -f2- || true)
+if [ -n "$IMAGE_PATH" ]; then
+    say "    materializing Docker PATH into /etc/environment"
+    $SUDO touch "$WORK/etc/environment"
+    $SUDO sed -i '/^PATH=/d' "$WORK/etc/environment" 2>/dev/null || true
+    echo "PATH=$IMAGE_PATH" | $SUDO tee -a "$WORK/etc/environment" >/dev/null
+else
+    say "    no PATH found in Docker Config.Env, keeping existing /etc/environment"
+fi
+
 # ----------------------------------------------------------------------------
 if [ "${#EXTRA_PKGS[@]}" -gt 0 ]; then
     say "[3/5] chroot apt install: ${EXTRA_PKGS[*]}"


### PR DESCRIPTION
## Summary

`forkd-agent.py` (PID 1 inside every sandbox VM) executes commands via the `exec` action using `subprocess.run()` with no `env=` parameter. The subprocess inherits the host's PATH instead of the container's, making container-installed tools at non-standard locations invisible (e.g. Go at `/usr/local/go/bin`, Rust at `/usr/local/cargo/bin`).

This caused CI-breaking failures: after a fresh Docker rebuild of the `go-base` forkd snapshot, CI test steps failed with `go: command not found` (exit 127).

## Changes

- Parse `/etc/environment` at agent startup (`_load_container_env()`) to get the container's PATH
- Build `GUEST_ENV` from `os.environ` with PATH overridden by the container value (fallback: `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`)
- Add `_subprocess_env(caller_env)` helper that merges caller env on top of `GUEST_ENV`
- Pass `env=_subprocess_env(cmd.get("env"))` to the `exec` handler's `subprocess.run()`
- Add `"path": _CONTAINER_PATH` to the `ping` response for debugging

## Test plan

- [ ] Boot a sandbox VM from a freshly-baked image, exec `go version` inside it — should find go at `/usr/local/go/bin`
- [ ] Boot a sandbox VM, exec `echo $PATH` — should show container PATH, not host PATH
- [ ] Boot a sandbox VM, ping — response should include `path` field with container PATH
- [ ] Boot a sandbox VM, exec with explicit `env: {"PATH": "/custom/bin"}` — should override container PATH

Closes #290.
