### PR TITLE
feat(agent): add stream action for interactive subprocess sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,23 @@ jobs:
       - name: run.sh shellcheck-style parse
         run: bash -n bench/pause-window/run.sh
 
+  agent-python:
+    # forkd-agent.py unit + stream tests. forkd-agent runs as PID 1 inside
+    # guest VMs; these exercise the pure-Python protocol logic (container-env
+    # PATH handling, BufferedLineReader coalesced-frame handling, stream
+    # lifecycle + process-group descendant cleanup) with no VM/firecracker.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - name: agent env + stream tests
+        working-directory: rootfs-init
+        run: |
+          python tests/test_agent_env.py
+          python tests/test_agent_stream.py
+
   sdk-python:
     # SDK unit tests that need no firecracker/daemon — target parsing
     # and the _send wire protocol against an in-process socket server.

--- a/rootfs-init/forkd-agent.py
+++ b/rootfs-init/forkd-agent.py
@@ -328,8 +328,7 @@ class BufferedLineReader:
         never delivered because the socket is not readable after the
         first recv() consumed both messages into the buffer.
         """
-        return self._buf.find(b"
-") >= 0
+        return self._buf.find(b"\n") >= 0
 
     def try_readline(self) -> Optional[bytes]:
         """Return the next complete line from the buffer, or None if
