### PR TITLE
fix(rootfs): use sparse ext4 files for rootfs images

### DIFF
--- a/crates/forkd-cli/src/hub.rs
+++ b/crates/forkd-cli/src/hub.rs
@@ -44,7 +44,7 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs::File;
-use std::io::{self, Read, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::time::Instant;
 
@@ -958,8 +958,35 @@ pub fn place_rootfs_sidecar(src: &Path, dst: &Path, expected_sha: &str) -> Resul
         let input = File::open(src).with_context(|| format!("open sidecar {}", src.display()))?;
         let mut dec = zstd::Decoder::new(input).context("init zstd decoder on sidecar")?;
         let mut out = File::create(&tmp).with_context(|| format!("create {}", tmp.display()))?;
-        io::copy(&mut dec, &mut out)
-            .with_context(|| format!("decompress sidecar to {}", tmp.display()))?;
+        // Sparse-aware decompression: instead of io::copy (which writes
+        // every byte including zeroes, producing a fully-allocated file),
+        // read in chunks and seek past zero blocks to create sparse holes.
+        // This preserves sparse ext4 extents through the pack/pull sidecar
+        // round-trip. A 24 GiB rootfs with 2 GiB of actual content
+        // decompresses to a 2 GiB physical file.
+        const CHUNK_SIZE: usize = 65536; // 64 KiB
+        let mut total_written: u64 = 0;
+        let mut buf = vec![0u8; CHUNK_SIZE];
+        loop {
+            let n = dec.read(&mut buf).context("read decompressed chunk")?;
+            if n == 0 {
+                break;
+            }
+            if buf[..n].iter().all(|&b| b == 0) {
+                // Zero block — seek forward (creates a sparse hole).
+                out.seek(SeekFrom::Current(n as i64))
+                    .with_context(|| format!("seek past zero block in {}", tmp.display()))?;
+            } else {
+                out.write_all(&buf[..n])
+                    .with_context(|| format!("write chunk to {}", tmp.display()))?;
+            }
+            total_written += n as u64;
+        }
+        // Ensure the file length accounts for any trailing zero blocks
+        // (seek-past-EOF extends the file logically but we must set the
+        // final length explicitly).
+        out.set_len(total_written)
+            .with_context(|| format!("set final length on {}", tmp.display()))?;
     }
     let actual = sha256_file(&tmp)?;
     if !actual.eq_ignore_ascii_case(expected_sha) {
@@ -1514,5 +1541,78 @@ mod tests {
             msg.contains("unsafe tag"),
             "error must name the unsafe-tag refusal: {msg}"
         );
+    }
+
+    /// Regression: place_rootfs_sidecar must preserve sparse ext4
+    /// extents through the pack/pull round-trip. A fully-allocated
+    /// decompression defeats the purpose of sparse rootfs (a 24 GiB
+    /// logical file would consume 24 GiB of physical disk). This test
+    /// creates a synthetic sparse file, compresses it to a sidecar,
+    /// decompresses with place_rootfs_sidecar, and verifies:
+    /// 1. SHA-256 matches (content integrity)
+    /// 2. Logical size matches (no truncation)
+    /// 3. Physical blocks < logical size (sparseness preserved)
+    #[test]
+    fn place_rootfs_sidecar_preserves_sparse_extents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+
+        // Create a 6 MiB sparse file: 1 MiB 0xAA + 4 MiB hole + 1 MiB 0xBB
+        let sparse_src = dir.join("sparse.src");
+        {
+            use std::io::{Seek, SeekFrom, Write};
+            let mut f = std::fs::File::create(&sparse_src).unwrap();
+            // Write 1 MiB of 0xAA
+            f.write_all(&vec![0xAA; 1024 * 1024]).unwrap();
+            // Seek forward 4 MiB (creates a sparse hole)
+            f.seek(SeekFrom::Start(5 * 1024 * 1024)).unwrap();
+            // Write 1 MiB of 0xBB at the end
+            f.write_all(&vec![0xBB; 1024 * 1024]).unwrap();
+            f.flush().unwrap();
+        }
+
+        // Compress to sidecar
+        let sidecar = dir.join("sparse.sidecar");
+        compress_file(&sparse_src, &sidecar, 3).expect("compress");
+
+        // Compute expected SHA-256 of the original sparse file
+        let expected_sha = sha256_file(&sparse_src).expect("sha256 original");
+
+        // Decompress with place_rootfs_sidecar
+        let out = dir.join("sparse.out.ext4");
+        place_rootfs_sidecar(&sidecar, &out, &expected_sha).expect("place_rootfs_sidecar");
+
+        // 1. SHA-256 must match (content integrity)
+        let actual_sha = sha256_file(&out).expect("sha256 output");
+        assert_eq!(
+            actual_sha, expected_sha,
+            "SHA-256 mismatch: sparse extents lost content"
+        );
+
+        // 2. Logical size must match
+        let src_meta = std::fs::metadata(&sparse_src).unwrap();
+        let out_meta = std::fs::metadata(&out).unwrap();
+        assert_eq!(
+            src_meta.len(),
+            out_meta.len(),
+            "logical size mismatch: src={}, out={}",
+            src_meta.len(),
+            out_meta.len()
+        );
+
+        // 3. Physical blocks must be less than logical size (sparseness)
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::linux::fs::MetadataExt;
+            let physical = out_meta.st_blocks() * 512;
+            let logical = out_meta.len();
+            assert!(
+                physical < logical,
+                "file is not sparse: physical={} logical={} — \
+                 sparse extents were not preserved",
+                physical,
+                logical
+            );
+        }
     }
 }

