### PR TITLE
ci: establish dev-to-main branch flow

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -2,11 +2,12 @@ name: ci-typescript
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - 'sdk/typescript/**'
       - '.github/workflows/ci-typescript.yml'
   pull_request:
+    branches: [main, dev]
     paths:
       - 'sdk/typescript/**'
       - '.github/workflows/ci-typescript.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
+    branches: [main, dev]
 
 jobs:
   rust:

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,30 @@
+name: pr-policy
+
+# Daily development lands on dev. The main branch is promoted only from the
+# repository's dev branch so a release candidate has one auditable lineage.
+# pull_request_target is intentional here: this policy must come from the
+# protected base branch, not from contributor-controlled PR contents. The job
+# never checks out or executes code from the pull request.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  main-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the repository dev branch
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "${HEAD_REPOSITORY}" != "${BASE_REPOSITORY}" || "${HEAD_BRANCH}" != "dev" ]]; then
+            echo "::error::Pull requests to main must come from ${BASE_REPOSITORY}:dev."
+            echo "::error::Retarget normal feature and fix pull requests to dev."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to forkd
+
+## Branch workflow
+
+- Open feature, fix, documentation, and dependency pull requests against
+  `dev`. GitHub uses `dev` as the repository's default branch.
+- `main` is the stable release line. Pull requests to `main` are accepted
+  only from this repository's `dev` branch.
+- Both branches run the full CI suite. A pull request must pass the required
+  `rust` check before it can merge.
+- Do not force-push or delete `dev` or `main`.
+
+Maintainers promote a tested `dev` revision to `main` with a pull request,
+then fast-forward `dev` to the resulting merge commit so the branches do not
+accumulate avoidable divergence.
+
+## Commits
+
+Use focused commits with an imperative subject. Sign off every commit for the
+[Developer Certificate of Origin](https://developercertificate.org/) with:
+
+```bash
+git commit --signoff
+```
+
+By signing off, you certify that you have the right to submit the contribution
+under the project's license.


### PR DESCRIPTION
## Summary

- run Rust/Python and TypeScript CI for pushes and pull requests targeting both `dev` and `main`
- add a base-controlled PR policy check so future `main` pull requests must originate from this repository's `dev` branch
- document `dev` as the daily integration/default PR branch and `main` as the stable release branch

## Bootstrap sequence

This one PR targets `main` to install the policy workflow on the protected base branch. After it merges, maintainers will fast-forward `dev` to the merge commit, switch the repository default branch to `dev`, protect `dev` with the required `rust` check, and require `main-source` on `main`.

## Validation

- `actionlint` passes for all workflows
- positive policy case accepts `deeplethe/forkd:dev`
- negative policy case rejects a fork branch named `dev`
- `git diff --check`