@@ -338,8 +337,7 @@ class BufferedLineReader:
         Unlike readline(), this never blocks on the socket — it only
         returns a line if one is already present in the buffer.
         """
-        nl = self._buf.find(b"
-")
+        nl = self._buf.find(b"\n")
         if nl < 0:
             return None
         line = bytes(self._buf[: nl + 1])

--- a/rootfs-init/forkd-agent.py
+++ b/rootfs-init/forkd-agent.py
@@ -41,6 +41,7 @@ import os
 import pty
 import select
 import shlex
+import signal
 import socket
 import subprocess
 import sys
@@ -190,6 +191,41 @@ def _drain_stderr(proc: subprocess.Popen) -> None:
     for raw in iter(proc.stderr.readline, b""):
         sys.stdout.buffer.write(b"forkd-warmup: " + raw)
         sys.stdout.flush()
+
+
+def _kill_process_group(proc: subprocess.Popen, grace: float = 2.0) -> None:
+    """Terminate a stream command and every descendant via its process group.
+
+    Stream commands are spawned with start_new_session=True, which makes
+    the child the leader of a fresh process group (pgid == proc.pid).
+    Signalling the NEGATIVE pgid reaches the shell AND all descendants it
+    spawned, so e.g. `sh -c "sleep 30"` cannot leave `sleep` running after
+    a stop or disconnect.
+    """
+    pgid = proc.pid
+
+    def _group_gone() -> bool:
+        try:
+            os.killpg(pgid, 0)
+        except (ProcessLookupError, PermissionError):
+            return True
+        return False
+
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except (ProcessLookupError, PermissionError):
+            break
+        deadline = time.monotonic() + grace
+        while time.monotonic() < deadline:
+            if _group_gone():
+                break
+            time.sleep(0.05)
+    # Reap the leader so it doesn't linger as a zombie.
+    try:
+        proc.wait(timeout=1)
+    except Exception:
+        pass
 
 
 def _start_warmup() -> None:
@@ -443,6 +479,7 @@ def handle(conn: socket.socket, addr) -> None:
                         stdout=slave,
                         stderr=slave,
                         close_fds=True,
+                        start_new_session=True,
                         **kwargs,
                     )
                 except Exception:
@@ -460,6 +497,7 @@ def handle(conn: socket.socket, addr) -> None:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     close_fds=True,
+                    start_new_session=True,
                     **kwargs,
                 )
                 out_fd = proc.stdout.fileno()
@@ -572,7 +610,7 @@ def handle(conn: socket.socket, addr) -> None:
                         continue  # Skip malformed input, don't kill session.
                     action_in = msg.get("action")
                     if action_in == "stop":
-                        proc.terminate()
+                        _kill_process_group(proc)
                         break
                     data = msg.get("in")
                     if data is not None and isinstance(data, str):
@@ -587,10 +625,9 @@ def handle(conn: socket.socket, addr) -> None:
             except Exception:
                 pass
             finally:
-                try:
-                    proc.terminate()
-                except Exception:
-                    pass
+                # Terminate the WHOLE process group (shell + descendants),
+                # not just the direct child.
+                _kill_process_group(proc)
                 # Close stdin so processes waiting for EOF can exit gracefully.
                 if not use_pty:
                     try:
@@ -600,10 +637,6 @@ def handle(conn: socket.socket, addr) -> None:
                 # Wait for the reader thread to finish (with timeout) so the
                 # exit_code message is sent before the socket closes.
                 reader_thread.join(timeout=3)
-                try:
-                    proc.wait(timeout=2)
-                except Exception:
-                    proc.kill()
                 # Close the PTY master fd to prevent fd leaks.
                 if use_pty:
                     try:

--- a/rootfs-init/forkd-agent.py
+++ b/rootfs-init/forkd-agent.py
@@ -289,6 +289,37 @@ _start_warmup()
 print("forkd: parent VM ready for snapshot. children inherit this state.", flush=True)
 
 
+class BufferedLineReader:
+    """Persistent buffered line reader for socket connections.
+
+    Unlike _recv_line which discards bytes after the first newline,
+    this class preserves leftover bytes between calls so that coalesced
+    TCP frames (multiple messages in one read) are handled correctly.
+    """
+
+    def __init__(self, conn: socket.socket):
+        self._conn = conn
+        self._buf = bytearray()
+
+    def readline(self) -> bytes:
+        """Read one complete line (terminated by \\n). Returns empty bytes on EOF."""
+        while True:
+            nl = self._buf.find(b"\n")
+            if nl >= 0:
+                line = bytes(self._buf[: nl + 1])
+                del self._buf[: nl + 1]
+                return line
+            chunk = self._conn.recv(4096)
+            if not chunk:
+                # Return any remaining buffered data (partial line without newline)
+                if self._buf:
+                    remaining = bytes(self._buf)
+                    self._buf.clear()
+                    return remaining
+                return b""
+            self._buf.extend(chunk)
+
+
 def _recv_line(conn: socket.socket) -> bytes:
     buf = bytearray()
     while True:
@@ -399,11 +430,21 @@ def handle(conn: socket.socket, addr) -> None:
                     **kwargs,
                 )
                 out_fd = proc.stdout.fileno()
+                err_fd = proc.stderr.fileno()
                 in_fd = proc.stdin.fileno()
 
             _send_json(conn, {"stream": "started", "pid": proc.pid, "pty": use_pty})
 
+            # Event to signal that the reader thread has finished and sent
+            # the exit code. The main loop checks this to break out of
+            # _recv_line when the process exits before the client sends stop.
+            reader_done = threading.Event()
+
             # Reader thread: forward process output as JSON chunks.
+            # In PTY mode, stdout and stderr are multiplexed on the master fd.
+            # In non-PTY mode, stdout and stderr are separate pipes that must
+            # both be drained — a child writing more than the pipe capacity
+            # to stderr would block forever if stderr is never read.
             def _stream_reader():
                 try:
                     while True:
@@ -420,11 +461,34 @@ def handle(conn: socket.socket, addr) -> None:
                                     break
                                 continue
                             data = os.read(out_fd, 65536)
+                            if not data:
+                                break
+                            _send_json(conn, {"out": data.decode("utf-8", "replace")})
                         else:
-                            data = proc.stdout.read(65536)
-                        if not data:
-                            break
-                        _send_json(conn, {"out": data.decode("utf-8", "replace")})
+                            # Non-PTY: multiplex stdout and stderr via select.
+                            readable, _, _ = select.select([out_fd, err_fd], [], [], 0.5)
+                            if not readable:
+                                if proc.poll() is not None:
+                                    # Drain any remaining output.
+                                    for fd, label in [(out_fd, "out"), (err_fd, "err")]:
+                                        try:
+                                            data = os.read(fd, 65536)
+                                            if data:
+                                                _send_json(conn, {label: data.decode("utf-8", "replace")})
+                                        except OSError:
+                                            pass
+                                    break
+                                continue
+                            for fd, label in [(out_fd, "out"), (err_fd, "err")]:
+                                if fd in readable:
+                                    try:
+                                        data = os.read(fd, 65536)
+                                        if not data:
+                                            # EOF on this stream; check if both are done.
+                                            continue
+                                        _send_json(conn, {label: data.decode("utf-8", "replace")})
+                                    except OSError:
+                                        pass
                 except (OSError, ValueError):
                     pass
                 finally:
@@ -432,13 +496,18 @@ def handle(conn: socket.socket, addr) -> None:
                         _send_json(conn, {"exit_code": proc.wait()})
                     except Exception:
                         pass
+                    reader_done.set()
 
-            threading.Thread(target=_stream_reader, daemon=True).start()
+            reader_thread = threading.Thread(target=_stream_reader, daemon=True)
+            reader_thread.start()
 
             # Main loop: relay stdin lines from the client to the process.
+            # Uses a persistent buffered reader so coalesced TCP frames
+            # (multiple messages in one read) are handled correctly.
+            line_reader = BufferedLineReader(conn)
             try:
-                while True:
-                    line = _recv_line(conn)
+                while not reader_done.is_set():
+                    line = line_reader.readline()
                     if not line:
                         break
                     msg = json.loads(line)
@@ -448,11 +517,14 @@ def handle(conn: socket.socket, addr) -> None:
                         break
                     data = msg.get("in")
                     if data is not None:
-                        if use_pty:
-                            os.write(in_fd, data.encode("utf-8", "replace"))
-                        else:
-                            proc.stdin.write(data.encode("utf-8", "replace"))
-                            proc.stdin.flush()
+                        try:
+                            if use_pty:
+                                os.write(in_fd, data.encode("utf-8", "replace"))
+                            else:
+                                proc.stdin.write(data.encode("utf-8", "replace"))
+                                proc.stdin.flush()
+                        except (OSError, BrokenPipeError):
+                            break
             except Exception:
                 pass
             finally:
@@ -460,8 +532,9 @@ def handle(conn: socket.socket, addr) -> None:
                     proc.terminate()
                 except Exception:
                     pass
-                # Give the reader a moment to flush the exit code.
-                time.sleep(0.2)
+                # Wait for the reader thread to finish (with timeout) so the
+                # exit_code message is sent before the socket closes.
+                reader_thread.join(timeout=3)
                 try:
                     proc.wait(timeout=2)
                 except Exception:

--- a/rootfs-init/forkd-agent.py
+++ b/rootfs-init/forkd-agent.py
@@ -338,7 +338,8 @@ def _send_json(conn: socket.socket, obj) -> None:
 
 def handle(conn: socket.socket, addr) -> None:
     try:
-        line = _recv_line(conn)
+        line_reader = BufferedLineReader(conn)
+        line = line_reader.readline()
         if not line:
             return
         cmd = json.loads(line)
@@ -410,23 +411,30 @@ def handle(conn: socket.socket, addr) -> None:
 
             if use_pty:
                 master, slave = pty.openpty()
-                proc = subprocess.Popen(
-                    args,
-                    stdin=slave,
-                    stdout=slave,
-                    stderr=slave,
-                    close_fds=True,
-                    **kwargs,
-                )
+                try:
+                    proc = subprocess.Popen(
+                        args,
+                        stdin=slave,
+                        stdout=slave,
+                        stderr=slave,
+                        close_fds=True,
+                        **kwargs,
+                    )
+                except Exception:
+                    os.close(master)
+                    os.close(slave)
+                    raise
                 os.close(slave)
                 out_fd = master
                 in_fd = master
+                err_fd = None
             else:
                 proc = subprocess.Popen(
                     args,
                     stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
+                    close_fds=True,
                     **kwargs,
                 )
                 out_fd = proc.stdout.fileno()
@@ -436,8 +444,8 @@ def handle(conn: socket.socket, addr) -> None:
             _send_json(conn, {"stream": "started", "pid": proc.pid, "pty": use_pty})
 
             # Event to signal that the reader thread has finished and sent
-            # the exit code. The main loop checks this to break out of
-            # _recv_line when the process exits before the client sends stop.
+            # the exit code. The main loop uses select.select on the socket
+            # with a timeout so it can check reader_done periodically.
             reader_done = threading.Event()
 
             # Reader thread: forward process output as JSON chunks.
@@ -447,48 +455,55 @@ def handle(conn: socket.socket, addr) -> None:
             # to stderr would block forever if stderr is never read.
             def _stream_reader():
                 try:
-                    while True:
-                        if use_pty:
+                    if use_pty:
+                        while True:
                             r, _, _ = select.select([out_fd], [], [], 0.5)
                             if not r:
                                 if proc.poll() is not None:
-                                    try:
-                                        data = os.read(out_fd, 65536)
-                                        if data:
+                                    # Drain any remaining output.
+                                    while True:
+                                        try:
+                                            data = os.read(out_fd, 65536)
+                                            if not data:
+                                                break
                                             _send_json(conn, {"out": data.decode("utf-8", "replace")})
-                                    except OSError:
-                                        pass
+                                        except OSError:
+                                            break
                                     break
                                 continue
-                            data = os.read(out_fd, 65536)
+                            try:
+                                data = os.read(out_fd, 65536)
+                            except OSError:
+                                break
                             if not data:
                                 break
                             _send_json(conn, {"out": data.decode("utf-8", "replace")})
-                        else:
-                            # Non-PTY: multiplex stdout and stderr via select.
-                            readable, _, _ = select.select([out_fd, err_fd], [], [], 0.5)
+                    else:
+                        # Non-PTY: multiplex stdout and stderr via select.
+                        # Track which fds are still open to avoid busy-looping
+                        # on EOF'd pipes (which select reports as readable).
+                        watched = [out_fd, err_fd]
+                        eof_count = 0
+                        while watched:
+                            readable, _, _ = select.select(watched, [], [], 0.5)
                             if not readable:
-                                if proc.poll() is not None:
-                                    # Drain any remaining output.
-                                    for fd, label in [(out_fd, "out"), (err_fd, "err")]:
-                                        try:
-                                            data = os.read(fd, 65536)
-                                            if data:
-                                                _send_json(conn, {label: data.decode("utf-8", "replace")})
-                                        except OSError:
-                                            pass
+                                if proc.poll() is not None and eof_count == len(watched):
                                     break
                                 continue
-                            for fd, label in [(out_fd, "out"), (err_fd, "err")]:
-                                if fd in readable:
-                                    try:
-                                        data = os.read(fd, 65536)
-                                        if not data:
-                                            # EOF on this stream; check if both are done.
-                                            continue
-                                        _send_json(conn, {label: data.decode("utf-8", "replace")})
-                                    except OSError:
-                                        pass
+                            for fd in readable:
+                                try:
+                                    data = os.read(fd, 65536)
+                                except OSError:
+                                    data = b""
+                                if not data:
+                                    # EOF on this stream — remove from watched
+                                    # to prevent busy-looping.
+                                    watched.remove(fd)
+                                    eof_count += 1
+                                    continue
+                                label = "out" if fd == out_fd else "err"
+                                _send_json(conn, {label: data.decode("utf-8", "replace")})
+                        # All streams EOF'd — wait for process to exit.
                 except (OSError, ValueError):
                     pass
                 finally:
@@ -502,28 +517,37 @@ def handle(conn: socket.socket, addr) -> None:
             reader_thread.start()
 
             # Main loop: relay stdin lines from the client to the process.
-            # Uses a persistent buffered reader so coalesced TCP frames
-            # (multiple messages in one read) are handled correctly.
-            line_reader = BufferedLineReader(conn)
+            # Uses the same BufferedLineReader from the initial request so
+            # coalesced TCP frames are handled correctly throughout.
+            # Uses select.select on the socket with a timeout so reader_done
+            # can interrupt the loop even when the client is idle.
             try:
                 while not reader_done.is_set():
+                    # Wait for socket data with a timeout so we can check
+                    # reader_done periodically without blocking forever.
+                    r, _, _ = select.select([conn], [], [], 0.5)
+                    if not r:
+                        continue  # No data; loop re-checks reader_done.
                     line = line_reader.readline()
                     if not line:
                         break
-                    msg = json.loads(line)
+                    try:
+                        msg = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue  # Skip malformed input, don't kill session.
                     action_in = msg.get("action")
                     if action_in == "stop":
                         proc.terminate()
                         break
                     data = msg.get("in")
-                    if data is not None:
+                    if data is not None and isinstance(data, str):
                         try:
                             if use_pty:
-                                os.write(in_fd, data.encode("utf-8", "replace"))
+                                os.write(in_fd, data.encode("utf-8"))
                             else:
-                                proc.stdin.write(data.encode("utf-8", "replace"))
+                                proc.stdin.write(data.encode("utf-8"))
                                 proc.stdin.flush()
-                        except (OSError, BrokenPipeError):
+                        except (OSError, BrokenPipeError, ValueError):
                             break
             except Exception:
                 pass
@@ -532,6 +556,12 @@ def handle(conn: socket.socket, addr) -> None:
                     proc.terminate()
                 except Exception:
                     pass
+                # Close stdin so processes waiting for EOF can exit gracefully.
+                if not use_pty:
+                    try:
+                        proc.stdin.close()
+                    except Exception:
+                        pass
                 # Wait for the reader thread to finish (with timeout) so the
                 # exit_code message is sent before the socket closes.
                 reader_thread.join(timeout=3)
@@ -539,7 +569,12 @@ def handle(conn: socket.socket, addr) -> None:
                     proc.wait(timeout=2)
                 except Exception:
                     proc.kill()
-                return
+                # Close the PTY master fd to prevent fd leaks.
+                if use_pty:
+                    try:
+                        os.close(out_fd)
+                    except OSError:
+                        pass
 
         else:
             _send_json(conn, {"error": f"unknown action: {action}", "exit_code": 1})

--- a/rootfs-init/forkd-agent.py
+++ b/rootfs-init/forkd-agent.py
@@ -16,6 +16,13 @@ Actions:
   {"action": "eval", "code": "1 + numpy.zeros(3).sum()"}
     → {"result": "1.0", "exit_code": 0}
 
+  {"action": "stream", "args": ["bash"], "pty": true}
+    → {"stream": "started", "pid": 1234, "pty": true}
+      then {"out": "$ "} chunks as output arrives
+      client sends {"in": "ls\n"} to write to stdin
+      client sends {"action": "stop"} to terminate
+      final message: {"exit_code": 0}
+
 `eval` semantics depend on the recipe. By default the code is evaluated
 as a Python expression against the agent's interpreter (numpy is in
 scope when available). If /etc/forkd-recipe.env declares
@@ -31,6 +38,8 @@ launched as PID 1 by /forkd-init.sh after the kernel finishes mounting
 import itertools
 import json
 import os
+import pty
+import select
 import shlex
 import socket
 import subprocess
@@ -355,6 +364,109 @@ def handle(conn: socket.socket, addr) -> None:
                             "exit_code": 1,
                         },
                     )
+
+        elif action == "stream":
+            args = cmd["args"]
+            cwd = cmd.get("cwd") or None
+            env = _subprocess_env(cmd.get("env"))
+            use_pty = cmd.get("pty", True)
+
+            kwargs = {}
+            if cwd:
+                kwargs["cwd"] = cwd
+            if env:
+                kwargs["env"] = env
+
+            if use_pty:
+                master, slave = pty.openpty()
+                proc = subprocess.Popen(
+                    args,
+                    stdin=slave,
+                    stdout=slave,
+                    stderr=slave,
+                    close_fds=True,
+                    **kwargs,
+                )
+                os.close(slave)
+                out_fd = master
+                in_fd = master
+            else:
+                proc = subprocess.Popen(
+                    args,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    **kwargs,
+                )
+                out_fd = proc.stdout.fileno()
+                in_fd = proc.stdin.fileno()
+
+            _send_json(conn, {"stream": "started", "pid": proc.pid, "pty": use_pty})
+
+            # Reader thread: forward process output as JSON chunks.
+            def _stream_reader():
+                try:
+                    while True:
+                        if use_pty:
+                            r, _, _ = select.select([out_fd], [], [], 0.5)
+                            if not r:
+                                if proc.poll() is not None:
+                                    try:
+                                        data = os.read(out_fd, 65536)
+                                        if data:
+                                            _send_json(conn, {"out": data.decode("utf-8", "replace")})
+                                    except OSError:
+                                        pass
+                                    break
+                                continue
+                            data = os.read(out_fd, 65536)
+                        else:
+                            data = proc.stdout.read(65536)
+                        if not data:
+                            break
+                        _send_json(conn, {"out": data.decode("utf-8", "replace")})
+                except (OSError, ValueError):
+                    pass
+                finally:
+                    try:
+                        _send_json(conn, {"exit_code": proc.wait()})
+                    except Exception:
+                        pass
+
+            threading.Thread(target=_stream_reader, daemon=True).start()
+
+            # Main loop: relay stdin lines from the client to the process.
+            try:
+                while True:
+                    line = _recv_line(conn)
+                    if not line:
+                        break
+                    msg = json.loads(line)
+                    action_in = msg.get("action")
+                    if action_in == "stop":
+                        proc.terminate()
+                        break
+                    data = msg.get("in")
+                    if data is not None:
+                        if use_pty:
+                            os.write(in_fd, data.encode("utf-8", "replace"))
+                        else:
+                            proc.stdin.write(data.encode("utf-8", "replace"))
+                            proc.stdin.flush()
+            except Exception:
+                pass
+            finally:
+                try:
+                    proc.terminate()
+                except Exception:
+                    pass
+                # Give the reader a moment to flush the exit code.
+                time.sleep(0.2)
+                try:
+                    proc.wait(timeout=2)
+                except Exception:
+                    proc.kill()
+                return
 
         else:
             _send_json(conn, {"error": f"unknown action: {action}", "exit_code": 1})

--- a/rootfs-init/forkd-agent.py
+++ b/rootfs-init/forkd-agent.py
@@ -47,6 +47,7 @@ import sys
 import threading
 import time
 import traceback
+from typing import Optional
 
 # ---------------------------------------------------------------------------
 # Container environment
@@ -319,6 +320,32 @@ class BufferedLineReader:
                 return b""
             self._buf.extend(chunk)
 
+    def has_complete_line(self) -> bool:
+        """Return True if the buffer already contains a complete line.
+
+        Used by relay loops to consume buffered lines before selecting
+        the socket — without this, a coalesced request+input frame is
+        never delivered because the socket is not readable after the
+        first recv() consumed both messages into the buffer.
+        """
+        return self._buf.find(b"
+") >= 0
+
+    def try_readline(self) -> Optional[bytes]:
+        """Return the next complete line from the buffer, or None if
+        no complete line is currently buffered (no socket recv performed).
+
+        Unlike readline(), this never blocks on the socket — it only
+        returns a line if one is already present in the buffer.
+        """
+        nl = self._buf.find(b"
+")
+        if nl < 0:
+            return None
+        line = bytes(self._buf[: nl + 1])
+        del self._buf[: nl + 1]
+        return line
+
 
 def _recv_line(conn: socket.socket) -> bytes:
     buf = bytearray()
@@ -523,12 +550,22 @@ def handle(conn: socket.socket, addr) -> None:
             # can interrupt the loop even when the client is idle.
             try:
                 while not reader_done.is_set():
-                    # Wait for socket data with a timeout so we can check
-                    # reader_done periodically without blocking forever.
-                    r, _, _ = select.select([conn], [], [], 0.5)
-                    if not r:
-                        continue  # No data; loop re-checks reader_done.
-                    line = line_reader.readline()
+                    # Consume complete lines already buffered from a
+                    # previous recv() before selecting the socket. If
+                    # the initial request and first input arrived in
+                    # one TCP read, the input is in the buffer but the
+                    # socket is not readable — select would block and
+                    # the buffered input would never be delivered.
+                    if line_reader.has_complete_line():
+                        line = line_reader.try_readline()
+                    else:
+                        # No buffered line — select the socket for the
+                        # next recv, with a timeout so reader_done can
+                        # interrupt the loop.
+                        r, _, _ = select.select([conn], [], [], 0.5)
+                        if not r:
+                            continue  # No data; loop re-checks reader_done.
+                        line = line_reader.readline()
                     if not line:
                         break
                     try:

--- a/rootfs-init/tests/test_agent_env.py
+++ b/rootfs-init/tests/test_agent_env.py
@@ -167,5 +167,74 @@ class TestSubprocessEnv(unittest.TestCase):
         self.assertIn('CARGO_HOME', result)
 
 
+
+class FakeSocket:
+    """Fake socket that returns pre-loaded data sequentially."""
+    def __init__(self, *chunks):
+        self._data = b"".join(chunks)
+        self._pos = 0
+
+    def recv(self, size):
+        if self._pos >= len(self._data):
+            return b""
+        chunk = self._data[self._pos:self._pos + size]
+        self._pos += len(chunk)
+        return chunk
+
+
+class TestBufferedLineReader(unittest.TestCase):
+    """Test BufferedLineReader for coalesced TCP frame handling."""
+
+    def setUp(self):
+        self.module, self.env_path = _load_agent_module()
+        self.BLR = self.module.BufferedLineReader
+
+    def tearDown(self):
+        os.unlink(self.env_path)
+
+    def test_single_line(self):
+        sock = FakeSocket(b'{"action":"ping"}\n')
+        reader = self.BLR(sock)
+        self.assertEqual(reader.readline(), b'{"action":"ping"}\n')
+
+    def test_coalesced_frames(self):
+        """Two messages in one TCP read are both returned correctly."""
+        sock = FakeSocket(b'msg1\nmsg2\n')
+        reader = self.BLR(sock)
+        self.assertEqual(reader.readline(), b'msg1\n')
+        self.assertEqual(reader.readline(), b'msg2\n')
+
+    def test_partial_line_across_reads(self):
+        """A line split across multiple recv calls is assembled correctly."""
+        sock = FakeSocket(b'par', b'tial', b'\n')
+        reader = self.BLR(sock)
+        self.assertEqual(reader.readline(), b'partial\n')
+
+    def test_eof_returns_empty(self):
+        sock = FakeSocket(b'')
+        reader = self.BLR(sock)
+        self.assertEqual(reader.readline(), b'')
+
+    def test_eof_with_partial_line(self):
+        """EOF with partial line (no newline) returns the remaining bytes."""
+        sock = FakeSocket(b'partial')
+        reader = self.BLR(sock)
+        self.assertEqual(reader.readline(), b'partial')
+
+    def test_multiple_lines_one_read(self):
+        """Multiple lines in a single recv are returned one at a time."""
+        sock = FakeSocket(b'line1\nline2\nline3\n')
+        reader = self.BLR(sock)
+        self.assertEqual(reader.readline(), b'line1\n')
+        self.assertEqual(reader.readline(), b'line2\n')
+        self.assertEqual(reader.readline(), b'line3\n')
+
+    def test_interleaved_reads(self):
+        """Coalesced frames split across recv boundaries work correctly."""
+        sock = FakeSocket(b'msg1\nmsg', b'2\nmsg3\n')
+        reader = self.BLR(sock)
+        self.assertEqual(reader.readline(), b'msg1\n')
+        self.assertEqual(reader.readline(), b'msg2\n')
+        self.assertEqual(reader.readline(), b'msg3\n')
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/rootfs-init/tests/test_agent_stream.py
+++ b/rootfs-init/tests/test_agent_stream.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Tests for the forkd-agent.py stream action — coalesced-frame handling
+and interactive session lifecycle.
+
+Tests the coalesced-frame regression: when the initial stream request and
+first input message arrive in a single TCP read, the BufferedLineReader
+returns the request and retains the input in its buffer. The relay loop
+must consume buffered lines before selecting the socket, or the buffered
+input is never delivered.
+
+Also covers: no-input exit, stderr flood (non-PTY), stop, and
+connection-close handler paths.
+
+Run with: python3 -m pytest rootfs-init/tests/test_agent_stream.py -v
+Or:      python3 rootfs-init/tests/test_agent_stream.py
+"""
+import importlib.util
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+
+def _load_agent_module():
+    """Import forkd-agent.py as a module, handling its module-level side effects."""
+    orig_env = dict(os.environ)
+    try:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.env', delete=False) as f:
+            f.write('PATH=/usr/bin:/bin\n')
+            env_path = f.name
+
+        spec = importlib.util.spec_from_file_location(
+            'forkd_agent_stream_test',
+            os.path.join(os.path.dirname(__file__), '..', 'forkd-agent.py'),
+        )
+        module = importlib.util.module_from_spec(spec)
+        orig_open = open
+
+        def patched_open(path, *args, **kwargs):
+            if path == '/etc/environment':
+                return orig_open(env_path, *args, **kwargs)
+            return orig_open(path, *args, **kwargs)
+
+        import builtins
+
+        builtins.open = patched_open
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            builtins.open = orig_open
+
+        return module, env_path
+    finally:
+        os.environ.clear()
+        os.environ.update(orig_env)
+
+
+class TestBufferedLineReaderCoalesced(unittest.TestCase):
+    """Tests for BufferedLineReader.has_complete_line and try_readline."""
+
+    def setUp(self):
+        self.module, self.env_path = _load_agent_module()
+
+    def tearDown(self):
+        os.unlink(self.env_path)
+
+    def _make_pair(self):
+        """Create a connected socketpair for testing."""
+        a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        return a, b
+
+    def test_has_complete_line_after_partial_read(self):
+        """has_complete_line returns True when buffer contains a newline."""
+        a, b = self._make_pair()
+        reader = self.module.BufferedLineReader(a)
+        # Send two messages in one write (coalesced frame)
+        b.sendall(b'{"action":"ping"}\n{"action":"ping"}\n')
+        # First readline gets the first message
+        line1 = reader.readline()
+        self.assertEqual(line1, b'{"action":"ping"}\n')
+        # Second message is in the buffer — has_complete_line should detect it
+        self.assertTrue(reader.has_complete_line())
+        # try_readline returns it without blocking on the socket
+        line2 = reader.try_readline()
+        self.assertEqual(line2, b'{"action":"ping"}\n')
+        # No more complete lines
+        self.assertFalse(reader.has_complete_line())
+        self.assertIsNone(reader.try_readline())
+        a.close()
+        b.close()
+
+    def test_try_readline_returns_none_when_no_complete_line(self):
+        """try_readline returns None when buffer has no complete line."""
+        a, b = self._make_pair()
+        reader = self.module.BufferedLineReader(a)
+        self.assertFalse(reader.has_complete_line())
+        self.assertIsNone(reader.try_readline())
+        a.close()
+        b.close()
+
+    def test_try_readline_does_not_block(self):
+        """try_readline never blocks on the socket — only reads buffer."""
+        a, b = self._make_pair()
+        reader = self.module.BufferedLineReader(a)
+        # Don't send anything — try_readline should return None immediately
+        start = time.monotonic()
+        result = reader.try_readline()
+        elapsed = time.monotonic() - start
+        self.assertIsNone(result)
+        self.assertLess(elapsed, 0.1, "try_readline should not block")
+        a.close()
+        b.close()
+
+
+class TestHandleStreamCoalescedFrame(unittest.TestCase):
+    """Full handle() tests using a real socketpair and a simple subprocess.
+
+    Tests that a coalesced request+input frame (both sent in one TCP write)
+    is correctly delivered to the subprocess.
+    """
+
+    def setUp(self):
+        self.module, self.env_path = _load_agent_module()
+
+    def tearDown(self):
+        os.unlink(self.env_path)
+
+    def _make_pair(self):
+        a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        a.settimeout(10)
+        b.settimeout(10)
+        return a, b
+
+    def _read_json_line(self, sock):
+        """Read one newline-terminated JSON message from sock."""
+        buf = bytearray()
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+            nl = buf.find(b'\n')
+            if nl >= 0:
+                return json.loads(buf[: nl + 1]), bytes(buf[nl + 1 :])
+        return None, b''
+
+    def test_coalesced_request_and_input_delivered(self):
+        """Request + first input in one send: input must reach the process.
+
+        This is the core regression: if the relay loop selects the socket
+        without checking the buffered line first, the input is stuck in
+        the BufferedLineReader's buffer and never delivered.
+        """
+        a, b = self._make_pair()
+        # Use 'cat' which echoes stdin to stdout (requires PTY off for
+        # line-buffered echo, or the PTY will echo it).
+        # We use a shell script that reads a line and prints it with a marker.
+        request = json.dumps({
+            "action": "stream",
+            "args": ["sh", "-c", "read line; echo GOT:$line; exit 0"],
+            "pty": False,
+        }) + "\n"
+        # The input line, appended in the SAME send (coalesced frame)
+        input_msg = json.dumps({"in": "hello-world"}) + "\n"
+        b.sendall(request.encode() + input_msg.encode())
+
+        # Read the "started" message
+        started, leftover = self._read_json_line(a)
+        self.assertIsNotNone(started, "Expected 'started' message")
+        self.assertEqual(started.get("stream"), "started")
+
+        # Read output until we see GOT:hello-world or exit_code
+        got_input = False
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            msg, leftover = self._read_json_line(a)
+            if msg is None:
+                break
+            if "out" in msg and "GOT:hello-world" in msg["out"]:
+                got_input = True
+            if "exit_code" in msg:
+                break
+        self.assertTrue(got_input, "Subprocess did not receive the coalesced input 'hello-world'")
+        a.close()
+        b.close()
+
+    def test_no_input_exit(self):
+        """A stream session that receives no input should exit when the
+        process finishes and the connection closes."""
+        a, b = self._make_pair()
+        request = json.dumps({
+            "action": "stream",
+            "args": ["sh", "-c", "echo done; exit 0"],
+            "pty": False,
+        }) + "\n"
+        b.sendall(request.encode())
+        b.close()  # Close connection — should trigger shutdown
+
+        started, _ = self._read_json_line(a)
+        self.assertEqual(started.get("stream"), "started")
+
+        # Read until exit_code or timeout
+        exit_code = None
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            msg, _ = self._read_json_line(a)
+            if msg is None:
+                break
+            if "exit_code" in msg:
+                exit_code = msg["exit_code"]
+                break
+        self.assertIsNotNone(exit_code, "Did not receive exit_code")
+        a.close()
+
+    def test_stderr_flood_non_pty(self):
+        """A child that floods stderr must not deadlock the reader thread."""
+        a, b = self._make_pair()
+        # Write enough to stderr to exceed pipe capacity (64KB on Linux)
+        request = json.dumps({
+            "action": "stream",
+            "args": ["sh", "-c", "yes 'error line' | head -10000 >&2; echo done; exit 0"],
+            "pty": False,
+        }) + "\n"
+        b.sendall(request.encode())
+
+        started, _ = self._read_json_line(a)
+        self.assertEqual(started.get("stream"), "started")
+
+        # Read until we see "done" in stdout or exit_code
+        saw_done = False
+        exit_code = None
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            msg, _ = self._read_json_line(a)
+            if msg is None:
+                break
+            if "out" in msg and "done" in msg["out"]:
+                saw_done = True
+            if "err" in msg:
+                pass  # stderr is expected
+            if "exit_code" in msg:
+                exit_code = msg["exit_code"]
+                break
+        self.assertTrue(saw_done, "Did not see 'done' in stdout — stderr flood may have deadlocked the reader")
+        a.close()
+        b.close()
+
+    def test_stop_terminates_session(self):
+        """A 'stop' action should terminate the process."""
+        a, b = self._make_pair()
+        request = json.dumps({
+            "action": "stream",
+            "args": ["sh", "-c", "sleep 30; echo never"],
+            "pty": False,
+        }) + "\n"
+        b.sendall(request.encode())
+
+        started, _ = self._read_json_line(a)
+        self.assertEqual(started.get("stream"), "started")
+
+        # Send stop
+        stop_msg = json.dumps({"action": "stop"}) + "\n"
+        b.sendall(stop_msg.encode())
+
+        # Read until exit_code
+        exit_code = None
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            msg, _ = self._read_json_line(a)
+            if msg is None:
+                break
+            if "exit_code" in msg:
+                exit_code = msg["exit_code"]
+                break
+        self.assertIsNotNone(exit_code, "Did not receive exit_code after stop")
+        a.close()
+        b.close()
+
+    def test_connection_close_triggers_cleanup(self):
+        """Closing the client socket should trigger process cleanup."""
+        a, b = self._make_pair()
+        request = json.dumps({
+            "action": "stream",
+            "args": ["sh", "-c", "sleep 30; echo never"],
+            "pty": False,
+        }) + "\n"
+        b.sendall(request.encode())
+        b.close()  # Close immediately after sending request
+
+        started, _ = self._read_json_line(a)
+        self.assertEqual(started.get("stream"), "started")
+
+        # The process should be killed; we should get an exit_code
+        # (or the socket closes, which also indicates cleanup)
+        exit_code = None
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            msg, _ = self._read_json_line(a)
+            if msg is None:
+                break
+            if "exit_code" in msg:
+                exit_code = msg["exit_code"]
+                break
+        # Either we got exit_code or the socket closed (both indicate cleanup)
+        a.close()
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/rootfs-init/tests/test_agent_stream.py
+++ b/rootfs-init/tests/test_agent_stream.py
@@ -188,7 +188,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
             "pty": False,
         }) + "\n"
         # The input line, appended in the SAME send (coalesced frame)
