### PR TITLE
fix(vmm): reap the Firecracker child on every failed boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ snapshot is fully published, so a tag always holds a consistent
 src == dst guard comment duplication and makes the chain-unpack tail
 bail instead of resolving an empty path.
 
+### A failed boot no longer orphans its Firecracker process
+
+`Vm::boot` spawned Firecracker and then issued the `/boot-source`,
+`/drives/rootfs`, `/entropy` and `/actions` calls with a bare
+`std::process::Child` in hand. `Child` has no kill-on-drop, so any `?` in
+that window — including `wait_for_sock` timing out — returned an error and
+abandoned a *live* Firecracker. The orphan holds the sandbox's tap device
+and rootfs fd, and the tap name is frozen into the vmstate, so every later
+spawn of that snapshot dies inside Firecracker with `Open tap device
+failed` before it can create its API socket; callers see
+`socket .../child-N.sock never appeared` and the snapshot stays unusable
+until the orphan is killed by hand. The child is now owned by a
+`PendingFirecracker` guard that reaps it on every early return and hands
+it over to the `Vm` only on success.
+
 ### Rootfs sidecar placement: recorded absolute path, validated
 
 Packs record the rootfs sidecar's target as the vmstate-frozen ABSOLUTE

--- a/crates/forkd-vmm/src/lib.rs
+++ b/crates/forkd-vmm/src/lib.rs
@@ -1580,6 +1580,45 @@ fn wait_for_sock(sock: &Path, timeout: Duration) -> Result<()> {
     )
 }
 
+/// Owns a just-spawned Firecracker until a [`Vm`] takes it over.
+///
+/// `std::process::Child` has no kill-on-drop, so every `?` between
+/// `spawn_firecracker` and the `Ok(Vm { .. })` at the end of [`Vm::boot`]
+/// used to abandon a *live* Firecracker: `wait_for_sock` timing out, or
+/// any of the `/boot-source`, `/drives`, `/entropy`, `/actions` calls
+/// failing after the process was up. The orphan keeps the tap device and
+/// the rootfs fd open, and the tap name is frozen into the vmstate, so
+/// every later spawn of that snapshot dies inside Firecracker with
+/// `Open tap device failed` before it can create its API socket — which
+/// the parent reports as `socket .../child-N.sock never appeared`, for
+/// good. Mirrors the `WorkDirGuard` idiom in the test module.
+struct PendingFirecracker(Option<Child>);
+
+impl PendingFirecracker {
+    fn new(child: Child) -> Self {
+        Self(Some(child))
+    }
+
+    fn pid(&self) -> u32 {
+        self.0.as_ref().expect("child is owned until taken").id()
+    }
+
+    /// Hand the running child to the `Vm`; dropping the guard afterwards
+    /// no longer reaps it.
+    fn take(mut self) -> Child {
+        self.0.take().expect("child is owned until taken")
+    }
+}
+
+impl Drop for PendingFirecracker {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
 fn spawn_firecracker(sock: &Path, console: &Path) -> Result<Child> {
     spawn_firecracker_in(None, sock, console)
 }
@@ -1649,8 +1688,8 @@ impl Vm {
         let _ = std::fs::remove_file(&sock);
         let _ = std::fs::remove_file(&console);
 
-        let proc = spawn_firecracker(&sock, &console)?;
-        let pid = proc.id();
+        let proc = PendingFirecracker::new(spawn_firecracker(&sock, &console)?);
+        let pid = proc.pid();
 
         wait_for_sock(&sock, Duration::from_secs(10))?;
 
@@ -1746,7 +1785,7 @@ impl Vm {
         )?;
 
         Ok(Vm {
-            proc,
+            proc: proc.take(),
             pid,
             sock,
             console,
@@ -2650,6 +2689,55 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
         }
+    }
+
+    fn spawn_sleeper() -> Child {
+        Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep")
+    }
+
+    fn proc_exists(pid: u32) -> bool {
+        Path::new(&format!("/proc/{pid}")).exists()
+    }
+
+    /// A boot that fails after Firecracker is up must reap it. Before the
+    /// guard, the `?` in `wait_for_sock` — and each API call after it —
+    /// dropped a bare `Child`, leaving a live Firecracker holding the tap
+    /// device. That orphan is what makes every later spawn of the snapshot
+    /// fail with `socket .../child-N.sock never appeared` (issue #301).
+    #[test]
+    fn pending_firecracker_drop_reaps_the_owned_pid() {
+        let child = spawn_sleeper();
+        let pid = child.id();
+        assert!(proc_exists(pid), "sleeper must be alive before the drop");
+        {
+            let pending = PendingFirecracker::new(child);
+            assert_eq!(pending.pid(), pid, "pid() must report the owned child");
+        } // the failed-boot path: dropped without take()
+        assert!(
+            !proc_exists(pid),
+            "dropping the guard must reap pid {pid}, not abandon it"
+        );
+    }
+
+    /// `take()` is the success path: the `Vm` owns the process from then on,
+    /// so the guard must leave it running.
+    #[test]
+    fn pending_firecracker_take_hands_over_a_live_child() {
+        let mut child = PendingFirecracker::new(spawn_sleeper()).take();
+        let pid = child.id();
+        assert!(
+            proc_exists(pid),
+            "the child must still be alive after take() — the Vm owns it now"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(!proc_exists(pid), "cleanup must reap the handed-over child");
     }
 
     #[test]


### PR DESCRIPTION
Relevant to #301 (the orphan reap/gate remainder you left open).

## The window

`Vm::boot` spawned Firecracker and then drove `/boot-source`, `/drives/rootfs`, `/entropy` and `/actions` with a bare `std::process::Child` in hand. `Child` has no kill-on-drop, so any `?` between the spawn and the `Ok(Vm { .. })` at the end — `wait_for_sock` timing out, or any API call failing after the process was up — returned an error and abandoned a **live** Firecracker.

`restore_many_with` wraps its children in a `Vm` immediately, so `boot` was the only place in the crate that could orphan a process with no handle left.

## Why it is permanent

The orphan keeps the sandbox's tap device and rootfs fd open, and the tap name is frozen into the vmstate. Every later spawn of that snapshot therefore dies inside Firecracker with `Open tap device failed` before it can create its API socket, and the caller sees:

```
restore_many: socket .../child-N.sock never appeared
```

for good. The snapshot stays unusable until the orphan is killed by hand — a failed boot converts into a permanently failing tag. In our deployment this is what made a single bad boot look like an exhausted netns allocator, because the symptom (every subsequent spawn failing at socket wait) is identical.

## Fix

The child is owned by a `PendingFirecracker` guard that kills and reaps it on every early return and hands it to the `Vm` only on success. `take()` is the single hand-over point; the guard mirrors the existing `WorkDirGuard` idiom in the test module.

Two unit tests: the drop path (the owned pid must actually be gone, not merely untracked) and the take path (the handed-over child must still be live).

## Verification, and the gap

`cargo fmt --check` and `cargo clippy --all-targets --all-features -D warnings` clean; `cargo test -p forkd-vmm pending_firecracker` passes.

The gap: this is unit-level only. I have not run a live bake on a KVM host to watch a boot fail mid-window and confirm no orphan survives, and given your point on `#[ignore]`d tests I would rather say so than imply otherwise. I can run that on our KVM host if you want it before review.