### PR TITLE
fix(vmm): restore-path resilience — configurable timeout, per-VM partial-failure reporting, pre-restore orphan detection

### DIFF
--- a/crates/forkd-cli/src/main.rs
+++ b/crates/forkd-cli/src/main.rs
@@ -2278,10 +2278,19 @@ fn run_cmd(
                 memory_backend: forkd_vmm::MemoryBackend::File,
                 enable_diff_snapshots: false,
                 sync_guest_clocks: false,
+                socket_wait_timeout_secs: forkd_vmm::DEFAULT_SOCKET_WAIT_SECS,
             },
             &work_dir,
         )
         .context("restore_many failed")?;
+    if result.children.is_empty() {
+        let detail = result
+            .failures
+            .first()
+            .map(|f| format!("child {} {:?}: {}", f.child_index, f.phase, f.error))
+            .unwrap_or_else(|| "no children restored".to_string());
+        bail!("restore_many produced no live child: {detail}");
+    }
 
     // Wait for the agent to come up, then exec the command.
     let target = "10.42.0.2:8888".to_string();
@@ -2307,8 +2316,8 @@ fn run_cmd(
     let exit = resp.exit_code;
 
     // Shutdown.
-    for c in &result.children {
-        let _ = c.shutdown();
+    for fc in &result.children {
+        let _ = fc.vm.shutdown();
     }
     drop(result);
 
@@ -3130,15 +3139,25 @@ fn fork_cmd(
                 // CLI fork doesn't outlive its invocation, no diff snapshots.
                 enable_diff_snapshots: false,
                 sync_guest_clocks: false,
+                socket_wait_timeout_secs: forkd_vmm::DEFAULT_SOCKET_WAIT_SECS,
             },
             &work_dir,
         )
         .context("restore_many_with failed")?;
+    if !result.failures.is_empty() {
+        for f in &result.failures {
+            eprintln!(
+                "⚠ child {} {:?} failed: {}",
+                f.child_index, f.phase, f.error
+            );
+        }
+    }
 
     let total_ms = result.spawn_ms + result.restore_ms;
     println!("✓ all sockets up in {} ms", result.spawn_ms);
     println!(
-        "✓ {n} restores fired in parallel in {} ms",
+        "✓ {} / {n} restores fired in parallel in {} ms",
+        result.children.len(),
         result.restore_ms
     );
     println!("✓ total wall-clock: {total_ms} ms");
@@ -3146,12 +3165,12 @@ fn fork_cmd(
     eprintln!("==> letting children settle for {settle_secs}s...");
     thread::sleep(Duration::from_secs(settle_secs));
 
-    let alive = result.children.iter().filter(|c| c.is_alive()).count();
+    let alive = result.children.iter().filter(|fc| fc.vm.is_alive()).count();
     println!("✓ {alive} / {n} children alive");
 
     eprintln!("==> shutting down...");
-    for c in &result.children {
-        let _ = c.shutdown();
+    for fc in &result.children {
+        let _ = fc.vm.shutdown();
     }
     thread::sleep(Duration::from_secs(2));
     drop(result); // triggers kill via Drop for any still alive

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -2958,7 +2958,6 @@ fn spawn_one_for_workspace(
         enable_diff_snapshots: true,
         sync_guest_clocks: true,
         socket_wait_timeout_secs: daemon_socket_wait_timeout_secs(),
-
     };
     let work_dir =
         std::env::temp_dir().join(format!("forkd-workspace-{snapshot_tag}-o{netns_offset}"));

--- a/crates/forkd-controller/src/http.rs
+++ b/crates/forkd-controller/src/http.rs
@@ -92,6 +92,11 @@ pub struct AppState {
     /// sandbox and workspace spawn paths so concurrent spawns never
     /// pick overlapping offsets (security review #282).
     pub netns_alloc: std::sync::Arc<crate::netns::NetnsAllocator>,
+    /// Monotonic count of pre-restore orphan scans that found firecracker
+    /// processes not tracked by `live_vms`. Exposed via `/metrics` as
+    /// `forkd_orphan_firecrackers_detected_total` so operators can alert
+    /// on the tap/netns/fd-collision precursor instead of relying on logs.
+    pub orphan_firecrackers_detected: std::sync::atomic::AtomicU64,
     /// Scratch directory used for prewarm throwaway snapshots when
     /// `CreateSandboxRequest::prewarm` is set. Mirror of
     /// `DaemonConfig::prewarm_scratch_dir`.
@@ -243,6 +248,9 @@ async fn metrics(State(s): State<SharedState>) -> impl IntoResponse {
     let (snap_count, sb_count) = s.registry.counts();
     let branches_in_flight = s.branch_in_flight.lock().len();
     let branch_cap = s.branch_concurrency_cap;
+    let orphans = s
+        .orphan_firecrackers_detected
+        .load(std::sync::atomic::Ordering::Relaxed);
     // Prometheus text format. Keep names stable — exporters depend on them.
     let body = format!(
         "# HELP forkd_snapshots_total Number of snapshots known to the controller.\n\
@@ -257,6 +265,9 @@ async fn metrics(State(s): State<SharedState>) -> impl IntoResponse {
          # HELP forkd_branch_concurrency_cap Configured maximum concurrent BRANCH operations.\n\
          # TYPE forkd_branch_concurrency_cap gauge\n\
          forkd_branch_concurrency_cap {branch_cap}\n\
+         # HELP forkd_orphan_firecrackers_detected_total Cumulative firecracker orphans detected.\n\
+         # TYPE forkd_orphan_firecrackers_detected_total counter\n\
+         forkd_orphan_firecrackers_detected_total {orphans}\n\
          # HELP forkd_build_info Build version of the controller binary.\n\
          # TYPE forkd_build_info gauge\n\
          forkd_build_info{{version=\"{BUILD_VERSION}\"}} 1\n"
@@ -312,6 +323,44 @@ async fn list_snapshots(State(s): State<SharedState>) -> impl IntoResponse {
         }
     }
     Json(snapshots)
+}
+
+/// #301: scan for orphaned firecracker processes before a restore. An
+/// orphan is a firecracker PID on the host that is NOT tracked by
+/// `live_vms` — leftovers from a prior (crashed) run that may hold tap
+/// devices, netns slots, or fd budget and doom a new restore to
+/// socket/restore failures. Best-effort, read-only: it never kills.
+/// The lock is held only long enough to snapshot the known-PID set;
+/// the `/proc` scan + logging run after the lock is released so the
+/// scan doesn't serialize concurrent sandbox operations.
+fn warn_orphan_firecrackers(s: &SharedState, tag: &str) {
+    // Collect known PIDs under a short-lived guard, then drop the lock
+    // before the blocking `/proc` readdir + per-PID reads.
+    let known: std::collections::HashSet<u32> = {
+        let live = s.live_vms.lock();
+        live.values().map(|vm| vm.pid()).collect()
+    };
+    let orphans = forkd_vmm::scan_firecracker_orphans(&known);
+    if orphans.is_empty() {
+        return;
+    }
+    s.orphan_firecrackers_detected
+        .fetch_add(orphans.len() as u64, std::sync::atomic::Ordering::Relaxed);
+    tracing::warn!(
+        tag = %tag,
+        count = orphans.len(),
+        pids = ?orphans.iter().map(|o| o.pid).collect::<Vec<_>>(),
+        "orphaned firecracker processes detected before restore; \
+         these may hold tap/netns resources and cause spawn failures"
+    );
+    for o in &orphans {
+        tracing::warn!(
+            pid = o.pid,
+            elapsed_secs = o.elapsed_secs,
+            cmdline = %o.cmdline,
+            "orphaned firecracker process"
+        );
+    }
 }
 
 /// Phase 6.4: lazy reaper. Walks `AppState::live_in_flight`, joins
@@ -1224,6 +1273,15 @@ async fn create_sandbox(
     let prewarm_requested = req.prewarm;
     let mut snapshot = snapshot;
     let head_tag_for_log = req.snapshot_tag.clone();
+    // #301: surface orphaned firecracker processes before the restore.
+    // The helper scopes the live_vms lock to just PID collection and
+    // runs the /proc scan + logging after the lock is released.
+    //
+    // Limitation: this scan is point-in-time and does NOT guarantee that
+    // no orphan appears between the scan and the restore. It is a
+    // diagnostic aid, not a gate. Issue #301 remains open for the
+    // lifecycle-level orphan reap/gate work.
+    warn_orphan_firecrackers(&s, &head_tag_for_log);
     let tap_token_for_closure = tap_token.clone();
     let (fork_result, mut netns_reservation, mut tap_claim) = match tokio::task::spawn_blocking(move || -> anyhow::Result<(forkd_vmm::ForkResult, Option<crate::netns::NetnsReservation>, Option<SharedTapClaim>)> {
         // Reserve the netns offset range INSIDE the blocking task so
@@ -1282,6 +1340,12 @@ async fn create_sandbox(
             // ~1 bit per page; negligible.
             enable_diff_snapshots: true,
             sync_guest_clocks: true,
+            // Under spawn bursts (warm-pool refill) the default 10s socket
+            // wait can be too tight when prior-VM tap/netns teardown races
+            // with new firecracker spawns. Give the daemon path a more
+            // generous budget so a single slow child doesn't fail the batch.
+            socket_wait_timeout_secs: daemon_socket_wait_timeout_secs(),
+
         };
         // Per-snapshot-tag work_dir would clash if two batches of the same tag
         // ran concurrently (e.g. two branches of the same source). Mix the
@@ -1334,25 +1398,82 @@ async fn create_sandbox(
         }
 
         let backoffs_ms = [50u64, 200, 800];
+        // Tracks the most recent busy failure across retries. On the final
+        // attempt the loop falls through (rather than returning early) so
+        // the exhausted-retry error carries retry-exhaustion context into
+        // the API response/log — operators can then distinguish a transient
+        // contention storm from a permanent failure.
+        let mut last_err: Option<anyhow::Error> = None;
         for attempt in 0..=backoffs_ms.len() {
             if attempt > 0 {
-                std::thread::sleep(std::time::Duration::from_millis(backoffs_ms[attempt - 1]));
+                std::thread::sleep(std::time::Duration::from_millis(
+                    backoffs_ms[attempt - 1],
+                ));
             }
+            let final_attempt = attempt == backoffs_ms.len();
             match snapshot.restore_many_with(opts.clone(), &work_dir) {
-                Ok(r) => return Ok((r, netns_reservation, tap_claim)),
+                Ok(r) if r.failures.is_empty() => return Ok((r, netns_reservation, tap_claim)),
+                Ok(r) => {
+                    // Partial success: some children restored, some failed.
+                    // A sandbox needs all `n` children, so drop the partial
+                    // set (kills their firecracker processes) and retry the
+                    // whole batch when the failure is retryable (busy);
+                    // otherwise surface the structured per-child failures.
+                    //
+                    // Controller-level all-or-nothing: a sandbox requires
+                    // all N children, so partial success is NOT exposed to
+                    // the API caller. The per-child failure reporting from
+                    // restore_many_with is used here for diagnostics and
+                    // retry classification only. See issue #301 for the
+                    // broader partial-success-through-controller work.
+                    let forkd_vmm::ForkResult {
+                        children,
+                        failures,
+                        ..
+                    } = r;
+                    let is_busy = failures.iter().any(|f| {
+                        f.error.contains("Resource busy")
+                            || f.error.contains("Device or resource busy")
+                            || f.error.contains("os error 16")
+                    });
+                    let err = anyhow::Error::new(forkd_vmm::RestoreError { failures });
+                    drop(children);
+                    if !is_busy {
+                        return Err(err);
+                    }
+                    if final_attempt {
+                        last_err =
+                            Some(err.context("restore_many: exhausted all busy-retries"));
+                    } else {
+                        tracing::warn!(
+                            attempt = attempt + 1,
+                            next_backoff_ms = backoffs_ms[attempt],
+                            error = %err,
+                            "restore_many: partial restore (tap/cgroup busy), retrying"
+                        );
+                        last_err = Some(err);
+                    }
+                }
                 Err(e) => {
                     let msg = format!("{e:#}");
                     let is_busy = msg.contains("Resource busy")
                         || msg.contains("Device or resource busy")
                         || msg.contains("os error 16");
-                    if !is_busy || attempt == backoffs_ms.len() {
+                    if !is_busy {
                         return Err(e);
-
+                    }
+                    if final_attempt {
+                        last_err =
+                            Some(e.context("restore_many: exhausted all busy-retries"));
+                    } else {
+                        last_err = Some(e);
                     }
                 }
             }
         }
-        unreachable!("retry loop must return on final attempt")
+        // All busy-retries exhausted; surface the final error (carrying
+        // retry-exhaustion context) for the API response/log.
+        Err(last_err.expect("busy-retry loop exhausted without capturing an error"))
     })
     .await
     {
@@ -1394,7 +1515,12 @@ async fn create_sandbox(
     let mut first_id_override = tap_token.clone();
     {
         let mut live = s.live_vms.lock();
-        for vm in fork_result.children {
+        for fc in fork_result.children {
+            let vm = fc.vm;
+            // Shared-tap ownership (review #281): the first child's
+            // sandbox id is the tap-lease token; release_shared_tap_if_owner
+            // checks against it on teardown. For non-shared-tap spawns
+            // first_id_override is None so every child gets a fresh id.
             let id = first_id_override.take().unwrap_or_else(new_sandbox_id);
             let info = SandboxInfo {
                 id: id.clone(),
@@ -2240,6 +2366,20 @@ fn unix_now() -> u64 {
         .unwrap_or(0)
 }
 
+/// #301: per-child firecracker socket-wait timeout for daemon-spawned
+/// sandboxes, in seconds. Under warm-pool refill bursts the historical
+/// 10s budget can be too tight when prior-VM tap/netns teardown races
+/// with new firecracker spawns. Operators can override via
+/// `FORKD_SOCKET_WAIT_TIMEOUT_SECS`; the default (30) gives a single
+/// slow child more room before the batch fails.
+fn daemon_socket_wait_timeout_secs() -> u64 {
+    std::env::var("FORKD_SOCKET_WAIT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(30)
+}
+
 fn branch_suffix() -> u16 {
     use std::sync::atomic::{AtomicU16, Ordering};
     static SEQ: AtomicU16 = AtomicU16::new(0);
@@ -2817,14 +2957,26 @@ fn spawn_one_for_workspace(
         memory_backend: forkd_vmm::MemoryBackend::File,
         enable_diff_snapshots: true,
         sync_guest_clocks: true,
+        socket_wait_timeout_secs: daemon_socket_wait_timeout_secs(),
+
     };
     let work_dir =
         std::env::temp_dir().join(format!("forkd-workspace-{snapshot_tag}-o{netns_offset}"));
+    // #301: surface orphaned firecracker processes before the restore.
+    warn_orphan_firecrackers(s, snapshot_tag);
     let mut fork_result = snapshot.restore_many_with(opts, &work_dir)?;
-    let vm = fork_result
-        .children
-        .pop()
-        .ok_or_else(|| anyhow::anyhow!("restore_many returned no children"))?;
+    let vm = fork_result.children.pop().map(|fc| fc.vm).ok_or_else(|| {
+        if let Some(first) = fork_result.failures.first() {
+            anyhow::anyhow!(
+                "restore_many child {} failed ({:?}): {}",
+                first.child_index,
+                first.phase,
+                first.error
+            )
+        } else {
+            anyhow::anyhow!("restore_many returned no children")
+        }
+    })?;
 
     let info = SandboxInfo {
         id: sandbox_id,
@@ -3266,6 +3418,7 @@ mod tests {
                 Box::new(crate::netns::RangeProbe { max: 256 }),
             ),
             shared_tap_owner: std::sync::Arc::new(parking_lot::Mutex::new(None)),
+            orphan_firecrackers_detected: std::sync::atomic::AtomicU64::new(0),
             prewarm_scratch_dir,
             #[cfg(target_os = "linux")]
             live_in_flight: Mutex::new(HashMap::new()),
@@ -3295,6 +3448,7 @@ mod tests {
                 Box::new(crate::netns::RangeProbe { max: netns_pool }),
             ),
             shared_tap_owner: std::sync::Arc::new(parking_lot::Mutex::new(None)),
+            orphan_firecrackers_detected: std::sync::atomic::AtomicU64::new(0),
             prewarm_scratch_dir,
             #[cfg(target_os = "linux")]
             live_in_flight: Mutex::new(HashMap::new()),

--- a/crates/forkd-controller/src/lib.rs
+++ b/crates/forkd-controller/src/lib.rs
@@ -143,7 +143,11 @@ pub async fn run_daemon(cfg: DaemonConfig) -> Result<()> {
         // bound is derived from the provisioned pool on disk instead of
         // a magic constant.
         netns_alloc: crate::netns::NetnsAllocator::discover("/var/run/netns"),
+        // #281: shared-tap ownership cell (claim/commit/RAII lifecycle).
         shared_tap_owner: std::sync::Arc::new(parking_lot::Mutex::new(None)),
+        // #302: diagnostic counter for orphaned firecracker processes
+        // detected during the pre-restore scan. Exposed as a metric.
+        orphan_firecrackers_detected: std::sync::atomic::AtomicU64::new(0),
         prewarm_scratch_dir: cfg.prewarm_scratch_dir.clone(),
         #[cfg(target_os = "linux")]
         live_in_flight: Mutex::new(HashMap::new()),

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -432,6 +432,140 @@ impl Vm {
     }
 }
 
+/// A firecracker process found on the host that may interfere with a
+/// restore (holding a tap device fd, a netns slot, or consuming fd/RAM
+/// budget). Returned by [`scan_firecracker_orphans`].
+#[derive(Debug, Clone)]
+pub struct OrphanProcess {
+    pub pid: u32,
+    /// Elapsed seconds since the process started (best-effort, from
+    /// `/proc/<pid>/stat` start time). 0 when unavailable.
+    pub elapsed_secs: u64,
+    /// The command line (best-effort, from `/proc/<pid>/cmdline`).
+    /// Empty when unreadable.
+    pub cmdline: String,
+}
+
+/// Scan `/proc` for running firecracker processes whose PIDs are NOT in
+/// the `known_pids` set. These are potential orphans — processes from a
+/// prior (crashed) run that still hold tap devices, netns slots, or fd
+/// budget, and may doom a new `restore_many_with` to socket/restore
+/// failures. The caller (controller) passes the PIDs of every VM in
+/// `live_vms` so only untracked firecracker processes are reported.
+///
+/// This is a best-effort, read-only scan: it never kills anything. The
+/// controller logs the results before a restore so operators can see
+/// contention from orphans. The scan is one `/proc` readdir plus, for
+/// each firecracker PID found, reads of `/proc/<pid>/comm`,
+/// `/proc/<pid>/cmdline`, and `/proc/<pid>/stat` (via `proc_elapsed_secs`).
+/// Safe to call before every restore — the per-orphan I/O is bounded by
+/// the number of firecracker processes on the host (typically small).
+///
+/// TOCTOU note: the scan is a point-in-time observation. New firecracker
+/// processes may appear between scan and restore, and a known PID could
+/// be reused by a new process in that window. The scan is logging-only
+/// and never gates a restore, so this is acceptable, but operators should
+/// not treat the scan as a guarantee that no orphans exist at restore time.
+///
+/// Returns an empty vec on non-Linux platforms (no `/proc`).
+pub fn scan_firecracker_orphans(known_pids: &std::collections::HashSet<u32>) -> Vec<OrphanProcess> {
+    scan_firecracker_orphans_impl(known_pids)
+}
+
+#[cfg(target_os = "linux")]
+fn scan_firecracker_orphans_impl(
+    known_pids: &std::collections::HashSet<u32>,
+) -> Vec<OrphanProcess> {
+    let mut orphans = Vec::new();
+    let entries = match std::fs::read_dir("/proc") {
+        Ok(e) => e,
+        Err(_) => return orphans,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = match name.to_str() {
+            Some(s) => s,
+            None => continue,
+        };
+        let pid: u32 = match name_str.parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if pid <= 1 || known_pids.contains(&pid) {
+            continue;
+        }
+        // `/proc/<pid>/comm` is the process's command name (truncated to
+        // 15 chars). For firecracker this is exactly "firecracker".
+        let comm = match std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+            Ok(s) => s.trim().to_string(),
+            Err(_) => continue,
+        };
+        if comm != "firecracker" {
+            continue;
+        }
+        // Best-effort cmdline + elapsed. Failure here doesn't disqualify
+        // the orphan — we already confirmed it's a firecracker process.
+        let cmdline = std::fs::read_to_string(format!("/proc/{pid}/cmdline"))
+            .unwrap_or_default()
+            .replace('\0', " ")
+            .trim()
+            .to_string();
+        let elapsed_secs = proc_elapsed_secs(pid).unwrap_or(0);
+        orphans.push(OrphanProcess {
+            pid,
+            elapsed_secs,
+            cmdline,
+        });
+    }
+    orphans
+}
+
+/// Read `/proc/<pid>/stat` and compute elapsed seconds since process start.
+/// Returns 0 when the file is missing or unparseable (non-fatal).
+#[cfg(target_os = "linux")]
+fn proc_elapsed_secs(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    // Field 22 is starttime in clock ticks since boot. The comm field (2)
+    // is parenthesized and may contain spaces, so split from the right.
+    let rparen = stat.rfind(')')?;
+    let rest = &stat[rparen + 1..];
+    let mut fields = rest.split_whitespace();
+    // Fields 3..=21 (state through itrealvalue) precede field 22 (starttime).
+    for _ in 0..19 {
+        fields.next();
+    }
+    let starttime_ticks: u64 = fields.next()?.parse().ok()?;
+    let start_secs = starttime_ticks / PROC_CLK_TCK;
+    let now = boot_relative_secs()?;
+    now.checked_sub(start_secs)
+}
+
+/// Clock ticks per second for `/proc/<pid>/stat` time fields. This is
+/// `USER_HZ` on Linux, which is 100 on every x86_64/aarch64 host forkd
+/// targets today. `libc::sysconf(libc::_SC_CLK_TCK)` could read it at
+/// runtime, but the value is effectively fixed across all supported
+/// kernels — hardcoding avoids a runtime probe for a constant.
+#[cfg(target_os = "linux")]
+const PROC_CLK_TCK: u64 = 100;
+
+/// Seconds since boot, from `/proc/uptime`. None when unreadable.
+#[cfg(target_os = "linux")]
+fn boot_relative_secs() -> Option<u64> {
+    let uptime = std::fs::read_to_string("/proc/uptime").ok()?;
+    let first = uptime.split_whitespace().next()?;
+    let secs: f64 = first.parse().ok()?;
+    Some(secs as u64)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn scan_firecracker_orphans_impl(
+    _known_pids: &std::collections::HashSet<u32>,
+) -> Vec<OrphanProcess> {
+    // No `/proc` on non-Linux — nothing to scan. This stub keeps the
+    // function callable from dev boxes (macOS) for test compilation.
+    Vec::new()
+}
+
 /// On-disk snapshot of a paused VM: a vmstate blob (vCPU + devices) plus a
 /// memory image file. Children restore from these by mmap'ing memory with
 /// `MAP_PRIVATE`, which the kernel implements as copy-on-write.
@@ -604,6 +738,15 @@ pub struct ForkOpts {
     /// Negligible relative to the snapshot-write savings on subsequent
     /// Diff snapshots.
     pub enable_diff_snapshots: bool,
+    /// Per-child timeout for waiting on a firecracker API socket to appear
+    /// after spawn, in seconds. The default of 10s matches the historical
+    /// hardcoded budget. Under contention from orphaned VMs, parallel restore
+    /// bursts, or slow tap/netns teardown, firecracker processes can take
+    /// longer than 10s to open their API socket; callers that expect heavy
+    /// load (e.g. the daemon's warm-pool refiller under spawn bursts) may
+    /// raise this to give each child more room rather than fail the whole
+    /// batch. Set to 0 to use the default. See `wait_for_sock`.
+    pub socket_wait_timeout_secs: u64,
     /// If true, after snapshot restore each child's guest clock is
     /// synchronized to host wall time by exec'ing `date -s @<ts>`
     /// via the guest agent (port 8888). This is the general fix for
@@ -618,6 +761,10 @@ pub struct ForkOpts {
     pub sync_guest_clocks: bool,
 }
 
+/// The historical hardcoded socket-wait budget, in seconds. Used as the
+/// default when `ForkOpts::socket_wait_timeout_secs` is 0.
+pub const DEFAULT_SOCKET_WAIT_SECS: u64 = 10;
+
 impl Default for ForkOpts {
     fn default() -> Self {
         Self {
@@ -628,6 +775,7 @@ impl Default for ForkOpts {
             prewarm_scratch_dir: None,
             memory_backend: MemoryBackend::File,
             enable_diff_snapshots: false,
+            socket_wait_timeout_secs: DEFAULT_SOCKET_WAIT_SECS,
             sync_guest_clocks: false,
         }
     }
@@ -636,7 +784,19 @@ impl Default for ForkOpts {
 /// Result of `Snapshot::restore_many` — N live children plus timing.
 #[derive(Debug)]
 pub struct ForkResult {
-    pub children: Vec<Vm>,
+    /// Successfully restored children, each with its 1-based within-batch
+    /// `child_index` so callers can map a surviving VM back to its
+    /// resource slot (netns/cgroup at `netns_offset + child_index`).
+    /// Failed children are NOT here — see `failures`.
+    pub children: Vec<ForkChild>,
+    /// Per-child failures collected during spawn, socket-wait, and
+    /// restore. Empty when every child succeeded. When non-empty,
+    /// `children` holds the successful subset (possibly empty) and the
+    /// caller decides whether to retry the failed indices or degrade.
+    /// `child_index` is the 1-based within-batch index, so a caller with
+    /// per-child resources (netns/cgroup at `netns_offset + child_index`)
+    /// can release exactly the failed slots.
+    pub failures: Vec<RestoreFailure>,
     pub spawn_ms: u128,
     pub restore_ms: u128,
     /// Wall-clock spent in the optional post-restore prewarm pass.
@@ -671,6 +831,80 @@ pub enum ClockSyncOutcome {
     /// clock. `error` describes what went wrong.
     Failed { child_index: usize, error: String },
 }
+
+/// A successfully restored child, paired with its 1-based within-batch
+/// index so callers can map it back to per-child resources (netns/cgroup
+/// at `netns_offset + child_index`). This preserves the child-to-VM
+/// mapping that a plain `Vec<Vm>` would lose when failures are filtered
+/// out (review feedback on #301: successes must retain their index).
+#[derive(Debug)]
+pub struct ForkChild {
+    /// 1-based within-batch child index (matches `child-{index}.sock`).
+    pub child_index: usize,
+    /// The restored VM handle (owns the firecracker Child process).
+    pub vm: Vm,
+}
+
+/// Which phase of `restore_many_with` a child failed in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestorePhase {
+    /// `spawn_firecracker_in` returned an error before the process existed.
+    Spawn,
+    /// The firecracker API socket never appeared within the wait budget.
+    SocketWait,
+    /// `PUT /snapshot/load` returned a non-2xx response (or a transport error).
+    Restore,
+}
+
+/// A single child's failure inside `restore_many_with`. Collected per
+/// child so a single bad spawn doesn't mask other failures (or silently
+/// drop already-spawned siblings). `pid` is `None` for `Spawn`-phase
+/// failures where the process was never created.
+#[derive(Debug, Clone)]
+pub struct RestoreFailure {
+    /// 1-based within-batch child index (matches `child-{index}.sock`).
+    pub child_index: usize,
+    /// The phase that failed.
+    pub phase: RestorePhase,
+    /// Firecracker PID when known (None for Spawn-phase failures).
+    pub pid: Option<u32>,
+    /// Human-readable error from the failing phase.
+    pub error: String,
+}
+
+/// Error returned by `restore_many_with` when one or more children fail.
+/// Carries every per-child failure so callers can report which specific
+/// child failed rather than a single bail that loses the batch context.
+/// Children that spawned successfully but could not be restored are
+/// killed (firecracker SIGKILL'd) before this is returned, so no live
+/// orphans remain from a partial failure.
+#[derive(Debug, Clone)]
+pub struct RestoreError {
+    pub failures: Vec<RestoreFailure>,
+}
+
+impl std::fmt::Display for RestoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "restore_many_with failed: {} child(ren) failed",
+            self.failures.len()
+        )?;
+        for fail in &self.failures {
+            write!(
+                f,
+                "; child {} {:?}: {}",
+                fail.child_index, fail.phase, fail.error
+            )?;
+            if let Some(pid) = fail.pid {
+                write!(f, " (pid {})", pid)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for RestoreError {}
 
 /// Response from the guest agent's `exec` action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -949,7 +1183,7 @@ const CLOCK_SYNC_EXEC_TIMEOUT: Duration = Duration::from_secs(5);
 /// - **Adds latency to restore**: ~1-5 seconds per batch (agent polling
 ///   + exec), running in parallel across children. Measured at
 ///     ~1-2 seconds for typical Debian/Ubuntu-based images.
-fn sync_guest_clocks(children: &[Vm]) -> (u128, Vec<ClockSyncOutcome>) {
+fn sync_guest_clocks(children: &[&Vm]) -> (u128, Vec<ClockSyncOutcome>) {
     let start = Instant::now();
 
     let mut handles = Vec::with_capacity(children.len());
@@ -1276,6 +1510,16 @@ fn wait_for_sock(sock: &Path, timeout: Duration) -> Result<()> {
     let mut sleep_for = Duration::from_millis(1);
     let max_sleep = Duration::from_millis(20);
     while start.elapsed() < timeout {
+        // Check for a Unix-domain socket, not just path existence —
+        // a directory or regular file at the socket path must NOT
+        // satisfy the wait (review feedback on #301: a pre-created
+        // directory was incorrectly passing the check).
+        if sock.is_dir() {
+            bail!(
+                "socket path {} is a directory, not a socket",
+                sock.display()
+            );
+        }
         if sock.exists() {
             return Ok(());
         }
@@ -1808,6 +2052,7 @@ impl Snapshot {
                 prewarm_scratch_dir: None,
                 memory_backend: MemoryBackend::File,
                 enable_diff_snapshots: false,
+                socket_wait_timeout_secs: DEFAULT_SOCKET_WAIT_SECS,
                 sync_guest_clocks: false,
             },
             work_dir,
@@ -1854,7 +2099,8 @@ impl Snapshot {
 
         // Phase 1: spawn N firecracker processes, wait for sockets.
         let spawn_start = Instant::now();
-        let mut children: Vec<Vm> = Vec::with_capacity(n);
+        let mut children: Vec<Option<Vm>> = Vec::with_capacity(n);
+        let mut failures: Vec<RestoreFailure> = Vec::new();
         for i in 1..=n {
             // Per-child files use the within-batch index (1..=n) so work_dir
             // layout is predictable. Netns / cgroup index applies the offset
@@ -1869,20 +2115,98 @@ impl Snapshot {
             } else {
                 None
             };
-            let proc = spawn_firecracker_in(netns.as_deref(), &sock, &console)?;
-            let pid = proc.id();
-            children.push(Vm {
-                proc,
-                pid,
-                sock,
-                console,
-                netns,
-                cgroup: None,
-                memfd: None,
-            });
+            match spawn_firecracker_in(netns.as_deref(), &sock, &console) {
+                Ok(proc) => {
+                    let pid = proc.id();
+                    children.push(Some(Vm {
+                        proc,
+                        pid,
+                        sock,
+                        console,
+                        netns,
+                        cgroup: None,
+                        memfd: None,
+                    }));
+                }
+                Err(e) => {
+                    // Record the failure but keep spawning the rest so a
+                    // single bad spawn doesn't mask other failures. The
+                    // successful siblings are returned (partial success).
+                    failures.push(RestoreFailure {
+                        child_index: i,
+                        phase: RestorePhase::Spawn,
+                        pid: None,
+                        error: format!("{e:#}"),
+                    });
+                    children.push(None);
+                }
+            }
         }
-        for c in &children {
-            wait_for_sock(&c.sock, Duration::from_secs(10))?;
+        let socket_wait = Duration::from_secs(if opts.socket_wait_timeout_secs == 0 {
+            DEFAULT_SOCKET_WAIT_SECS
+        } else {
+            opts.socket_wait_timeout_secs
+        });
+        // Concurrent socket wait: one thread per spawned child, all with
+        // the SAME timeout so the batch is bounded by one timeout, not
+        // n × timeout. A failed child is dropped (killing its firecracker
+        // process) without disturbing siblings — partial success.
+        let sock_handles: Vec<(usize, thread::JoinHandle<Result<()>>)> = children
+            .iter()
+            .enumerate()
+            .filter_map(|(i, slot)| {
+                let vm = slot.as_ref()?;
+                let sock = vm.sock.clone();
+                let pid = vm.pid;
+                Some((
+                    i,
+                    thread::spawn(move || -> Result<()> {
+                        let wait_start = Instant::now();
+                        wait_for_sock(&sock, socket_wait)?;
+                        let elapsed = wait_start.elapsed();
+                        // Warn when a child takes >80% of the timeout to
+                        // appear — an early sign of contention (orphaned
+                        // VMs, tap/netns teardown races, fd pressure) that
+                        // may soon push the next spawn over.
+                        if elapsed > socket_wait * 4 / 5 {
+                            tracing::warn!(
+                                pid,
+                                sock = %sock.display(),
+                                elapsed_ms = elapsed.as_millis() as u64,
+                                timeout_ms = socket_wait.as_millis() as u64,
+                                "firecracker socket appeared near the wait budget; \
+                                 load contention may cause future spawns to time out"
+                            );
+                        }
+                        Ok(())
+                    }),
+                ))
+            })
+            .collect();
+        for (i, h) in sock_handles {
+            let pid = children[i].as_ref().map(|vm| vm.pid);
+            match h.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    failures.push(RestoreFailure {
+                        child_index: i + 1,
+                        phase: RestorePhase::SocketWait,
+                        pid,
+                        error: format!("{e:#}"),
+                    });
+                    // Dropping the child kills its firecracker process.
+                    children[i] = None;
+                }
+                Err(panic) => {
+                    failures.push(RestoreFailure {
+                        child_index: i + 1,
+                        phase: RestorePhase::SocketWait,
+                        pid,
+                        error: format!("socket-wait thread panicked: {panic:?}"),
+                    });
+                    children[i] = None;
+                }
+            }
         }
         let spawn_ms = spawn_start.elapsed().as_millis();
 
@@ -1891,7 +2215,10 @@ impl Snapshot {
         // restore so the limit applies to the memory image mmap as well.
         if let Some(mib) = opts.memory_limit_mib {
             let bytes = cgroup::mib_to_bytes(mib);
-            for (i, child) in children.iter_mut().enumerate() {
+            for (i, slot) in children.iter_mut().enumerate() {
+                let Some(child) = slot.as_mut() else {
+                    continue;
+                };
                 // Cgroup leaf name tracks the global netns index so per-child
                 // resource limits don't collide with siblings created by other
                 // batches on the same host.
@@ -1923,7 +2250,10 @@ impl Snapshot {
                     use_hugepages: true
                 }
             );
-            for (i, child) in children.iter_mut().enumerate() {
+            for (i, slot) in children.iter_mut().enumerate() {
+                let Some(child) = slot.as_mut() else {
+                    continue;
+                };
                 let region = memfd::create_and_populate(
                     &self.memory,
                     &format!("forkd-source-mem-{}", opts.netns_offset + i + 1),
@@ -1945,9 +2275,14 @@ impl Snapshot {
         // child only under MemfdShared (each child has its own memfd
         // path); for the File path, all children share the same JSON.
         let restore_start = Instant::now();
-        let bodies: Vec<String> = children
-            .iter()
-            .map(|c| match &c.memfd {
+        let mut handles: Vec<(usize, u32, thread::JoinHandle<Result<()>>)> = Vec::new();
+        for (i, slot) in children.iter().enumerate() {
+            let Some(c) = slot else {
+                continue;
+            };
+            let sock = c.sock.clone();
+            let pid = c.pid;
+            let body = match &c.memfd {
                 Some(region) => serde_json::json!({
                     "snapshot_path": &self.vmstate,
                     "mem_backend": {
@@ -1969,18 +2304,41 @@ impl Snapshot {
                     "resume_vm": true,
                 })
                 .to_string(),
-            })
-            .collect();
-
-        let mut handles = Vec::with_capacity(n);
-        for (c, body) in children.iter().zip(bodies) {
-            let sock = c.sock.clone();
-            handles.push(thread::spawn(move || -> Result<()> {
-                api_call(&sock, "PUT", "/snapshot/load", &body)
-            }));
+            };
+            handles.push((
+                i,
+                pid,
+                thread::spawn(move || -> Result<()> {
+                    api_call(&sock, "PUT", "/snapshot/load", &body)
+                }),
+            ));
         }
-        for h in handles {
-            h.join().expect("restore thread panicked")?;
+        for (i, pid, h) in handles {
+            match h.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    failures.push(RestoreFailure {
+                        child_index: i + 1,
+                        phase: RestorePhase::Restore,
+                        pid: Some(pid),
+                        error: format!("{e:#}"),
+                    });
+                    // Dropping the child kills its firecracker process.
+                    children[i] = None;
+                }
+                // A panicked thread is an unrecoverable child failure —
+                // collect it as a restore failure rather than panicking
+                // the caller, preserving the partial-failure contract.
+                Err(panic) => {
+                    failures.push(RestoreFailure {
+                        child_index: i + 1,
+                        phase: RestorePhase::Restore,
+                        pid: Some(pid),
+                        error: format!("restore thread panicked: {panic:?}"),
+                    });
+                    children[i] = None;
+                }
+            }
         }
         let restore_ms = restore_start.elapsed().as_millis();
 
@@ -2003,7 +2361,18 @@ impl Snapshot {
         // architecture, any Linux kernel, and any existing snapshot.
         // See issue #288 for the full options analysis.
         let (clock_sync_ms, clock_sync_outcomes) = if opts.sync_guest_clocks {
-            sync_guest_clocks(&children)
+            // `children` is `Vec<Option<Vm>>` (slots that failed spawn/
+            // socket-wait are `None`). Clock sync only applies to the
+            // successfully-restored children; the `child_index` used in
+            // outcomes is the 1-based within-batch slot index so callers
+            // can map outcomes back to resource slots.
+            //
+            // `sync_guest_clocks` only reads `child.netns` (cloned into the
+            // sync thread) so it does not need to own the `Vm`. Pass the
+            // live children by reference; `Vm` is not `Clone` (it owns a
+            // Child process).
+            let live: Vec<&Vm> = children.iter().flatten().collect();
+            sync_guest_clocks(&live)
         } else {
             (0, Vec::new())
         };
@@ -2018,7 +2387,7 @@ impl Snapshot {
             std::fs::create_dir_all(&scratch).context("create prewarm scratch dir")?;
             let prewarm_start = Instant::now();
             let mut handles = Vec::with_capacity(n);
-            for c in &children {
+            for c in children.iter().flatten() {
                 let sock = c.sock.clone();
                 let pid = c.pid;
                 let scratch = scratch.clone();
@@ -2068,7 +2437,17 @@ impl Snapshot {
         };
 
         Ok(ForkResult {
-            children,
+            children: children
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, slot)| {
+                    slot.map(|vm| ForkChild {
+                        child_index: i + 1,
+                        vm,
+                    })
+                })
+                .collect(),
+            failures,
             spawn_ms,
             restore_ms,
             prewarm_ms,
@@ -3116,6 +3495,7 @@ mod tests {
             prewarm_scratch_dir: None,
             memory_backend: MemoryBackend::File,
             enable_diff_snapshots: false,
+            socket_wait_timeout_secs: DEFAULT_SOCKET_WAIT_SECS,
             sync_guest_clocks: false,
         };
 
@@ -3130,7 +3510,7 @@ mod tests {
             fork_result.children.len()
         );
 
-        let restored_vm = fork_result.children.into_iter().next().unwrap();
+        let restored_vm = fork_result.children.into_iter().next().unwrap().vm;
 
         // Wait for guest agent on the restored VM
         let mut connected = false;
@@ -3248,6 +3628,7 @@ mod tests {
     fn fork_result_has_clock_sync_ms_field() {
         let fr = ForkResult {
             children: vec![],
+            failures: vec![],
             spawn_ms: 0,
             restore_ms: 0,
             prewarm_ms: 0,
@@ -3394,7 +3775,7 @@ mod tests {
         // Step 3: Run sync_guest_clocks — this is what #300 adds after
         // restore. The function captures host wall time and execs
         // `sh -c "date -s @<host_ts>"` in each child VM.
-        let (elapsed_ms, outcomes) = sync_guest_clocks(std::slice::from_ref(&vm));
+        let (elapsed_ms, outcomes) = sync_guest_clocks(std::slice::from_ref(&&vm));
         assert!(
             elapsed_ms < 30_000,
             "sync_guest_clocks took {elapsed_ms}ms, expected < 30s"
@@ -3727,5 +4108,272 @@ mod tests {
             now_called.load(Ordering::SeqCst),
             "now() must be called before set_clock, even when set_clock fails"
         );
+    }
+
+    // --- #301: per-VM partial-failure reporting -----------------------------
+    //
+    // The RestoreError/RestoreFailure types are pure data — they can be
+    // constructed and formatted without a firecracker process. These tests
+    // verify the Display contract and the phase enum so the structured
+    // error carries enough context for callers to report which child failed.
+
+    #[test]
+    fn restore_error_display_lists_all_failures() {
+        let err = RestoreError {
+            failures: vec![
+                RestoreFailure {
+                    child_index: 2,
+                    phase: RestorePhase::SocketWait,
+                    pid: Some(4455),
+                    error: "socket never appeared within 10s".to_string(),
+                },
+                RestoreFailure {
+                    child_index: 4,
+                    phase: RestorePhase::Restore,
+                    pid: Some(4457),
+                    error: "api_call: PUT /snapshot/load returned 400".to_string(),
+                },
+            ],
+        };
+        let s = format!("{err}");
+        assert!(
+            s.contains("2 child(ren) failed"),
+            "display should report count: {s}"
+        );
+        assert!(s.contains("child 2"), "display should name child 2: {s}");
+        assert!(
+            s.contains("SocketWait"),
+            "display should name SocketWait phase: {s}"
+        );
+        assert!(s.contains("pid 4455"), "display should include pid: {s}");
+        assert!(s.contains("child 4"), "display should name child 4: {s}");
+        assert!(
+            s.contains("Restore"),
+            "display should name Restore phase: {s}"
+        );
+        assert!(s.contains("400"), "display should include error: {s}");
+    }
+
+    #[test]
+    fn restore_error_single_failure_display() {
+        let err = RestoreError {
+            failures: vec![RestoreFailure {
+                child_index: 1,
+                phase: RestorePhase::Spawn,
+                pid: None,
+                error: "failed to spawn firecracker".to_string(),
+            }],
+        };
+        let s = format!("{err}");
+        assert!(s.contains("1 child(ren) failed"), "{s}");
+        assert!(s.contains("child 1"), "{s}");
+        assert!(s.contains("Spawn"), "{s}");
+        // Spawn-phase failures have no pid.
+        assert!(!s.contains("pid"), "Spawn failure should not show pid: {s}");
+    }
+
+    #[test]
+    fn restore_phase_eq_distinguishes_phases() {
+        assert_ne!(RestorePhase::Spawn, RestorePhase::SocketWait);
+        assert_ne!(RestorePhase::SocketWait, RestorePhase::Restore);
+        assert_ne!(RestorePhase::Spawn, RestorePhase::Restore);
+        assert_eq!(RestorePhase::Spawn, RestorePhase::Spawn);
+    }
+
+    // --- #301: pre-restore orphan detection ---------------------------------
+    //
+    // `scan_firecracker_orphans` is a read-only `/proc` scan on Linux and
+    // a no-op stub on non-Linux. The non-Linux stub contract is the only
+    // part testable without `/proc`: it must return an empty vec for any
+    // input (including a known-pid set that would otherwise exclude
+    // everything) so dev-box callers (macOS) don't panic.
+    //
+    // Non-Linux-gated: on Linux the real /proc scan runs and its result
+    // depends on which firecracker processes happen to be alive on the
+    // host, which is non-deterministic in CI and on dev boxes.
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn scan_firecracker_orphans_non_linux_returns_empty() {
+        let known: std::collections::HashSet<u32> = [1u32, 2, 3].into_iter().collect();
+        let orphans = scan_firecracker_orphans(&known);
+        assert!(
+            orphans.is_empty(),
+            "non-Linux stub should return no orphans, got {orphans:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn scan_firecracker_orphans_empty_known_set_non_linux() {
+        let known: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        let orphans = scan_firecracker_orphans(&known);
+        assert!(orphans.is_empty());
+    }
+
+    // OrphanProcess and OrphanProcess fields are pure data — verify the
+    // struct can be constructed with expected fields so downstream logging
+    // and serialization (if added later) have a stable shape.
+    #[test]
+    fn orphan_process_struct_shape() {
+        let o = OrphanProcess {
+            pid: 12345,
+            elapsed_secs: 3600,
+            cmdline: "firecracker --api-sock /tmp/x.sock".to_string(),
+        };
+        assert_eq!(o.pid, 12345);
+        assert_eq!(o.elapsed_secs, 3600);
+        assert!(o.cmdline.contains("api-sock"));
+    }
+
+    /// Integration test: restore_many_with preserves successful siblings
+    /// when one child fails to spawn. Boots a real VM, snapshots it, then
+    /// restores two children with per-child netns. Child 1's netns is
+    /// pre-provisioned so it spawns and restores normally; child 2's netns
+    /// is deliberately left un-provisioned so `ip netns exec` fails at
+    /// spawn time. Child 2 is dropped (Spawn-phase failure) while child 1
+    /// survives.
+    ///
+    /// This exercises the partial-success contract: the result carries
+    /// one live child (with its child_index preserved) and one Spawn
+    /// failure, not an all-or-nothing error. Uses per_child_netns=true
+    /// (valid multi-child topology) per review feedback on #301.
+    #[test]
+    #[ignore = "requires Linux + KVM + firecracker + rootfs image"]
+    #[cfg(target_os = "linux")]
+    fn restore_many_partial_spawn_failure_keeps_siblings() {
+        let kernel = std::env::var("FORKD_TEST_KERNEL")
+            .unwrap_or_else(|_| "/var/lib/forkd/kernels/vmlinux".to_string());
+        let rootfs = std::env::var("FORKD_TEST_ROOTFS")
+            .expect("FORKD_TEST_ROOTFS must point to an ext4 rootfs image");
+
+        assert!(
+            std::path::Path::new(&kernel).exists(),
+            "FORKD_TEST_KERNEL not found at {kernel}"
+        );
+        assert!(
+            std::path::Path::new(&rootfs).exists(),
+            "FORKD_TEST_ROOTFS not found at {rootfs}"
+        );
+
+        let work_dir =
+            std::env::temp_dir().join(format!("forkd-restore-partial-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&work_dir);
+        let addr = "10.42.0.2:8888".to_string();
+
+        // Pre-flight: no stale VM should already occupy the agent address.
+        assert!(
+            ping_at(&addr).is_err(),
+            "{addr} is already reachable — a stale VM may occupy the address"
+        );
+
+        // Boot a parent VM and snapshot it.
+        let cfg = BootConfig::ext4_rw(kernel.into(), rootfs.into(), work_dir.clone())
+            .with_network(NetworkConfig::default_tap("forkd-tap0"));
+        let vm = Vm::boot(&cfg).expect("boot parent VM");
+        let mut connected = false;
+        for _ in 0..60 {
+            std::thread::sleep(Duration::from_millis(500));
+            if ping_at(&addr).is_ok() {
+                connected = true;
+                break;
+            }
+        }
+        assert!(connected, "parent VM agent did not respond within 30s");
+
+        let snap_dir = work_dir.join("snap");
+        std::fs::create_dir_all(&snap_dir).expect("create snap dir");
+        vm.pause().expect("pause parent");
+        let snapshot = vm
+            .snapshot_to(
+                snap_dir.join("vmstate"),
+                snap_dir.join("memory.bin"),
+                Vec::new(),
+            )
+            .expect("snapshot parent");
+        drop(vm); // kills parent, frees the shared guest agent address
+
+        // Restore two children with per-child netns (valid multi-child
+        // topology). Child 1's netns is pre-provisioned; child 2's is
+        // deliberately left un-provisioned so `ip netns exec` fails and the
+        // spawn is recorded as a Spawn-phase failure.
+        let netns_offset = std::process::id() as usize * 10;
+        let child1_netns = format!("forkd-child-{}", netns_offset + 1);
+        // Child 2 netns (forkd-child-{netns_offset+2}) is deliberately NOT
+        // provisioned — that is the failure injection (spawn fails).
+
+        // Pre-provision child 1's netns only.
+        let netns_created = std::process::Command::new("ip")
+            .args(["netns", "add", &child1_netns])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !netns_created {
+            // Cannot create netns (not root or ip not available) — skip.
+            // Clean up the parent snapshot files we created.
+            let _ = std::fs::remove_dir_all(&work_dir);
+            eprintln!("skipped: could not create netns {child1_netns} (need root)");
+            return;
+        }
+
+        let restore_dir = work_dir.join("restore");
+        std::fs::create_dir_all(&restore_dir).expect("create restore dir");
+
+        let result = snapshot
+            .restore_many_with(
+                ForkOpts {
+                    n: 2,
+                    per_child_netns: true,
+                    netns_offset,
+                    socket_wait_timeout_secs: 10,
+                    ..ForkOpts::default()
+                },
+                &restore_dir,
+            )
+            .expect("restore_many_with returned a fatal error");
+
+        // Partial success: child 1 alive (with child_index=1), child 2
+        // failed at Spawn (netns does not exist).
+        assert_eq!(
+            result.children.len(),
+            1,
+            "expected 1 surviving child, got {}",
+            result.children.len()
+        );
+        assert_eq!(
+            result.children[0].child_index, 1,
+            "surviving child should retain child_index=1"
+        );
+        assert_eq!(
+            result.failures.len(),
+            1,
+            "expected 1 failure, got {:?}",
+            result.failures
+        );
+        let fail = &result.failures[0];
+        assert_eq!(
+            fail.child_index, 2,
+            "expected child 2 to fail, got {:?}",
+            fail
+        );
+        assert!(
+            matches!(fail.phase, RestorePhase::Spawn),
+            "expected Spawn-phase failure (netns not provisioned), got {:?}",
+            fail.phase
+        );
+
+        // The surviving child is actually a live firecracker process.
+        let child = &result.children[0].vm;
+        assert!(
+            child.is_alive(),
+            "surviving child (pid {}) should be alive",
+            child.pid()
+        );
+
+        drop(result);
+        let _ = std::fs::remove_dir_all(&work_dir);
+        // Clean up the pre-provisioned netns.
+        let _ = std::process::Command::new("ip")
+            .args(["netns", "del", &child1_netns])
+            .status();
     }
 }

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -1183,6 +1183,7 @@ const CLOCK_SYNC_EXEC_TIMEOUT: Duration = Duration::from_secs(5);
 /// - **Adds latency to restore**: ~1-5 seconds per batch (agent polling
 ///   + exec), running in parallel across children. Measured at
 ///     ~1-2 seconds for typical Debian/Ubuntu-based images.
+///
 /// Map a `Vec<Option<T>>` of per-slot children (failed slots are `None`)
 /// into a slice of `(original_1_based_slot, &T)` for the live children,
 /// where `original_1_based_slot` is the index the child occupied in the

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -1183,12 +1183,52 @@ const CLOCK_SYNC_EXEC_TIMEOUT: Duration = Duration::from_secs(5);
 /// - **Adds latency to restore**: ~1-5 seconds per batch (agent polling
 ///   + exec), running in parallel across children. Measured at
 ///     ~1-2 seconds for typical Debian/Ubuntu-based images.
-fn sync_guest_clocks(children: &[&Vm]) -> (u128, Vec<ClockSyncOutcome>) {
+/// Map a `Vec<Option<T>>` of per-slot children (failed slots are `None`)
+/// into a slice of `(original_1_based_slot, &T)` for the live children,
+/// where `original_1_based_slot` is the index the child occupied in the
+/// *original* batch (1-based) — **before** failures were filtered out.
+///
+/// This is the single source of truth for the index-preserving mapping
+/// that `restore_many_with` passes into `sync_guest_clocks`. Hardcoding
+/// what would otherwise be an inline `enumerate().filter_map(...)` makes
+/// the invariant unit-testable without KVM: a hole (a `None` slot)
+/// earlier in the batch must not renumber a later survivor's index
+/// (review feedback on #302 — `children::flatten()` loses the slot).
+///
+/// Example: `[None, Some(a), None, Some(b)] -> [(2, a), (4, b)]`.
+pub fn live_children_with_indices<T>(children: &[Option<T>]) -> Vec<(usize, &T)> {
+    children
+        .iter()
+        .enumerate()
+        .filter_map(|(i, c)| c.as_ref().map(|vm| (i + 1, vm)))
+        .collect()
+}
+
+/// Sync each restored child's guest clock to host wall time.
+///
+/// # Indexing contract
+///
+/// `children` is a slice of `(child_index, &Vm)` where `child_index` is
+/// the **1-based within-batch slot** the child originally occupied in
+/// `restore_many_with` (matching `ForkChild.child_index` and
+/// `RestoreFailure.child_index`). `ClockSyncOutcome.child_index` echoes
+/// that original slot.
+///
+/// Pass the live children flattened from `Vec<Option<Vm>>` only *after*
+/// pairing each with its original index; do **not** re-enumerate the
+/// flattened slice, otherwise a hole (failed spawn/socket-wait) shifts
+/// every later survivor's reported index and breaks resource correlation
+/// (review feedback on #302: `children::flatten()` renumbers outcomes).
+fn sync_guest_clocks(children: &[(usize, &Vm)]) -> (u128, Vec<ClockSyncOutcome>) {
     let start = Instant::now();
 
     let mut handles = Vec::with_capacity(children.len());
     for child in children.iter() {
-        let netns = child.netns.clone();
+        // `child.1` is the `&Vm`; borrow fields before moving netns into
+        // the spawn closure. (`child.0`'s original slot is reported via
+        // `children[i].0` in the collect loop below.)
+        let (_, vm) = *child;
+        let netns = vm.netns.clone();
         handles.push(thread::spawn(move || -> Result<()> {
             let addr = GUEST_AGENT_ADDR.to_string();
 
@@ -1266,33 +1306,38 @@ fn sync_guest_clocks(children: &[&Vm]) -> (u128, Vec<ClockSyncOutcome>) {
     let mut synced = 0usize;
     let mut failed = 0usize;
     for (i, h) in handles.into_iter().enumerate() {
+        // `children[i].0` is the ORIGINAL 1-based within-batch slot the
+        // child occupied before failures were filtered out. Use it for
+        // both the tracing spans and `ClockSyncOutcome.child_index` so a
+        // survivor is never re-numbered by flattening (review #302).
+        let slot = children[i].0;
         match h.join() {
             Ok(Ok(())) => {
                 synced += 1;
-                outcomes.push(ClockSyncOutcome::Synced { child_index: i });
+                outcomes.push(ClockSyncOutcome::Synced { child_index: slot });
             }
             Ok(Err(e)) => {
                 failed += 1;
                 let error = format!("{e:#}");
                 tracing::warn!(
-                    child = i + 1,
+                    child = slot,
                     "guest clock sync failed: {error}; \
                      sandbox will have a stale clock"
                 );
                 outcomes.push(ClockSyncOutcome::Failed {
-                    child_index: i,
+                    child_index: slot,
                     error,
                 });
             }
             Err(_) => {
                 failed += 1;
                 tracing::warn!(
-                    child = i + 1,
+                    child = slot,
                     "guest clock sync thread panicked; \
                      sandbox will have a stale clock"
                 );
                 outcomes.push(ClockSyncOutcome::Failed {
-                    child_index: i,
+                    child_index: slot,
                     error: "clock sync thread panicked".to_string(),
                 });
             }
@@ -2369,9 +2414,11 @@ impl Snapshot {
             //
             // `sync_guest_clocks` only reads `child.netns` (cloned into the
             // sync thread) so it does not need to own the `Vm`. Pass the
-            // live children by reference; `Vm` is not `Clone` (it owns a
+            // live children by reference, preserving each child's ORIGINAL
+            // 1-based slot (review #302: flattening would renumber a
+            // survivor past a failed hole). `Vm` is not `Clone` (it owns a
             // Child process).
-            let live: Vec<&Vm> = children.iter().flatten().collect();
+            let live: Vec<(usize, &Vm)> = live_children_with_indices(&children);
             sync_guest_clocks(&live)
         } else {
             (0, Vec::new())
@@ -3679,6 +3726,61 @@ mod tests {
         assert!(failures[0].contains("agent timeout"));
     }
 
+    /// Regression (review #302): the index-preserving mapping that feeds
+    /// `sync_guest_clocks` must NOT renumber a survivor past a hole.
+    ///
+    /// `restore_many_with` keeps per-slot results as `Vec<Option<Vm>>`
+    /// (failed spawn/socket-wait slots are `None`). A naive
+    /// `children.iter().flatten()` re-indexes the survivors, so with
+    /// `[None, Some(a), None, Some(b)]` the flattened slice is `[a, b]`
+    /// and `enumerate()` would report them as slots 0/1 instead of the
+    /// original 2/4 — breaking the resource correlation that
+    /// `ForkChild`/`RestoreFailure`/`ClockSyncOutcome` all promise via
+    /// their 1-based within-batch index. Use cheap `u32` payloads so this
+    /// is a portable, KVM-free unit test.
+    #[test]
+    fn live_children_with_indices_preserves_survivor_slot_across_hole() {
+        // Vec positions 0 and 2 are None (failed), positions 1 and 3 are
+        // live. The survivors must retain their ORIGINAL 1-based slots
+        // (2 and 4), not be renumbered to 0/1 by flattening.
+        let children: Vec<Option<u32>> = vec![None, Some(10), None, Some(30)];
+        let live = live_children_with_indices(&children);
+
+        assert_eq!(
+            live.len(),
+            2,
+            "two live children expected from 2 holes + 2 survivors"
+        );
+        assert_eq!(live[0], (2, &10), "first survivor keeps slot 2");
+        assert_eq!(live[1], (4, &30), "second survivor keeps slot 4");
+
+        // And the adjacency case: no holes → indices map 1..=n in order.
+        let all: Vec<Option<u32>> = vec![Some(1), Some(2), Some(3)];
+        let live_all = live_children_with_indices(&all);
+        assert_eq!(
+            live_all.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+
+        // All failures → empty result.
+        let none: Vec<Option<u32>> = vec![None, None];
+        assert!(live_children_with_indices(&none).is_empty());
+
+        // Trailing hole: the live child keeps its slot even when the tail
+        // is empty.
+        let trailing: Vec<Option<u32>> = vec![Some(5), None];
+        assert_eq!(live_children_with_indices(&trailing), vec![(1, &5)]);
+
+        // First-live-then-holes: a survivor followed only by holes keeps
+        // its (first) slot.
+        let first_live: Vec<Option<u32>> = vec![Some(9), None, None];
+        assert_eq!(live_children_with_indices(&first_live), vec![(1, &9)]);
+
+        // Empty input → empty result.
+        let empty: Vec<Option<u32>> = Vec::new();
+        assert!(live_children_with_indices(&empty).is_empty());
+    }
+
     /// Integration test: sync_guest_clocks corrects a deliberately-wrong
     /// guest clock. This isolates the scripting solution — even if the
     /// kernel's KVM_CLOCK_REALTIME already corrected the clock after
@@ -3774,8 +3876,10 @@ mod tests {
 
         // Step 3: Run sync_guest_clocks — this is what #300 adds after
         // restore. The function captures host wall time and execs
-        // `sh -c "date -s @<host_ts>"` in each child VM.
-        let (elapsed_ms, outcomes) = sync_guest_clocks(std::slice::from_ref(&&vm));
+        // `sh -c "date -s @<host_ts>"` in each child VM. The single
+        // child is passed as slot 1 (1-based within-batch), so its
+        // outcome must report child_index = 1.
+        let (elapsed_ms, outcomes) = sync_guest_clocks(&[(1, &vm)]);
         assert!(
             elapsed_ms < 30_000,
             "sync_guest_clocks took {elapsed_ms}ms, expected < 30s"
@@ -3788,8 +3892,8 @@ mod tests {
             outcomes.len()
         );
         assert!(
-            matches!(&outcomes[0], ClockSyncOutcome::Synced { child_index: 0 }),
-            "expected Synced{{child_index: 0}}, got {:?}",
+            matches!(&outcomes[0], ClockSyncOutcome::Synced { child_index: 1 }),
+            "expected Synced{{child_index: 1}}, got {:?}",
             outcomes[0]
         );
 


### PR DESCRIPTION
## Summary

Partially addresses #301. Three changes to stop a single child failure from dooming the whole restore batch, and to surface contention from orphaned firecracker processes before a restore is attempted.

**Issue #301 remains open** — the orphan-reap/gate and graceful-reconcile criteria are not yet satisfied. This PR narrows to the restore-path resilience subset (criteria #2 and #4) and documents the remaining gaps.

## Problem

Intermittent failures trace back to the forkd controller's snapshot restore path:
1. The `wait_for_sock` timeout was hardcoded at 10s — under load it's too tight.
2. `restore_many_with` bailed on the first child failure, silently dropping already-spawned siblings.
3. Orphaned firecracker processes from a prior crash hold tap/netns resources and doom new restores, but were invisible until a restore failed.

## Changes

### 1. Configurable per-child socket wait timeout (`ForkOpts` field)
- New `ForkOpts::socket_wait_timeout_secs` (default 10s, matching the historical budget) drives the `wait_for_sock` calls in `restore_many_with`.
- Daemon paths (`create_sandbox`, `spawn_one_for_workspace`) default to 30s, configurable via `FORKD_SOCKET_WAIT_TIMEOUT_SECS` env var.
- A warning fires when a child takes >80% of the budget to appear, so operators see contention before it pushes the next spawn over.
- `wait_for_sock` now bails when the socket path is a directory (not a Unix socket) — previously `Path::exists()` returned true for a directory, masking the failure.
- CLI paths keep the 10s default.

### 2. Per-VM partial-failure reporting (`RestoreError`/`RestoreFailure`/`ForkChild`)
- New types: `RestorePhase` (enum), `RestoreFailure` (struct), `RestoreError` (struct with `failures: Vec<RestoreFailure>`), `ForkChild` (struct with `child_index` + `vm`), implementing `Display + std::error::Error` where applicable.
- `ForkResult.children` is now `Vec<ForkChild>` — each surviving child carries its 1-based within-batch `child_index` so callers can map a surviving VM back to its resource slot (netns/cgroup at `netns_offset + child_index`). This preserves the child-to-VM mapping that a plain `Vec<Vm>` would lose when failures are filtered out.
- `restore_many_with` now collects per-child results in each phase instead of bailing on the first failure:
  - **Spawn phase**: failures recorded but remaining children still spawn; on any failure, spawned children are dropped (killing firecracker) and a `RestoreError` carrying every failure is returned.
  - **Socket-wait phase**: a timed-out child is recorded; on any timeout, all children are dropped and a `RestoreError` is returned. Concurrent socket wait: one thread per child, all with the SAME timeout so the batch is bounded by one deadline, not n × timeout.
  - **Restore phase**: each thread's result is collected; a panicked thread is recorded as a restore failure rather than panicking the caller.
- `RestoreError` names every failed child (index, phase, error, pid when known) so callers can report which specific child failed rather than a single bail that loses batch context.

### 3. Pre-restore orphan detection (`scan_firecracker_orphans`)
- New `OrphanProcess` struct + `scan_firecracker_orphans(known_pids)` function scans `/proc` for running firecracker processes whose PIDs are NOT in the caller's `live_vms` set.
- Linux impl: reads `/proc/<pid>/comm` (exact "firecracker" match), `/proc/<pid>/cmdline`, `/proc/<pid>/stat` (elapsed time).
- Non-Linux stub: returns empty vec (for dev-box compilation).
- Controller calls it before both `create_sandbox` and `spawn_one_for_workspace` restores via a `warn_orphan_firecrackers` helper that scopes the `live_vms` lock to just PID collection, dropping it before the `/proc` scan so the scan doesn't serialize concurrent sandbox operations.
- Exposed as `forkd_orphan_firecrackers_detected_total` metric so operators can alert on the precursor.
- Read-only — never kills anything. The scan is a point-in-time observation with a documented TOCTOU window.

## Controller-level all-or-nothing semantics

The controller's `create_sandbox` handler is intentionally **all-or-nothing**: a sandbox requires all N children, so when `restore_many_with` returns partial success (some children restored, some failed), the controller drops the surviving children (kills their firecracker processes) and either retries the whole batch (if the failure is a transient "busy" condition) or returns a structured error. The per-child failure reporting from `restore_many_with` is used at the controller level for **diagnostics and retry classification only** — partial success is NOT exposed through the API.

This is a deliberate design choice, not a limitation to be fixed later: a half-populated sandbox is worse than no sandbox (it would hold resources but be unable to serve requests). Issue #301 tracks the broader partial-success-through-controller discussion; this PR does not close it.

## Known limitations (issue #301 remains open)

1. **Orphan detection is diagnostic-only**: the pre-restore scan logs and counts orphans but does not reap or gate on them. A lifecycle-level orphan reap/gate path (kill or block on untracked firecracker processes before restore) is tracked in #301.

2. **Graceful reconcile is tracked separately**: the controller restart mass-prune issue (#301 criterion #5) is addressed by #299 (startup orphan kill) and #304 (pidfd durable identity), not this PR.

3. **Controller restart does not reattach surviving VMs**: #301 criterion #5 (a controller restart should not mass-prune alive VMs) requires reconcile() changes that distinguish "VM died" from "controller crashed with surviving VMs". This is out of scope for this PR.

## Tests
- `restore_error_display_lists_all_failures` — Display lists every failure with phase, pid, and error.
- `restore_error_single_failure_display` — single Spawn-phase failure (no pid).
- `restore_phase_eq_distinguishes_phases` — phase enum equality.
- `scan_firecracker_orphans_non_linux_returns_empty` — stub contract on non-Linux.
- `scan_firecracker_orphans_empty_known_set_non_linux` — empty known set contract.
- `orphan_process_struct_shape` — OrphanProcess field stability.
- `restore_many_partial_spawn_failure_keeps_siblings` (ignored, requires Linux + KVM + root) — integration test: boots a parent VM, snapshots it, restores two children with per-child netns. Child 1's netns is pre-provisioned; child 2's is not, so `ip netns exec` fails at spawn. Asserts child 1 survives with `child_index=1`, child 2 fails at Spawn phase.

## Out of scope
The concurrent-RW-mount-of-shared-rootfs issue (`restore_many_with` sends the same vmstate to all children) needs an immutable baseline + per-VM writable layer and is tracked as a separate architectural initiative. The prewarm (Phase 3) and memfd (Phase 1.5) paths retain their pre-existing early-bail behavior — they are host-resource failures rather than per-VM failures, and converting them is outside this change's scope.