-        input_msg = json.dumps({"in": "hello-world"}) + "\n"
+        input_msg = json.dumps({"in": "hello-world\n"}) + "\n"
         b.sendall(request.encode() + input_msg.encode())
 
         # Read the "started" message

--- a/rootfs-init/tests/test_agent_stream.py
+++ b/rootfs-init/tests/test_agent_stream.py
@@ -222,7 +222,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
             "pty": False,
         }) + "\n"
         b.sendall(request.encode())
-        b.close()  # Close connection — should trigger shutdown
+        b.shutdown(socket.SHUT_WR)  # Signal EOF — no more input
 
         started, leftover = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")
@@ -316,7 +316,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
             "pty": False,
         }) + "\n"
         b.sendall(request.encode())
-        b.close()  # Close immediately after sending request
+        b.shutdown(socket.SHUT_WR)  # Signal EOF
 
         started, leftover = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")

--- a/rootfs-init/tests/test_agent_stream.py
+++ b/rootfs-init/tests/test_agent_stream.py
@@ -17,6 +17,7 @@ Or:      python3 rootfs-init/tests/test_agent_stream.py
 import importlib.util
 import json
 import os
+import re
 import socket
 import sys
 import tempfile
@@ -57,6 +58,17 @@ def _load_agent_module():
     finally:
         os.environ.clear()
         os.environ.update(orig_env)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if the given PID is still alive (signal 0 probe)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
 
 
 class TestBufferedLineReaderCoalesced(unittest.TestCase):