--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -331,7 +331,7 @@ enum Cmd {
         #[arg(long)]
         extra: Vec<String>,
         /// Rootfs size in MiB.
-        #[arg(long, default_value_t = 1536)]
+        #[arg(long, default_value_t = DEFAULT_ROOTFS_SIZE_MIB)]
         size_mib: u32,
         /// Cache directory for built rootfs artifacts (so re-running
         /// with the same image skips the Docker → ext4 step).
@@ -718,8 +718,8 @@ enum ParentAction {
         /// Output ext4 file (default: `./<image-slug>.ext4`).
         #[arg(long, short)]
         output: Option<PathBuf>,
-        /// Image size in MiB (default 1536).
-        #[arg(long, default_value_t = 1536)]
+        /// Image size in MiB (default 24576, sparse).
+        #[arg(long, default_value_t = DEFAULT_ROOTFS_SIZE_MIB)]
         size_mib: u32,
         /// Extra apt packages to install on top of the base image.
         #[arg(long)]
@@ -1501,6 +1501,14 @@ fn unpack_chain_into(
 const DEFAULT_HUB_REGISTRY_URL: &str =
     "https://raw.githubusercontent.com/deeplethe/forkd/main/registry.json";
 
+/// Default rootfs image size in MiB. With sparse ext4 files (build-rootfs.sh
+/// uses `truncate`, not `dd`), physical disk usage is proportional to
+/// actual written content, so a generous nominal default is safe: a 24 GiB
+/// rootfs with 2 GiB of content consumes only ~2 GiB of disk. This eliminates
+/// the tradeoff between engineering workloads (need large disk for
+/// compilation) and ephemeral sandboxes (waste space with large rootfs).
+const DEFAULT_ROOTFS_SIZE_MIB: u32 = 24576;
+
 #[derive(serde::Deserialize)]
 struct Registry {
     #[allow(dead_code)]
@@ -2212,7 +2220,7 @@ fn run_cmd(
 
     // 1. Materialize the rootfs (cached). Cache key includes size + extras.
     std::fs::create_dir_all(&cache).ok();
-    let rootfs = cache.join(rootfs_cache_key(&image, 1536, &extra));
+    let rootfs = cache.join(rootfs_cache_key(&image, DEFAULT_ROOTFS_SIZE_MIB, &extra));
     if !rootfs.exists() {
         eprintln!(
             "==> building rootfs for {image} (cached at {})",

--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -2034,7 +2034,7 @@ fn quickstart_cmd(n: usize, image: String, yes: bool) -> Result<()> {
             image,
             tag.clone(),
             vec![],
-            1536,
+            DEFAULT_ROOTFS_SIZE_MIB,
             PathBuf::from("/var/cache/forkd"),
             None,
             "forkd-tap0".to_string(),
@@ -2219,14 +2219,18 @@ fn run_cmd(
     }
 
     // 1. Materialize the rootfs (cached). Cache key includes size + extras.
+    // Resolve the size ONCE so the cache key and the builder always agree.
+    // (Previously the key used the 24576 default while the builder hard-coded
+    // 1536, caching an undersized rootfs under a full-size key.)
     std::fs::create_dir_all(&cache).ok();
-    let rootfs = cache.join(rootfs_cache_key(&image, DEFAULT_ROOTFS_SIZE_MIB, &extra));
+    let size_mib = DEFAULT_ROOTFS_SIZE_MIB;
+    let rootfs = cache.join(rootfs_cache_key(&image, size_mib, &extra));
     if !rootfs.exists() {
         eprintln!(
             "==> building rootfs for {image} (cached at {})",
             rootfs.display()
         );
-        parent_build_cmd(image.clone(), Some(rootfs.clone()), 1536, extra)?;
+        parent_build_cmd(image.clone(), Some(rootfs.clone()), size_mib, extra)?;
     } else {
         eprintln!("==> using cached rootfs {}", rootfs.display());
     }
@@ -3495,6 +3499,23 @@ mod tests {
     fn cache_key_sanitizes_image_slug() {
         let k = rootfs_cache_key("ghcr.io/foo/bar:1.0", 2048, &[]);
         assert!(k.starts_with("ghcr-io-foo-bar-1-0-2048-"), "got: {k}");
+    }
+
+    #[test]
+    fn run_default_cache_key_uses_default_size_not_legacy_1536() {
+        // Regression guard: the run path must build and cache at the SAME
+        // resolved size. Previously run_cmd used the 24576 default in the
+        // cache key but hard-coded 1536 in the builder call, so an
+        // undersized rootfs was cached under a full-size key.
+        let key = rootfs_cache_key("python:3.12-slim", DEFAULT_ROOTFS_SIZE_MIB, &[]);
+        assert!(
+            key.contains(&DEFAULT_ROOTFS_SIZE_MIB.to_string()),
+            "run default cache key must embed {DEFAULT_ROOTFS_SIZE_MIB}, got: {key}"
+        );
+        assert!(
+            !key.contains("1536"),
+            "run default cache key must not use the legacy 1536 size, got: {key}"
+        );
     }
 
     #[test]

--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -150,8 +150,23 @@ $SUDO chroot "$WORK" /bin/bash -c "passwd -d root 2>/dev/null || true"
 
 # ----------------------------------------------------------------------------
 say "[5/5] building ext4 image ($SIZE_MB MiB)..."
-dd if=/dev/zero of="$OUTPUT" bs=1M count="$SIZE_MB" status=progress 2>&1 | tail -1
-mkfs.ext4 -q -F -L forkd-rootfs -d "$WORK" "$OUTPUT"
+# Build a sparse ext4 file. Use truncate (not dd) so the file is
+# sparse — physical disk usage is proportional to actual written
+# content, not the nominal size. This lets us use a generous default
+# size (24 GiB) for engineering workloads without wasting disk on
+# ephemeral function-call sandboxes.
+#
+# Build to a temporary sibling then atomically rename on success, so
+# a failed mkfs does not destroy a prior cache artifact: truncate -s
+# in-place on an existing fully-allocated file does not release its
+# blocks, and if mkfs fails the old file is already corrupted.
+TMP_OUTPUT="${OUTPUT}.tmp.$$"
+truncate -s "${SIZE_MB}M" "$TMP_OUTPUT"
+if ! mkfs.ext4 -q -F -L forkd-rootfs -d "$WORK" "$TMP_OUTPUT"; then
+    rm -f "$TMP_OUTPUT"
+    die "mkfs.ext4 failed"
+fi
+mv "$TMP_OUTPUT" "$OUTPUT"
 ls -lh "$OUTPUT"
 
 echo


### PR DESCRIPTION
fix(rootfs): use sparse ext4 files for rootfs images

Rebased on main to reuse the merged `rootfs_cache_key` helper (#280)
instead of reimplementing the cache key with `DefaultHasher`.

Changes:
- **build-rootfs.sh**: replace `dd if=/dev/zero` with `truncate -s` to
  produce sparse ext4 files. Physical disk usage is proportional to
  actual written content, not the nominal size.
- **build-rootfs.sh**: build to a temporary sibling (`${OUTPUT}.tmp.$$`),
  run `mkfs.ext4`, then atomically rename on success. This prevents a
  failed `mkfs` from destroying a prior cache artifact — `truncate -s`
  in-place on an existing fully-allocated file does not release its
  blocks, and if `mkfs` fails the old file is already corrupted.
- **hub.rs `place_rootfs_sidecar`**: replace `io::copy` with sparse-aware
  decompression (64 KiB chunks, seek past zero blocks to create sparse
  holes, `set_len` for trailing zeros). This preserves sparse ext4
  extents through the pack/pull sidecar round-trip.
- **main.rs**: add `DEFAULT_ROOTFS_SIZE_MIB` const (24576 = 24 GiB) and
  use it as the default for `--size-mib` in from-image and parent-build
  subcommands. With sparse files, 24 GiB is safe — physical usage is
  proportional to content.
- **Reuses `rootfs_cache_key` from #280** (SHA-256 with raw image
  reference) — no cache key reimplementation or collision regression.

Added test: `place_rootfs_sidecar_preserves_sparse_extents` — creates a
6 MiB sparse file (1 MiB 0xAA + 4 MiB hole + 1 MiB 0xBB), compresses,
decompresses, verifies SHA-256 match, logical size match, and
`st_blocks*512 < logical size` (sparseness) on Linux.