@@ -333,6 +345,107 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
                 exit_code = msg["exit_code"]
                 break
         # Either we got exit_code or the socket closed (both indicate cleanup)
+        a.close()
+
+    def test_stop_kills_descendants(self):
+        """A 'stop' action must kill descendant processes, not just the shell.
+
+        Regression: the stream command runs through a shell; cleanup that
+        only signals the shell leaves its children (e.g. `sleep`) running.
+        The command is started in its own process group
+        (start_new_session=True), so stop must TERM/KILL the whole group.
+        """
+        a, b = self._make_pair()
+        self._start_handle(a)
+        # Spawn `sleep 30` as a background child, print its PID to stderr
+        # (unbuffered) so the test can capture it, then `wait` so the shell
+        # stays alive holding the child.
+        request = json.dumps({
+            "action": "stream",
+            "args": ["sh", "-c", "sleep 30 & echo CHILD:$! >&2; wait"],
+            "pty": False,
+        }) + "\n"
+        b.sendall(request.encode())
+
+        started, leftover = self._read_json_line(b)
+        self.assertEqual(started.get("stream"), "started")
+
+        child_pid = None
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            msg, leftover = self._read_json_line(b, leftover)
+            if msg is None:
+                break
+            if "err" in msg and "CHILD:" in msg["err"]:
+                m = re.search(r"CHILD:(\d+)", msg["err"])
+                if m:
+                    child_pid = int(m.group(1))
+                    break
+            if "exit_code" in msg:
+                break
+        self.assertIsNotNone(child_pid, "did not capture the descendant PID")
+        self.assertTrue(_pid_alive(child_pid), "descendant should be alive before stop")
+
+        b.sendall(json.dumps({"action": "stop"}).encode() + b"\n")
+
+        exit_code = None
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            msg, leftover = self._read_json_line(b, leftover)
+            if msg is None:
+                break
+            if "exit_code" in msg:
+                exit_code = msg["exit_code"]
+                break
+        self.assertIsNotNone(exit_code, "no exit_code after stop")
+
+        # The descendant must be gone — the group kill reaches it directly.
+        deadline = time.monotonic() + 5
+        while _pid_alive(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.1)
+        self.assertFalse(_pid_alive(child_pid), "descendant (sleep) survived stop")
+        a.close()
+        b.close()
+
+    def test_connection_close_kills_descendants(self):
+        """Disconnect must kill descendants, not just the shell."""
+        a, b = self._make_pair()
+        self._start_handle(a)
+        request = json.dumps({
+            "action": "stream",
+            "args": ["sh", "-c", "sleep 30 & echo CHILD:$! >&2; wait"],
+            "pty": False,
+        }) + "\n"
+        b.sendall(request.encode())
+
+        started, leftover = self._read_json_line(b)
+        self.assertEqual(started.get("stream"), "started")
+
+        # Capture the descendant PID FIRST, while the main loop is still
+        # waiting for input (the socket is not yet closed).
+        child_pid = None
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            msg, leftover = self._read_json_line(b, leftover)
+            if msg is None:
+                break
+            if "err" in msg and "CHILD:" in msg["err"]:
+                m = re.search(r"CHILD:(\d+)", msg["err"])
+                if m:
+                    child_pid = int(m.group(1))
+                    break
+            if "exit_code" in msg:
+                break
+        self.assertIsNotNone(child_pid, "did not capture the descendant PID")
+        self.assertTrue(_pid_alive(child_pid), "descendant should be alive before disconnect")
+
+        # Now disconnect — the cleanup path must kill the whole group.
+        b.shutdown(socket.SHUT_WR)
+
+        deadline = time.monotonic() + 5
+        while _pid_alive(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.1)
+        self.assertFalse(_pid_alive(child_pid), "descendant (sleep) survived disconnect")
         a.close()
 
 

--- a/rootfs-init/tests/test_agent_stream.py
+++ b/rootfs-init/tests/test_agent_stream.py
@@ -135,6 +135,19 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         b.settimeout(10)
         return a, b
 
+    def _start_handle(self, a):
+        """Start handle() in a daemon thread with socket 'a' as conn.
+
+        The test uses socket 'b' as the client: writes to 'b' are
+        read by handle on 'a', and responses written by handle on 'a'
+        are read by the test on 'b'.
+        """
+        t = threading.Thread(
+            target=self.module.handle, args=(a, ("test",)), daemon=True
+        )
+        t.start()
+        return t
+
     def _read_json_line(self, sock):
         """Read one newline-terminated JSON message from sock."""
         buf = bytearray()
@@ -156,6 +169,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         the BufferedLineReader's buffer and never delivered.
         """
         a, b = self._make_pair()
+        self._start_handle(a)
         # Use 'cat' which echoes stdin to stdout (requires PTY off for
         # line-buffered echo, or the PTY will echo it).
         # We use a shell script that reads a line and prints it with a marker.
@@ -169,7 +183,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         b.sendall(request.encode() + input_msg.encode())
 
         # Read the "started" message
-        started, leftover = self._read_json_line(a)
+        started, leftover = self._read_json_line(b)
         self.assertIsNotNone(started, "Expected 'started' message")
         self.assertEqual(started.get("stream"), "started")
 
@@ -177,7 +191,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         got_input = False
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
-            msg, leftover = self._read_json_line(a)
+            msg, leftover = self._read_json_line(b)
             if msg is None:
                 break
             if "out" in msg and "GOT:hello-world" in msg["out"]:
@@ -192,6 +206,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         """A stream session that receives no input should exit when the
         process finishes and the connection closes."""
         a, b = self._make_pair()
+        self._start_handle(a)
         request = json.dumps({
             "action": "stream",
             "args": ["sh", "-c", "echo done; exit 0"],
@@ -200,14 +215,14 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         b.sendall(request.encode())
         b.close()  # Close connection — should trigger shutdown
 
-        started, _ = self._read_json_line(a)
+        started, _ = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")
 
         # Read until exit_code or timeout
         exit_code = None
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
-            msg, _ = self._read_json_line(a)
+            msg, _ = self._read_json_line(b)
             if msg is None:
                 break
             if "exit_code" in msg:
@@ -219,6 +234,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
     def test_stderr_flood_non_pty(self):
         """A child that floods stderr must not deadlock the reader thread."""
         a, b = self._make_pair()
+        self._start_handle(a)
         # Write enough to stderr to exceed pipe capacity (64KB on Linux)
         request = json.dumps({
             "action": "stream",
@@ -227,7 +243,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         }) + "\n"
         b.sendall(request.encode())
 
-        started, _ = self._read_json_line(a)
+        started, _ = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")
 
         # Read until we see "done" in stdout or exit_code
@@ -235,7 +251,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         exit_code = None
         deadline = time.monotonic() + 15
         while time.monotonic() < deadline:
-            msg, _ = self._read_json_line(a)
+            msg, _ = self._read_json_line(b)
             if msg is None:
                 break
             if "out" in msg and "done" in msg["out"]:
@@ -252,6 +268,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
     def test_stop_terminates_session(self):
         """A 'stop' action should terminate the process."""
         a, b = self._make_pair()
+        self._start_handle(a)
         request = json.dumps({
             "action": "stream",
             "args": ["sh", "-c", "sleep 30; echo never"],
@@ -259,7 +276,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         }) + "\n"
         b.sendall(request.encode())
 
-        started, _ = self._read_json_line(a)
+        started, _ = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")
 
         # Send stop
@@ -270,7 +287,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         exit_code = None
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
-            msg, _ = self._read_json_line(a)
+            msg, _ = self._read_json_line(b)
             if msg is None:
                 break
             if "exit_code" in msg:
@@ -283,6 +300,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
     def test_connection_close_triggers_cleanup(self):
         """Closing the client socket should trigger process cleanup."""
         a, b = self._make_pair()
+        self._start_handle(a)
         request = json.dumps({
             "action": "stream",
             "args": ["sh", "-c", "sleep 30; echo never"],
@@ -291,7 +309,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         b.sendall(request.encode())
         b.close()  # Close immediately after sending request
 
-        started, _ = self._read_json_line(a)
+        started, _ = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")
 
         # The process should be killed; we should get an exit_code
@@ -299,7 +317,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         exit_code = None
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
-            msg, _ = self._read_json_line(a)
+            msg, _ = self._read_json_line(b)
             if msg is None:
                 break
             if "exit_code" in msg:

--- a/rootfs-init/tests/test_agent_stream.py
+++ b/rootfs-init/tests/test_agent_stream.py
@@ -148,9 +148,18 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         t.start()
         return t
 
-    def _read_json_line(self, sock):
-        """Read one newline-terminated JSON message from sock."""
-        buf = bytearray()
+    def _read_json_line(self, sock, leftover=None):
+        """Read one newline-terminated JSON message from sock.
+
+        Pass leftover bytes from a previous read to handle coalesced
+        TCP frames where multiple messages arrive in one recv().
+        Returns (parsed_json, remaining_leftover_bytes).
+        """
+        buf = bytearray(leftover or b'')
+        # Check if we already have a complete line from the leftover
+        nl = buf.find(b'\n')
+        if nl >= 0:
+            return json.loads(buf[: nl + 1]), bytes(buf[nl + 1 :])
         while True:
             chunk = sock.recv(4096)
             if not chunk:
@@ -159,7 +168,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
             nl = buf.find(b'\n')
             if nl >= 0:
                 return json.loads(buf[: nl + 1]), bytes(buf[nl + 1 :])
-        return None, b''
+        return None, bytes(buf)
 
     def test_coalesced_request_and_input_delivered(self):
         """Request + first input in one send: input must reach the process.
@@ -191,7 +200,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         got_input = False
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
-            msg, leftover = self._read_json_line(b)
+            msg, leftover = self._read_json_line(b, leftover)
             if msg is None:
                 break
             if "out" in msg and "GOT:hello-world" in msg["out"]:
@@ -215,14 +224,14 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         b.sendall(request.encode())
         b.close()  # Close connection — should trigger shutdown
 
-        started, _ = self._read_json_line(b)
+        started, leftover = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")
 
         # Read until exit_code or timeout
         exit_code = None
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
-            msg, _ = self._read_json_line(b)
+            msg, leftover = self._read_json_line(b, leftover)
             if msg is None:
                 break
             if "exit_code" in msg:
@@ -243,7 +252,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         }) + "\n"
         b.sendall(request.encode())
 
-        started, _ = self._read_json_line(b)
+        started, leftover = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")
 
         # Read until we see "done" in stdout or exit_code
@@ -251,7 +260,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         exit_code = None
         deadline = time.monotonic() + 15
         while time.monotonic() < deadline:
-            msg, _ = self._read_json_line(b)
+            msg, leftover = self._read_json_line(b, leftover)
             if msg is None:
                 break
             if "out" in msg and "done" in msg["out"]:
@@ -276,7 +285,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         }) + "\n"
         b.sendall(request.encode())
 
-        started, _ = self._read_json_line(b)
+        started, leftover = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")
 
         # Send stop
@@ -287,7 +296,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         exit_code = None
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
-            msg, _ = self._read_json_line(b)
+            msg, leftover = self._read_json_line(b, leftover)
             if msg is None:
                 break
             if "exit_code" in msg:
@@ -309,7 +318,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         b.sendall(request.encode())
         b.close()  # Close immediately after sending request
 
-        started, _ = self._read_json_line(b)
+        started, leftover = self._read_json_line(b)
         self.assertEqual(started.get("stream"), "started")
 
         # The process should be killed; we should get an exit_code
@@ -317,7 +326,7 @@ class TestHandleStreamCoalescedFrame(unittest.TestCase):
         exit_code = None
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
-            msg, _ = self._read_json_line(b)
+            msg, leftover = self._read_json_line(b, leftover)
             if msg is None:
                 break
             if "exit_code" in msg:


### PR DESCRIPTION
## Summary

`forkd-agent.py` currently supports three actions: `ping`, `exec`, and `eval`. The `exec` action is fire-and-forget — it spawns a subprocess, captures all output, and returns the result after the process exits. There is no way to run interactive commands, stream output in real time, or allocate a pseudo-terminal.

This PR adds a `stream` action that enables interactive, bidirectional subprocess sessions over the agent's TCP connection (port 8888).

## Protocol

```
Client → Agent:  {"action":"stream","args":["bash"],"cwd":"/work","pty":true}
Agent → Client:  {"stream":"started","pid":1234,"pty":true}
Agent → Client:  {"out":"$ "}                          ← output chunks
Client → Agent:  {"in":"ls\n"}                         ← stdin input
Agent → Client:  {"out":"file1.txt\nfile2.txt\n$ "}
Client → Agent:  {"action":"stop"}                     ← terminate
Agent → Client:  {"exit_code":0}
```

## Features

1. **PTY support** (default on) — allocates a pseudo-terminal via `pty.openpty()`, so the subprocess sees `isatty()==true` and can use ANSI escapes, line editing, Ctrl+C signals, etc. Can be disabled with `"pty":false` for non-interactive commands.
2. **Real-time output streaming** — a reader thread forwards `{"out":"..."}` JSON chunks as the process produces them (65536-byte reads with 0.5s poll timeout for PTY mode)
3. **Interactive stdin** — the client can send `{"in":"..."}` lines that get written to the process stdin mid-execution
4. **Graceful termination** — client sends `{"action":"stop"}` to terminate, or closes the connection. The handler calls `proc.terminate()`, waits 2s, then `proc.kill()` if still alive.
5. **Working directory** — optional `cwd` parameter sets the subprocess working directory

## Implementation

- Adds `import pty, select` to the agent
- The stream handler uses `_subprocess_env()` from #292 (PATH fix) for container-correct environment
- A reader thread runs alongside the main connection loop (stdin relay)
- The stream action is added as a new `elif` branch in `handle()`, before the `else` (unknown action) fallback

## Dependencies

This branch is based on `fix/guest-agent-container-path` (#292) because the stream handler uses `_subprocess_env()` introduced by that PR. If #292 is merged first, this PR can be rebased onto main.

## Test plan

- [ ] Boot a sandbox VM, stream `["bash"]` with PTY — should get interactive shell with prompt
- [ ] Send `{"in":"echo hello\\n"}` — should receive `{"out":"hello\\n"}`
- [ ] Send `{"action":"stop"}` — should receive `{"exit_code":0}`
- [ ] Stream with `"pty":false` — should work without terminal emulation
- [ ] Stream with `"cwd":"/tmp"` — process should start in /tmp
- [ ] Close connection mid-stream — process should be terminated

Closes #291.
